### PR TITLE
feat(compact-core): add compact-witness-ts skill

### DIFF
--- a/docs/plans/2026-02-28-compact-witness-ts-design.md
+++ b/docs/plans/2026-02-28-compact-witness-ts-design.md
@@ -1,0 +1,126 @@
+# Design: compact-witness-ts Skill
+
+**Date:** 2026-02-28
+**Plugin:** compact-core
+**Status:** Approved
+
+## Problem
+
+Every Compact contract requires TypeScript witness implementations, yet the existing compact-core skills repeatedly say "implementation goes in TypeScript" without explaining how. The six existing skills (compact-structure, compact-ledger, compact-privacy-disclosure, compact-standard-library, compact-tokens, compact-language-ref) cover the Compact side exclusively. The TypeScript side — which is half of every contract — has no skill coverage.
+
+## Scope
+
+**In scope:**
+- Writing witness functions in TypeScript (WitnessContext pattern, return tuples)
+- Private state management (types, factory functions, state transitions)
+- Compiler-generated .d.ts files (Witnesses interface, Circuits type, Contract class)
+- Type mappings (Compact → TypeScript)
+- The Compact JavaScript runtime (Contract class, pureCircuits, ledger())
+
+**Out of scope:**
+- DApp infrastructure (wallet setup, providers, proof server, indexer)
+- Contract deployment and interaction (deployContract, findDeployedContract, callTx)
+- Network configuration and wallet SDKs
+- These would be a separate future skill
+
+## Approach: Contract-Out
+
+Organized by developer workflow: you compiled your Compact contract, now what?
+
+1. Compiler output → 2. Type mappings → 3. Witness implementation → 4. Contract runtime
+
+This mirrors the natural developer journey and avoids duplicating the pattern-heavy approach already in compact-structure.
+
+## Skill Identity
+
+- **Name:** `compact-witness-ts`
+- **Location:** `plugins/compact-core/skills/compact-witness-ts/`
+- **Trigger description:** Covers TypeScript witness implementation, WitnessContext pattern, private state management, Compact-to-TypeScript type mappings, compiler-generated .d.ts files, Contract class, pure circuits, and ledger reading
+
+## File Structure
+
+```
+plugins/compact-core/skills/compact-witness-ts/
+├── SKILL.md
+└── references/
+    ├── type-mappings.md
+    ├── witness-implementation.md
+    └── contract-runtime.md
+```
+
+## SKILL.md Content
+
+1. **Opening paragraph** — One sentence positioning the skill
+2. **Compiler Output Overview** — What `compact compile` produces, key exports, import patterns
+3. **Type Mapping Quick Reference** — Inline table of all Compact → TypeScript type mappings
+4. **Witness Implementation Pattern** — Core WitnessContext pattern with concrete example
+5. **Private State Design** — Brief coverage of private state types and factory functions
+6. **Contract Class Usage** — Instantiation, pureCircuits, ledger reading
+7. **Reference Routing Table** — Links to the three reference files
+
+Cross-references to: compact-structure, compact-privacy-disclosure, compact-standard-library.
+
+## Reference Files
+
+### type-mappings.md
+
+- Complete Compact → TypeScript type mapping table (expanded)
+- CompactType<T> interface for runtime type validation
+- Runtime bounds/length checking behavior
+- Type casting patterns between Compact and TypeScript
+- Generic type export rules (numeric params dropped)
+- Maybe<T>, Either<L, R> representation
+- Opaque<"string">, Opaque<"Uint8Array"> pass-through types
+- Ledger ADT representation via ledger() function
+- MerkleTreePath<N, T> representation for witness providers
+
+### witness-implementation.md
+
+- WitnessContext<L, PS> interface: ledger, privateState, contractAddress fields
+- Witness return tuple [PS, ReturnType] — why it returns new private state
+- Immutable private state pattern
+- Private state mutation via spread-and-override
+- Common witness patterns:
+  - Secret key provider
+  - Parameterized witness (circuit arguments after WitnessContext)
+  - State-mutating witness
+  - Ledger-reading witness
+  - Contract-address-keyed state
+- Side-effect-only witnesses returning []
+- Error handling in witnesses
+- The witnesses object: keys must match Compact names exactly
+
+### contract-runtime.md
+
+- Compiler-generated Contract class: constructor, circuits, impureCircuits, pureCircuits
+- circuits vs impureCircuits distinction
+- pureCircuits: local computation without proof
+- The ledger() function: parsing contract state
+- Contract instantiation patterns
+- Witnesses interface type-checking
+- Circuits type signatures
+- Private state ID string identifier
+- Re-export pattern (index.ts)
+
+## Plugin Integration
+
+Add keywords to plugin.json: `"witness-typescript"`, `"WitnessContext"`, `"private-state"`, `"type-mapping"`, `"compact-runtime"`, `"contract-class"`, `"pureCircuits"`, `"compiler-generated"`
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Witness & runtime only, no DApp infra | Focused scope; DApp infra is a separate concern |
+| Inline examples only | Type mappings and patterns shown best as annotated snippets |
+| Complement existing skills, no duplication | Avoids redundancy with compact-structure's Compact-side coverage |
+| 3 reference files | Clean separation: types, witnesses, runtime |
+| Contract-Out approach | Follows natural developer workflow post-compilation |
+
+## Research Sources
+
+- Official Midnight docs: bboard tutorial (witness implementation, contract types)
+- Compiler documentation: .d.ts file structure, type translation rules
+- Example DApps: counter (empty witnesses), bboard (secret key pattern), midnames (multi-key pattern), midnight-bank (parameterized witnesses), naval-battle (state-mutating witnesses)
+- Compact runtime source: WitnessContext interface definition
+- OpenZeppelin compact-contracts: empty witness patterns
+- Language reference: type representation rules, generic export rules

--- a/plugins/compact-core/.claude-plugin/plugin.json
+++ b/plugins/compact-core/.claude-plugin/plugin.json
@@ -36,6 +36,14 @@
     "selective-disclosure",
     "commit-reveal",
     "anonymous-auth",
-    "merkle-proof"
+    "merkle-proof",
+    "witness-typescript",
+    "WitnessContext",
+    "private-state",
+    "type-mapping",
+    "compact-runtime",
+    "contract-class",
+    "pureCircuits",
+    "compiler-generated"
   ]
 }

--- a/plugins/compact-core/skills/compact-witness-ts/SKILL.md
+++ b/plugins/compact-core/skills/compact-witness-ts/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: compact-witness-ts
+description: This skill should be used when the user asks about implementing Compact witness functions in TypeScript, the WitnessContext pattern, private state management, Compact-to-TypeScript type mappings (Field to bigint, Bytes to Uint8Array, Uint to bigint), compiler-generated .d.ts files (Witnesses interface, Circuits type, Contract class), the Compact JavaScript runtime, how contract.circuits works, pure circuits in TypeScript, reading ledger state from TypeScript, the witness return tuple pattern [PrivateState, ReturnValue], or how to connect a Compact contract to its TypeScript implementation.
+---
+
+# TypeScript Witness Implementation & Contract Runtime
+
+This skill covers the TypeScript half of every Compact contract: implementing witnesses, understanding compiler-generated types, and using the Contract runtime. For Compact witness declarations and disclosure rules, see `compact-structure`. For privacy patterns using witnesses, see `compact-privacy-disclosure`. For standard library functions referenced in witnesses, see `compact-standard-library`.
+
+## Compiler Output
+
+Running `compact compile src/mycontract.compact src/managed/mycontract` produces a `managed/` directory containing the generated TypeScript API:
+
+```
+src/managed/mycontract/
+├── contract/
+│   ├── index.js        # Runtime implementation
+│   └── index.d.ts      # Type declarations
+├── compiler/           # Compiler metadata
+├── keys/               # ZK proving/verifying keys
+└── zkir/               # ZK intermediate representation
+```
+
+Key exports from `contract/index.js`:
+
+```typescript
+import { Ledger, Witnesses, Circuits, Contract } from "./managed/mycontract/contract/index.js";
+```
+
+- **`Ledger`** — TypeScript type matching the contract's ledger declarations
+- **`Witnesses`** — Interface defining required witness implementations
+- **`Circuits`** — Type describing available circuit functions
+- **`Contract`** — Class that binds witnesses to circuits
+- **`ledger()`** — Function to parse on-chain state into typed objects
+
+## Type Mapping Quick Reference
+
+| Compact Type | TypeScript Type | Notes |
+|---|---|---|
+| `Field` | `bigint` | Runtime bounds checked (max field value) |
+| `Uint<N>` / `Uint<0..N>` | `bigint` | Runtime bounds checked |
+| `Boolean` | `boolean` | |
+| `Bytes<N>` | `Uint8Array` | Runtime length checked (N bytes) |
+| `Opaque<"string">` | `string` | Pass-through |
+| `Opaque<"Uint8Array">` | `Uint8Array` | Pass-through |
+| `enum` variants | `number` | Runtime membership checked |
+| `struct { a: A, b: B }` | `{ a: A, b: B }` | Plain object |
+| `Vector<N, T>` / tuples | `T[]` | Runtime length checked |
+| `Maybe<T>` | `{ is_some: boolean; value: T }` | Must export from Compact to use type |
+| `Either<L, R>` | Tagged union | `{ tag: "left"; value: L } \| { tag: "right"; value: R }` |
+| `Counter` | `bigint` | Via `ledger()` |
+| `Map<K, V>` | `Map<K, V>` | Via `ledger()` |
+| `Set<T>` | `Set<T>` | Via `ledger()` |
+| `MerkleTreePath<N, T>` | Nested structure | Array of sibling hashes + directions |
+
+For complete type mapping details, runtime validation, and casting rules, see `references/type-mappings.md`.
+
+## Witness Implementation Pattern
+
+Every witness function follows the same pattern:
+
+```typescript
+import { WitnessContext } from "@midnight-ntwrk/compact-runtime";
+import { Ledger } from "./managed/mycontract/contract/index.js";
+
+// 1. Define private state type
+type MyPrivateState = {
+  readonly secretKey: Uint8Array;
+};
+
+// 2. Create factory function
+const createMyPrivateState = (secretKey: Uint8Array): MyPrivateState => ({
+  secretKey,
+});
+
+// 3. Implement witnesses object — keys must match Compact witness names exactly
+export const witnesses = {
+  local_secret_key: ({
+    privateState,
+  }: WitnessContext<Ledger, MyPrivateState>): [MyPrivateState, Uint8Array] => [
+    privateState,
+    privateState.secretKey,
+  ],
+};
+```
+
+**Key rules:**
+- First parameter is always `WitnessContext<Ledger, PrivateState>`
+- Return type is always `[PrivateState, ReturnValue]` — a tuple of updated private state and the declared return value
+- Object keys in `witnesses` must match Compact witness function names exactly
+- Additional parameters (after WitnessContext) match the Compact witness declaration parameters
+
+For WitnessContext API details, common patterns, and state management, see `references/witness-implementation.md`.
+
+## Private State Design
+
+Private state holds off-chain data that witnesses access. It persists across circuit calls within a session:
+
+```typescript
+// Simple: single secret key
+type SimpleState = { readonly secretKey: Uint8Array };
+
+// Complex: multiple values, per-contract scoping
+type ComplexState = {
+  readonly secretKey: Uint8Array;
+  readonly localData: Map<string, string[]>;
+};
+```
+
+To mutate private state, return a new object in the witness tuple:
+
+```typescript
+store_data: (
+  { privateState, contractAddress }: WitnessContext<Ledger, ComplexState>,
+  data: bigint[],
+): [ComplexState, Uint8Array] => {
+  const updatedData = new Map(privateState.localData);
+  updatedData.set(contractAddress, data.map(String));
+  return [
+    { ...privateState, localData: updatedData },
+    someComputedValue,
+  ];
+},
+```
+
+## Contract Class Usage
+
+The compiler-generated `Contract` class binds witnesses to circuits:
+
+```typescript
+import { MyContract } from "@midnight-ntwrk/mycontract-contract";
+
+// Instantiate with witnesses
+const contractInstance = new MyContract.Contract(witnesses);
+
+// Pure circuits — local computation, no proof, no transaction
+const hash = contractInstance.pureCircuits.computeHash(inputData);
+
+// Read ledger state from on-chain data
+const ledgerState = MyContract.ledger(contractStateData);
+const currentValue = ledgerState.myField;
+```
+
+For Contract class details, circuits vs impureCircuits, and the ledger function, see `references/contract-runtime.md`.
+
+## Reference Files
+
+| Topic | Reference File |
+|-------|---------------|
+| Complete type mapping table, CompactType\<T\>, runtime validation, casting rules | `references/type-mappings.md` |
+| WitnessContext API, return tuples, common patterns, state transitions | `references/witness-implementation.md` |
+| Contract class, circuits vs impureCircuits, pureCircuits, ledger() | `references/contract-runtime.md` |

--- a/plugins/compact-core/skills/compact-witness-ts/references/contract-runtime.md
+++ b/plugins/compact-core/skills/compact-witness-ts/references/contract-runtime.md
@@ -1,0 +1,203 @@
+# Compact Contract Runtime
+
+Reference for the compiler-generated Contract class, circuit interfaces, and the ledger function. For witness implementation details, see `references/witness-implementation.md`. For type mappings, see `references/type-mappings.md`.
+
+## Compiler-Generated .d.ts Structure
+
+Every compiled Compact contract produces a `.d.ts` file with this structure:
+
+```typescript
+import type * as __compactRuntime from '@midnight-ntwrk/compact-runtime';
+
+// 1. Exported types (enums, structs, Maybe, etc.)
+export type Maybe<a> = { is_some: boolean; value: a };
+
+// 2. Witnesses interface
+export interface Witnesses<PS> {
+  myWitness(context: __compactRuntime.WitnessContext<Ledger, PS>): [PS, Uint8Array];
+}
+
+// 3. Circuits type
+export type Circuits<PS> = {
+  myCircuit(arg: bigint): [];
+  pureCompute(x: bigint, y: bigint): bigint;
+};
+
+// 4. Contract class
+export declare class Contract<PS = any, W extends Witnesses<PS> = Witnesses<PS>> {
+  witnesses: W;
+  circuits: Circuits<PS>;
+  impureCircuits: ImpureCircuits<PS>;
+  constructor(witnesses: W);
+  initialState(context: __compactRuntime.ConstructorContext<PS>): __compactRuntime.ConstructorResult<PS>;
+}
+
+// 5. Ledger type and function
+export type Ledger = {
+  readonly myField: bigint;
+  readonly owner: Uint8Array;
+};
+
+export declare function ledger(state: __compactRuntime.ContractState): Ledger;
+```
+
+## The Contract Class
+
+### Instantiation
+
+Create a contract instance by passing your witnesses object:
+
+```typescript
+import { MyContract } from "@midnight-ntwrk/mycontract-contract";
+import { witnesses } from "./witnesses.js";
+
+const contractInstance = new MyContract.Contract(witnesses);
+```
+
+The `Witnesses` interface type-checks your implementations at compile time — if your witness functions have wrong signatures, TypeScript reports the error.
+
+### Constructor Arguments
+
+If the Compact contract has a `constructor(arg1: T1, arg2: T2)`, the generated Contract constructor takes witnesses first, then the constructor arguments:
+
+```typescript
+// Compact: constructor(value: Field)
+const instance = new MyContract.Contract(witnesses, 42n);
+
+// Compact: constructor() — no args
+const instance = new MyContract.Contract(witnesses);
+```
+
+## Circuits vs ImpureCircuits vs PureCircuits
+
+The Contract class exposes three circuit interfaces:
+
+| Interface | Contains | Proof Generated? | Modifies State? |
+|-----------|----------|-------------------|-----------------|
+| `circuits` | All circuits | Yes (for impure) | Impure: yes, Pure: no |
+| `impureCircuits` | Only circuits that touch state/witnesses | Yes | Yes |
+| `pureCircuits` | Only `pure circuit` declarations | **No** | **No** |
+
+### impureCircuits
+
+Circuits that read/write ledger state or call witnesses. These generate ZK proofs and create transactions:
+
+```compact
+// Compact
+export circuit increment(): [] {
+  round.increment(1);
+}
+```
+
+```typescript
+// TypeScript — called through the DApp's transaction layer
+// (via deployContract/findDeployedContract, not directly)
+const result = await deployedContract.callTx.increment();
+```
+
+### pureCircuits
+
+Circuits marked `pure` in Compact run locally without generating proofs. Call them directly on the contract instance:
+
+```compact
+// Compact
+export pure circuit computeHash(data: Bytes<32>): Bytes<32> {
+  return persistentHash<Vector<2, Bytes<32>>>([pad(32, "prefix:"), data]);
+}
+```
+
+```typescript
+// TypeScript — synchronous, local computation
+const hash: Uint8Array = contractInstance.pureCircuits.computeHash(myData);
+```
+
+Pure circuits are useful for:
+- Computing values locally that witnesses need to provide
+- Hashing data in the same way the contract does (e.g., computing a public key hash)
+- Validating inputs before submitting a transaction
+
+## The ledger() Function
+
+The compiler generates a `ledger()` function that parses raw on-chain contract state into typed TypeScript objects:
+
+```typescript
+import { MyContract } from "@midnight-ntwrk/mycontract-contract";
+
+// Parse raw contract state into typed ledger object
+const state = MyContract.ledger(contractState.data);
+
+// Access typed fields
+const round: bigint = state.round;           // Counter -> bigint
+const owner: Uint8Array = state.owner;        // Bytes<32> -> Uint8Array
+const message = state.message;                // Maybe<Opaque<"string">>
+```
+
+Only `export ledger` fields are accessible through the `ledger()` function. Non-exported ledger fields are not visible.
+
+### Querying Ledger State
+
+In a DApp context, you typically query the indexer for contract state, then parse it:
+
+```typescript
+const contractState = await providers.publicDataProvider
+  .queryContractState(contractAddress);
+
+if (contractState != null) {
+  const ledgerState = MyContract.ledger(contractState.data);
+  console.log(`Current round: ${ledgerState.round}`);
+}
+```
+
+## Private State ID
+
+When deploying or joining a contract, you provide a string identifier for the private state store. This lets the runtime persist and retrieve private state across sessions:
+
+```typescript
+// Deploying
+const deployed = await deployContract(providers, {
+  contract: contractInstance,
+  privateStateId: 'myContractPrivateState',
+  initialPrivateState: createMyPrivateState(secretKey),
+});
+
+// Joining an existing deployment
+const found = await findDeployedContract(providers, {
+  contract: contractInstance,
+  contractAddress: address,
+  privateStateId: 'myContractPrivateState',
+  initialPrivateState: createMyPrivateState(secretKey),
+});
+```
+
+The `privateStateId` is a string key used by the private state provider to store and retrieve state. Use a descriptive, unique name per contract type.
+
+## Re-Export Pattern
+
+The standard pattern for a contract package is an `index.ts` that re-exports both the generated code and your witness implementations:
+
+```typescript
+// contract/src/index.ts
+export * from "./managed/mycontract/contract/index.js";
+export * from "./witnesses.js";
+
+// Optional: re-export for convenient access
+import * as CompiledContract from "./managed/mycontract/contract/index.js";
+export { CompiledContract };
+```
+
+This provides a single import point for consuming applications:
+
+```typescript
+// In your DApp
+import { Contract, Ledger, witnesses, createMyPrivateState } from "@midnight-ntwrk/mycontract-contract";
+```
+
+## Common Mistakes
+
+| Mistake | Correct | Why |
+|---------|---------|-----|
+| Calling `impureCircuits` directly | Use `deployedContract.callTx.circuitName()` | Impure circuits need the full transaction pipeline |
+| Using `pureCircuits` for state-changing logic | Pure circuits cannot read or modify ledger | Use impure circuits for state changes |
+| Forgetting to export ledger fields in Compact | `export ledger myField: Type;` | Non-exported fields aren't in the `ledger()` output |
+| Importing from wrong path | `./managed/<name>/contract/index.js` | Path includes the contract name subdirectory |
+| Mixing up `.js` and `.cjs` imports | Check your package `type` field | `"type": "module"` uses `.js`, CommonJS uses `.cjs` |

--- a/plugins/compact-core/skills/compact-witness-ts/references/type-mappings.md
+++ b/plugins/compact-core/skills/compact-witness-ts/references/type-mappings.md
@@ -1,0 +1,194 @@
+# Compact to TypeScript Type Mappings
+
+Complete reference for how Compact types map to TypeScript representations. All type translations are handled by the compiler-generated code and the `@midnight-ntwrk/compact-runtime` package.
+
+## Primitive Types
+
+| Compact Type | TypeScript Type | Runtime Validation | Example |
+|---|---|---|---|
+| `Field` | `bigint` | Must be `>= 0` and `< MAX_FIELD` | `42n` |
+| `Boolean` | `boolean` | Must be `true` or `false` | `true` |
+| `Uint<N>` | `bigint` | Must be `>= 0` and `< 2^N` | `255n` for `Uint<8>` |
+| `Uint<0..N>` | `bigint` | Must be `>= 0` and `<= N` | `5n` for `Uint<0..10>` |
+| `Bytes<N>` | `Uint8Array` | Must have exactly `N` bytes | `new Uint8Array(32)` |
+
+### Runtime Bounds Checking
+
+Compact types have size and range limits that TypeScript's type system cannot express. The runtime enforces these:
+
+```typescript
+// TypeScript sees: bigint
+// Runtime checks: 0 <= value < 2^64
+const amount: bigint = 1000n;  // OK
+const tooLarge: bigint = 2n ** 64n;  // Runtime error when passed to circuit
+```
+
+This is necessary because:
+- `Field` values are limited by the ZK field's maximum value
+- `Uint` values are bounded by their declared bit-width
+- `Bytes` values must match their declared length exactly
+- TypeScript compile-time checks are easily bypassed
+
+## Opaque Types
+
+Opaque types pass through without transformation:
+
+| Compact Type | TypeScript Type | Use Case |
+|---|---|---|
+| `Opaque<"string">` | `string` | Human-readable text |
+| `Opaque<"Uint8Array">` | `Uint8Array` | Raw binary data |
+
+## Collection Types
+
+| Compact Type | TypeScript Type | Notes |
+|---|---|---|
+| `Vector<N, T>` | `T[]` | Array with runtime length check (exactly `N` elements) |
+| `[T1, T2, T3]` (tuple) | `[T1, T2, T3]` or `T[]` | Tuple or array with runtime length check |
+| `Maybe<T>` | `{ is_some: boolean; value: T }` | Must `export { Maybe }` in Compact to use the type annotation in TypeScript |
+| `Either<L, R>` | Tagged union object | See below |
+| `List<T>` | `T[]` | Variable-length (ledger only) |
+
+### Maybe Representation
+
+```typescript
+// Compact: Maybe<Uint<64>>
+// TypeScript:
+type Maybe<T> = { is_some: boolean; value: T };
+
+// Usage in witnesses:
+const found: Maybe<bigint> = { is_some: true, value: 42n };
+const notFound: Maybe<bigint> = { is_some: false, value: 0n };
+```
+
+To use `Maybe<T>` as a TypeScript type annotation, export it from your Compact contract:
+
+```compact
+export { Maybe };
+```
+
+### Either Representation
+
+```typescript
+// Compact: Either<Uint<64>, Bytes<32>>
+// TypeScript:
+type Either<L, R> = { tag: "left"; value: L } | { tag: "right"; value: R };
+```
+
+## User-Defined Types
+
+### Enums
+
+Compact enums become numeric constants:
+
+```compact
+// Compact
+export enum GameState { waiting, playing, finished }
+```
+
+```typescript
+// TypeScript (compiler-generated)
+export const GameState = { waiting: 0, playing: 1, finished: 2 } as const;
+// Runtime checks: value must be a valid index (0, 1, or 2)
+```
+
+### Structs
+
+Compact structs become plain objects:
+
+```compact
+// Compact
+export struct Config { threshold: Uint<64>, admin: Bytes<32> }
+```
+
+```typescript
+// TypeScript (compiler-generated)
+export type Config = { threshold: bigint; admin: Uint8Array };
+```
+
+### Generic Type Export Rules
+
+When Compact exports a generic type, numeric parameters (`#n`) are dropped in TypeScript:
+
+```compact
+// Compact
+export struct S<#n, T> { v: Vector<n, T>; curidx: Uint<0..n> }
+```
+
+```typescript
+// TypeScript (compiler-generated) — #n parameter is dropped
+export type S<T> = { v: T[]; curidx: bigint };
+```
+
+## Ledger ADT Representations
+
+When reading ledger state through the `ledger()` function, ADTs are represented as:
+
+| Compact Ledger Type | TypeScript via `ledger()` | Notes |
+|---|---|---|
+| `Counter` | `bigint` | Current counter value |
+| `Map<K, V>` | Read-only accessor | Access via ledger object |
+| `Set<T>` | Read-only accessor | Access via ledger object |
+| `MerkleTree<N, T>` | Root hash accessible | Tree data is not fully exposed |
+| Direct fields (`Field`, `Bytes<N>`, etc.) | Corresponding TS type | Direct property access |
+
+```typescript
+// Reading ledger state
+const state = MyContract.ledger(contractState.data);
+const roundValue: bigint = state.round;           // Counter -> bigint
+const ownerKey: Uint8Array = state.owner;          // Bytes<32> -> Uint8Array
+const currentState: number = state.gameState;      // enum -> number
+```
+
+## Witness-Specific Type Patterns
+
+### MerkleTreePath for Witness Providers
+
+When a Compact witness returns a `MerkleTreePath<N, T>`, the TypeScript representation is a structured object containing the sibling hashes and direction indicators needed for the ZK proof:
+
+```compact
+// Compact declaration
+witness get_merkle_path(leaf: Bytes<32>): MerkleTreePath<10, Bytes<32>>;
+```
+
+```typescript
+// TypeScript witness implementation provides the path data
+get_merkle_path: (
+  { privateState }: WitnessContext<Ledger, MyState>,
+  leaf: Uint8Array,
+): [MyState, MerkleTreePath] => {
+  const path = computeMerklePath(privateState.tree, leaf);
+  return [privateState, path];
+},
+```
+
+### Side-Effect Witnesses Returning Empty Tuple
+
+Compact witnesses that return `[]` (side-effect only) map to an empty array in TypeScript:
+
+```compact
+// Compact
+witness store_locally(data: Field): [];
+```
+
+```typescript
+// TypeScript
+store_locally: (
+  { privateState }: WitnessContext<Ledger, MyState>,
+  data: bigint,
+): [MyState, []] => {
+  return [{ ...privateState, storedData: data }, []];
+},
+```
+
+## CompactType\<T\> Interface
+
+The `@midnight-ntwrk/compact-runtime` package provides runtime types satisfying the `CompactType<T>` interface for values that need explicit size/length tracking:
+
+```typescript
+interface CompactType<T> {
+  toValue(value: T): Value;      // TypeScript -> field-aligned binary
+  fromValue(value: Value): T;    // field-aligned binary -> TypeScript
+}
+```
+
+This representation is not user-facing most of the time. It is used internally by the runtime for serialization of public state. You typically interact with the friendly TypeScript types (`bigint`, `Uint8Array`, etc.) in your witness implementations and circuit calls.

--- a/plugins/compact-core/skills/compact-witness-ts/references/witness-implementation.md
+++ b/plugins/compact-core/skills/compact-witness-ts/references/witness-implementation.md
@@ -1,0 +1,313 @@
+# Witness Implementation in TypeScript
+
+Complete reference for implementing Compact witness functions in TypeScript. For Compact-side witness declarations and disclosure rules, see the `compact-structure` skill. For privacy patterns, see `compact-privacy-disclosure`.
+
+## WitnessContext Interface
+
+Every witness function receives a `WitnessContext` as its first parameter:
+
+```typescript
+import { WitnessContext } from "@midnight-ntwrk/compact-runtime";
+
+interface WitnessContext<L = any, PS = any> {
+  readonly ledger: L;              // Projected ledger state
+  readonly privateState: PS;       // Current private state
+  readonly contractAddress: string; // Address of the contract being called
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ledger` | `L` (Ledger type) | The projected ledger state as it would look if the transaction ran against the current local view. Read-only. |
+| `privateState` | `PS` (your type) | The current private state for this contract. Passed through and updated by witness return values. |
+| `contractAddress` | `string` | The on-chain address of the contract being called. Useful for scoping private state per deployment. |
+
+The type parameters are:
+- `L` — The compiler-generated `Ledger` type matching your contract's ledger declarations
+- `PS` — Your custom private state type
+
+## Witness Return Tuple
+
+Every witness function returns `[PS, ReturnValue]`:
+
+```typescript
+myWitness: (context: WitnessContext<Ledger, MyState>): [MyState, Uint8Array] => {
+  return [context.privateState, someValue];
+  //      ^^^^^^^^^^^^^^^^^     ^^^^^^^^^
+  //      updated private       declared return
+  //      state                 value from Compact
+}
+```
+
+**Why return private state?** The runtime is functional — no hidden side effects. If a witness needs to update private state (e.g., store data), it returns the new state in the tuple. If no update is needed, return `privateState` unchanged.
+
+## Private State Design
+
+### Defining Private State Types
+
+Private state is a plain TypeScript object type. Mark fields `readonly` to signal immutability:
+
+```typescript
+// Simple: one secret key
+type MyPrivateState = {
+  readonly secretKey: Uint8Array;
+};
+
+// Complex: multiple values
+type GamePrivateState = {
+  readonly secretKey: Uint8Array;
+  readonly localGameplay: Record<string, string[]>;
+};
+```
+
+### Factory Functions
+
+Create a factory function for initialization:
+
+```typescript
+export const createMyPrivateState = (secretKey: Uint8Array): MyPrivateState => ({
+  secretKey,
+});
+```
+
+This is used when deploying or joining a contract to provide the initial private state.
+
+### Contracts Without Private State
+
+If your contract has no witnesses (e.g., pure counter), use an empty object:
+
+```typescript
+type CounterPrivateState = Record<string, never>;
+
+export const witnesses = {};
+```
+
+## The Witnesses Object
+
+The `witnesses` export is a plain object where:
+- **Keys** must match Compact witness function names **exactly** (including casing)
+- **Values** are functions following the `(WitnessContext, ...args) => [PS, ReturnType]` signature
+
+```compact
+// Compact declarations
+witness local_secret_key(): Bytes<32>;
+witness get_data(id: Bytes<32>): Maybe<UserRecord>;
+```
+
+```typescript
+// TypeScript implementations — keys match Compact names exactly
+export const witnesses = {
+  local_secret_key: ({ privateState }: WitnessContext<Ledger, MyState>): [MyState, Uint8Array] => {
+    return [privateState, privateState.secretKey];
+  },
+
+  get_data: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    id: Uint8Array,
+  ): [MyState, { is_some: boolean; value: UserRecord }] => {
+    const record = privateState.records.get(toHex(id));
+    if (record) {
+      return [privateState, { is_some: true, value: record }];
+    }
+    return [privateState, { is_some: false, value: defaultRecord }];
+  },
+};
+```
+
+## Common Witness Patterns
+
+### Pattern 1: Secret Key Provider
+
+The simplest and most common pattern. Returns a stored secret key without modifying state:
+
+```compact
+// Compact
+witness local_secret_key(): Bytes<32>;
+```
+
+```typescript
+// TypeScript
+local_secret_key: ({
+  privateState,
+}: WitnessContext<Ledger, MyState>): [MyState, Uint8Array] => [
+  privateState,
+  privateState.secretKey,
+],
+```
+
+Destructuring `{ privateState }` from the WitnessContext is idiomatic when you don't need `ledger` or `contractAddress`.
+
+### Pattern 2: Parameterized Witness
+
+Witnesses can receive additional parameters from the calling circuit. These appear after the WitnessContext parameter and match the Compact declaration:
+
+```compact
+// Compact
+witness get_user_balance(userId: Bytes<32>): Uint<64>;
+```
+
+```typescript
+// TypeScript — userId comes after WitnessContext
+get_user_balance: (
+  { privateState }: WitnessContext<Ledger, BankState>,
+  userId: Uint8Array,
+): [BankState, bigint] => {
+  const userIdStr = new TextDecoder().decode(userId).replace(/\0/g, '');
+  const balance = privateState.userBalances.get(userIdStr);
+  if (!balance) {
+    throw new Error(`User ${userIdStr} not found`);
+  }
+  return [privateState, balance];
+},
+```
+
+### Pattern 3: State-Mutating Witness
+
+When a witness needs to update private state, spread the existing state and override changed fields:
+
+```compact
+// Compact
+witness store_gameplay(setup: Vector<10, Uint<64>>): Bytes<32>;
+```
+
+```typescript
+// TypeScript — returns updated private state
+store_gameplay: (
+  { privateState, contractAddress }: WitnessContext<Ledger, GameState>,
+  playerSetup: bigint[],
+): [GameState, Uint8Array] => {
+  const updatedGameplay = { ...privateState.localGameplay };
+  updatedGameplay[contractAddress] = playerSetup.map(String);
+
+  return [
+    { ...privateState, localGameplay: updatedGameplay },
+    computeSetupHash(playerSetup),
+  ];
+},
+```
+
+### Pattern 4: Ledger-Reading Witness
+
+Access current ledger state to make decisions. The `ledger` field provides a read-only view:
+
+```compact
+// Compact
+witness should_participate(): Boolean;
+```
+
+```typescript
+// TypeScript — reads ledger state
+should_participate: ({
+  privateState,
+  ledger,
+}: WitnessContext<Ledger, MyState>): [MyState, boolean] => {
+  // Check on-chain state to decide
+  const currentRound = ledger.round;
+  return [privateState, currentRound < 10n];
+},
+```
+
+### Pattern 5: Contract-Address-Keyed State
+
+Use `contractAddress` to scope private state per deployment, enabling one witness implementation to work across multiple contract instances:
+
+```compact
+// Compact
+witness get_local_data(): Vector<5, Field>;
+```
+
+```typescript
+// TypeScript — different data per contract deployment
+get_local_data: ({
+  privateState,
+  contractAddress,
+}: WitnessContext<Ledger, MultiContractState>): [MultiContractState, bigint[]] => {
+  const data = privateState.perContract.get(contractAddress) ?? defaultData;
+  return [privateState, data];
+},
+```
+
+### Pattern 6: Side-Effect-Only Witness
+
+Witnesses returning `[]` in Compact perform side effects only (store data locally):
+
+```compact
+// Compact
+witness save_result(value: Field): [];
+```
+
+```typescript
+// TypeScript — returns empty array for the "return value"
+save_result: (
+  { privateState }: WitnessContext<Ledger, MyState>,
+  value: bigint,
+): [MyState, []] => {
+  return [
+    { ...privateState, lastResult: value },
+    [],
+  ];
+},
+```
+
+### Pattern 7: Multiple Secret Keys
+
+Some contracts need multiple keys (e.g., identity systems with per-DID keys):
+
+```compact
+// Compact
+witness local_secret_key(): Bytes<32>;
+witness additional_keys(): Vector<5, Bytes<32>>;
+```
+
+```typescript
+// TypeScript
+type MultiKeyState = {
+  readonly local_secret_key: Uint8Array;
+  readonly multiple_local_secret_keys: Uint8Array[];
+};
+
+export const witnesses = {
+  local_secret_key: ({
+    privateState,
+  }: WitnessContext<Ledger, MultiKeyState>): [MultiKeyState, Uint8Array] => [
+    privateState,
+    privateState.local_secret_key,
+  ],
+
+  additional_keys: ({
+    privateState,
+  }: WitnessContext<Ledger, MultiKeyState>): [MultiKeyState, Uint8Array[]] => [
+    privateState,
+    privateState.multiple_local_secret_keys,
+  ],
+};
+```
+
+## Error Handling
+
+Throwing an error inside a witness function aborts the transaction. Use this for validation:
+
+```typescript
+get_balance: (
+  { privateState }: WitnessContext<Ledger, BankState>,
+  userId: Uint8Array,
+): [BankState, bigint] => {
+  const balance = privateState.balances.get(decodeUserId(userId));
+  if (balance === undefined) {
+    throw new Error(`User not found in private state`);
+  }
+  return [privateState, balance];
+},
+```
+
+The error propagates to the circuit caller. There is no on-chain effect from a failed witness — the transaction is simply not submitted.
+
+## Common Mistakes
+
+| Mistake | Correct | Why |
+|---------|---------|-----|
+| Witness key doesn't match Compact name | Keys must be identical to Compact witness names | Runtime lookup by name |
+| Forgetting to return updated private state | Always return `[newState, value]` tuple | Runtime expects the tuple |
+| Mutating `privateState` directly | Spread and override: `{ ...privateState, field: newVal }` | Private state should be treated as immutable |
+| Returning wrong tuple order | `[privateState, returnValue]` not `[returnValue, privateState]` | State first, value second |
+| Missing parameters after WitnessContext | Additional params must match Compact declaration order | Circuit passes args positionally |


### PR DESCRIPTION
## Summary

- Add new `compact-witness-ts` skill covering the TypeScript half of Compact contracts
- SKILL.md entry point with compiler output, type mapping quick reference, witness patterns, private state design, and Contract class usage
- 3 reference files: type-mappings.md (194 lines), witness-implementation.md (313 lines), contract-runtime.md (203 lines)
- Add 8 new keywords to plugin.json for discoverability

## Details

This skill complements existing Compact-side skills (`compact-structure`, `compact-privacy-disclosure`, `compact-standard-library`) with cross-references. It follows the "Contract-Out" approach: compiler output -> types -> witnesses -> runtime.

**Reference files:**
- `type-mappings.md` — Compact-to-TypeScript type mapping (primitives, collections, enums, structs, ledger ADTs, CompactType\<T\>)
- `witness-implementation.md` — WitnessContext API, return tuple pattern, 7 common witness patterns, error handling
- `contract-runtime.md` — Contract class, circuits vs impureCircuits vs pureCircuits, ledger(), re-export pattern

## Test plan
- [x] All 4 files created in correct directory structure
- [x] SKILL.md has valid YAML frontmatter
- [x] All reference files have substantial content (862 lines total)
- [x] plugin.json updated with 8 new keywords
- [x] Git history is clean with atomic commits

Generated with [Claude Code](https://claude.com/claude-code)