### PR TITLE
feat(compact-core): augment compact-review with Midnight MCP server tools

### DIFF
--- a/docs/plans/2026-03-02-compact-review-agent-design.md
+++ b/docs/plans/2026-03-02-compact-review-agent-design.md
@@ -1,0 +1,295 @@
+# Compact Code Review Agent — Design Document
+
+**Date:** 2026-03-02
+**Status:** Approved
+**Plugin:** compact-core
+
+## Overview
+
+A comprehensive code review system for Midnight Compact smart contracts, their TypeScript witness implementations, and associated tests. The system identifies issues across 11 review categories with privacy concerns surfaced first, given Midnight's privacy-first design philosophy.
+
+## Architecture
+
+Three components work together:
+
+```
+┌─────────────────────────────────────────────────┐
+│  /compact-core:review-compact  (COMMAND)        │
+│  Orchestrates the review, detects agent teams   │
+│                                                 │
+│  if CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:       │
+│    → Creates agent team with reviewers          │
+│    → Teammates claim tasks from shared list     │
+│    → Teammates can challenge each other         │
+│                                                 │
+│  else:                                          │
+│    → Spawns parallel subagents (Agent tool)     │
+│    → Each returns findings to command           │
+│    → Command consolidates                       │
+└──────────────────┬──────────────────────────────┘
+                   │
+         ┌─────────┴─────────┐
+         │                   │
+    ┌────▼────┐        ┌────▼────┐
+    │reviewer │  x11   │reviewer │
+    │ agent   │───────▶│ agent   │
+    └─────────┘        └─────────┘
+         │                   │
+    loads compact-review     loads compact-review
+    skill + reference        skill + reference
+    for assigned category    for assigned category
+```
+
+### Component 1: `compact-review` Skill (Knowledge Layer)
+
+**Location:** `plugins/compact-core/skills/compact-review/`
+
+The skill SKILL.md acts as a routing table, directing agents to the correct reference file based on their assigned review category. Each reference file contains:
+
+1. A checklist of specific issues to look for
+2. Guidance on patterns and anti-patterns
+3. Severity classification criteria for that category
+4. Example findings showing what good output looks like
+
+**Reference files (11 total):**
+
+| File | Category | Key Focus |
+|------|----------|-----------|
+| `privacy-review.md` | Privacy & Disclosure | Unnecessary `disclose()`, witness data leaking to public ledger, `Set` vs `MerkleTree` for private membership, `persistentHash` vs `persistentCommit` confusion, salt reuse, conditional disclosure leaks, selective disclosure overexposure |
+| `security-review.md` | Security & Cryptographic Correctness | Access control on exported circuits, persistent vs transient hash/commit usage, domain separation, nullifier construction, commitment schemes, Merkle path verification, error message leakage |
+| `token-security-review.md` | Token & Economic Security | Double-spend via nullifier reuse, `Uint<64>` vs `Uint<128>` overflow, unsafe transfer/mint patterns, missing `receiveShielded`, balance manipulation, authorization checks |
+| `concurrency-review.md` | Concurrency & Contention | Read-then-write patterns, Counter `read()+set()` vs `increment()`, simultaneous user interactions, transaction conflict potential |
+| `compilation-review.md` | Compilation & Type Safety | Deprecated syntax, wrong return types (`Void` vs `[]`), implicit disclosure errors, invalid casts, missing generics, `include` vs `import` |
+| `performance-review.md` | Performance & Circuit Efficiency | Proof generation cost, excessive ledger reads, MerkleTree depth oversizing, redundant computations, loop impact, unnecessary type conversions |
+| `witness-consistency-review.md` | Witness-Contract Consistency | TS witness names matching Compact declarations, type mapping correctness (`Field`→`bigint`, `Bytes<N>`→`Uint8Array`), private state immutability, `WitnessContext` usage, `Maybe`/`Either` mapping |
+| `architecture-review.md` | Architecture, State Design & Composability | ADT selection, MerkleTree depth planning, constructor initialization, `sealed` vs `export`, module usage, contract decomposition, circuit vs witness boundary |
+| `code-quality-review.md` | Code Quality & Best Practices | Naming conventions, circuit complexity, dead code, stdlib usage (avoiding hallucinated functions), Compact idioms, duplication |
+| `testing-review.md` | Testing Adequacy | Edge case coverage, negative testing, private state testing, witness mock correctness, integration test patterns |
+| `documentation-review.md` | Documentation | Circuit documentation, witness contracts, ledger state semantics, constructor docs |
+
+### Component 2: `reviewer` Agent (Execution Layer)
+
+**Location:** `plugins/compact-core/agents/reviewer.md`
+
+A reusable agent that performs focused review of a single category. Same base prompt, different category assignment each time.
+
+**Frontmatter:**
+```yaml
+name: reviewer
+description: "Specialized Compact code reviewer for a single review category.
+  Dispatched by the review-compact command with a category assignment.
+  Not intended for direct user invocation."
+skills: compact-core:compact-structure, compact-core:compact-ledger,
+  compact-core:compact-privacy-disclosure, compact-core:compact-tokens,
+  compact-core:compact-language-ref, compact-core:compact-standard-library,
+  compact-core:compact-witness-ts, compact-core:compact-review,
+  devs:code-review, devs:typescript-core, devs:security-core
+model: sonnet
+color: blue
+```
+
+**Skills loaded (10 total):**
+- All 7 compact-core skills for domain knowledge
+- `compact-core:compact-review` for category-specific checklists
+- `devs:code-review`, `devs:typescript-core`, `devs:security-core` for general review capabilities
+
+**Persona:** Midnight/Compact domain expert with deep knowledge of zero-knowledge proof systems, privacy-preserving smart contracts, and the Compact language.
+
+**Review methodology:**
+1. Receive assignment (category name + file list)
+2. Load the `compact-review` skill → routed to correct reference file
+3. Read all assigned files
+4. Systematically apply each checklist item from the reference
+5. Classify findings by severity
+6. Format structured output with file:line references and fix suggestions
+7. Highlight positive aspects
+
+**Severity classifications:**
+
+| Level | Criteria |
+|-------|----------|
+| **Critical** | Will cause loss of funds, data breach, or contract exploitation |
+| **High** | Security vulnerability or privacy leak exploitable under certain conditions |
+| **Medium** | Correctness issue, compilation problem, or significant performance concern |
+| **Low** | Code quality, style, or minor best practice deviation |
+| **Suggestion** | Enhancement opportunity, not a problem |
+
+**Output format per finding:**
+```markdown
+### [Severity]
+
+- **[Issue title]** (`file:line`)
+  - **Problem:** Description of the issue
+  - **Impact:** Why it matters
+  - **Fix:** Suggested fix with code example
+```
+
+### Component 3: `/compact-core:review-compact` Command (Orchestration Layer)
+
+**Location:** `plugins/compact-core/commands/review-compact.md`
+
+**Frontmatter:**
+```yaml
+description: Comprehensive review of Compact smart contract code covering privacy,
+  security, tokens, performance, and more. Supports agent teams when available.
+allowed-tools: Bash, Agent, Read, Glob, Grep, TaskCreate, TaskUpdate, TaskList,
+  AskUserQuestion
+argument-hint: [path/to/contract.compact or directory]
+```
+
+**Command flow:**
+
+#### Step 1: Identify Files
+
+- If user provides a path argument, use it
+- Otherwise, find all `.compact` files, companion witness `.ts` files, and test files in the project
+- Group files by contract
+
+#### Step 2: Check for Agent Teams
+
+```bash
+echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-not_set}"
+```
+
+#### Step 3a: Agent Teams Mode
+
+When `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is set, create an agent team:
+
+```
+Create an agent team to review Compact code. Spawn 11 reviewer teammates,
+one for each review category. Each teammate should:
+
+1. Load the compact-core:compact-review skill
+2. Read their assigned reference file for their category
+3. Read the contract files: [file list]
+4. Apply the checklist from their reference
+5. Report findings in the structured format
+
+Assign teammates as follows:
+- Teammate 1: Privacy & Disclosure (reference: privacy-review.md)
+- Teammate 2: Security & Cryptographic Correctness (reference: security-review.md)
+- [... all 11 categories ...]
+
+Use sonnet model for each teammate.
+Wait for all teammates to complete before synthesizing.
+```
+
+#### Step 3b: Subagent Mode (concurrent execution)
+
+When agent teams are not available, spawn all 11 subagents in a SINGLE message:
+
+```
+You MUST launch ALL 11 reviewer agents in a SINGLE message using 11 Agent
+tool calls. This ensures they run concurrently. Do NOT call them one at a
+time — that would make them sequential.
+
+In ONE message, make these 11 Agent tool calls simultaneously:
+
+Agent call 1:
+  subagent_type: "compact-core:reviewer"
+  description: "Review privacy & disclosure"
+  prompt: "You are reviewing category: Privacy & Disclosure.
+    Files to review: [file list].
+    Load the compact-core:compact-review skill and read the
+    privacy-review.md reference. Apply every checklist item.
+    Report findings in the structured format with severity levels."
+
+Agent call 2:
+  subagent_type: "compact-core:reviewer"
+  description: "Review security & crypto"
+  prompt: "You are reviewing category: Security & Cryptographic Correctness.
+    Files to review: [file list].
+    Load the compact-core:compact-review skill and read the
+    security-review.md reference. Apply every checklist item.
+    Report findings in the structured format with severity levels."
+
+[...Agent calls 3-11 follow the same pattern for remaining categories...]
+
+CRITICAL: All 11 calls MUST be in the same message to run in parallel.
+```
+
+#### Step 4: Consolidated Report
+
+Collect all reviewer results and produce:
+
+```markdown
+# Compact Code Review Report
+
+## Summary
+- Total issues found: N
+- Critical: N | High: N | Medium: N | Low: N | Suggestions: N
+- Files reviewed: [list]
+
+## Privacy & Disclosure
+[Privacy findings shown FIRST, always]
+
+### Critical
+- **[Issue]** (`file:line`) ...
+
+### High
+...
+
+## Security & Cryptographic Correctness
+[Then remaining categories ordered by highest severity found]
+...
+
+## Positive Highlights
+[Aggregated from all reviewers]
+```
+
+**Report ordering rules:**
+1. Privacy & Disclosure is always the first category
+2. Remaining categories ordered by highest severity issue found (categories with Critical issues before those with only Medium, etc.)
+3. Within each category: Critical → High → Medium → Low → Suggestions
+4. Duplicate issues found by multiple reviewers are deduplicated
+5. Positive highlights aggregated at the end
+
+## File Structure
+
+```
+plugins/compact-core/
+├── .claude-plugin/
+│   └── plugin.json (update with new keywords)
+├── agents/
+│   └── reviewer.md
+├── commands/
+│   └── review-compact.md
+└── skills/
+    ├── compact-review/
+    │   ├── SKILL.md
+    │   └── references/
+    │       ├── privacy-review.md
+    │       ├── security-review.md
+    │       ├── token-security-review.md
+    │       ├── concurrency-review.md
+    │       ├── compilation-review.md
+    │       ├── performance-review.md
+    │       ├── witness-consistency-review.md
+    │       ├── architecture-review.md
+    │       ├── code-quality-review.md
+    │       ├── testing-review.md
+    │       └── documentation-review.md
+    ├── compact-structure/
+    ├── compact-ledger/
+    ├── compact-privacy-disclosure/
+    ├── compact-tokens/
+    ├── compact-language-ref/
+    ├── compact-standard-library/
+    └── compact-witness-ts/
+```
+
+## Review Scope
+
+The agent reviews the full stack:
+- `.compact` contract files
+- TypeScript witness implementations
+- Test files
+
+## Data Sources
+
+The reference files draw from:
+- Existing compact-core skill knowledge (common mistakes tables, privacy anti-patterns, compiler error references)
+- Midnight MCP server research (security test vectors, economic attack vectors, contention patterns)
+- Official Midnight documentation (explicit disclosure mechanics, ZK proof fundamentals)
+- OpenZeppelin Compact contracts (token security patterns, authorization patterns)
+- Community examples (real-world Compact contract patterns)

--- a/docs/plans/2026-03-02-compact-review-agent-plan.md
+++ b/docs/plans/2026-03-02-compact-review-agent-plan.md
@@ -1,0 +1,1119 @@
+# Compact Review Agent Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a comprehensive Compact smart contract review system with 11 review categories, a reusable reviewer agent, and an orchestrating command.
+
+**Architecture:** A `compact-review` skill provides category-specific checklists via 11 reference files. A `reviewer` agent applies one checklist per invocation. A `/review-compact` command orchestrates 11 parallel reviewer instances (via agent teams or subagents) and consolidates findings.
+
+**Tech Stack:** Claude Code plugin system (skills, agents, commands). Markdown files with YAML frontmatter.
+
+**Design doc:** `docs/plans/2026-03-02-compact-review-agent-design.md`
+
+---
+
+### Task 1: Scaffold directories and create SKILL.md routing table
+
+**Files:**
+- Create: `plugins/compact-core/skills/compact-review/SKILL.md`
+- Create: `plugins/compact-core/skills/compact-review/references/` (directory)
+- Create: `plugins/compact-core/agents/` (directory)
+- Create: `plugins/compact-core/commands/` (directory)
+
+**Step 1: Create directories**
+
+```bash
+mkdir -p plugins/compact-core/skills/compact-review/references
+mkdir -p plugins/compact-core/agents
+mkdir -p plugins/compact-core/commands
+```
+
+**Step 2: Write `plugins/compact-core/skills/compact-review/SKILL.md`**
+
+This is the routing table that directs reviewers to the correct reference file.
+
+```markdown
+---
+name: compact-review
+description: This skill should be used when reviewing Compact smart contract code, TypeScript witness implementations, or test files for a Midnight project. It provides category-specific checklists for privacy, security, cryptographic correctness, token economics, concurrency, compilation, performance, witness-contract consistency, architecture, code quality, testing adequacy, and documentation. Use this skill when you need structured review checklists and severity classification criteria for any of these categories. Load the appropriate reference file for your assigned review category.
+---
+
+# Compact Code Review Checklists
+
+This skill contains review checklists for 11 categories of Compact smart contract review. Each reference file provides a focused checklist for one review category.
+
+## How to Use
+
+You will be assigned a **review category** by the review-compact command or coordinator. Load the reference file for your assigned category and apply every checklist item to the code under review.
+
+## Category Reference Map
+
+| Category | Reference File | Focus |
+|----------|---------------|-------|
+| Privacy & Disclosure | `privacy-review` | `disclose()` usage, witness data leaks, Set vs MerkleTree, persistentHash vs persistentCommit, salt reuse, conditional disclosure |
+| Security & Cryptographic Correctness | `security-review` | Access control, hash/commit usage, domain separation, nullifiers, commitments, Merkle paths, error leakage |
+| Token & Economic Security | `token-security-review` | Double-spend, overflow, unsafe transfers, missing receiveShielded, authorization |
+| Concurrency & Contention | `concurrency-review` | Read-then-write patterns, Counter ops, transaction conflicts |
+| Compilation & Type Safety | `compilation-review` | Deprecated syntax, return types, disclosure errors, casts, generics |
+| Performance & Circuit Efficiency | `performance-review` | Proof cost, ledger reads, MerkleTree depth, redundant computation, loops |
+| Witness-Contract Consistency | `witness-consistency-review` | Name matching, type mappings, private state patterns, WitnessContext |
+| Architecture, State Design & Composability | `architecture-review` | ADT selection, depth planning, visibility, modules, decomposition |
+| Code Quality & Best Practices | `code-quality-review` | Naming, complexity, dead code, stdlib hallucinations, idioms |
+| Testing Adequacy | `testing-review` | Edge cases, negative tests, private state testing, witness mocks |
+| Documentation | `documentation-review` | Circuit docs, witness contracts, ledger semantics |
+
+## Severity Classification
+
+Apply these severity levels consistently across all categories:
+
+| Level | Criteria | Examples |
+|-------|----------|----------|
+| **Critical** | Will cause loss of funds, data breach, or contract exploitation | Missing access control on mint, private key leaked to ledger, double-spend vulnerability |
+| **High** | Security vulnerability or privacy leak exploitable under certain conditions | Unnecessary disclose() on sensitive data, missing overflow check on token amounts |
+| **Medium** | Correctness issue, compilation problem, or significant performance concern | Wrong type cast that will fail at runtime, MerkleTree depth 32 when 10 suffices |
+| **Low** | Code quality, style, or minor best practice deviation | Inconsistent naming, unused import, missing sealed modifier |
+| **Suggestion** | Enhancement opportunity, not a problem | Could use pureCircuit for better reuse, consider adding assertion message |
+
+## Output Format
+
+For each finding, use this format:
+
+```
+- **[Issue title]** (`file:line`)
+  - **Problem:** Clear description of what is wrong
+  - **Impact:** Why this matters (security, privacy, correctness, performance)
+  - **Fix:** Suggested fix with code example when applicable
+```
+
+Group findings by severity within your category: Critical → High → Medium → Low → Suggestions.
+End with a **Positive Highlights** section noting what was done well.
+```
+
+**Step 3: Commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/SKILL.md
+git commit -m "feat(compact-core): add compact-review skill routing table"
+```
+
+---
+
+### Task 2: Write privacy-review.md reference
+
+**Files:**
+- Create: `plugins/compact-core/skills/compact-review/references/privacy-review.md`
+
+**Step 1: Write the reference file**
+
+This is the highest-priority review category. Content must cover:
+
+1. **Unnecessary Disclosure Checklist**
+   - Every `disclose()` call: is it actually needed? Could the value stay private?
+   - `disclose()` placed at witness call site instead of near the public boundary (bad practice — place close to disclosure point)
+   - Bulk `disclose()` on structs when only one field needs disclosure
+   - Return values from exported circuits: does everything returned need to be public?
+
+2. **Witness Data Leakage Checklist**
+   - Witness-derived values written to public ledger without `disclose()` (compiler catches this, but review for intent)
+   - Conditional branches revealing private information (`if (disclose(secret == expected))` — leaks boolean result)
+   - Assert conditions that leak private state (`assert(disclose(balance > 0), "...")`)
+   - Indirect leakage through control flow timing or state changes observable on-chain
+   - Cross-contract calls passing witness data (crosses trust boundary)
+
+3. **Data Structure Privacy Checklist**
+   - Using `Set<Bytes<32>>` for membership that should be private (reveals who acted — use `MerkleTree` + nullifier instead)
+   - Using `Map<key, value>` where key reveals identity (keys are always visible on insert/lookup)
+   - Using `Counter` read-then-increment vs direct `increment()` (read reveals current value unnecessarily)
+   - Using `List` which reveals insertion order and all values
+   - `MerkleTree.insert()` properly used to hide leaf content (only op that hides data)
+
+4. **Cryptographic Privacy Checklist**
+   - `persistentHash` used where `persistentCommit` is needed (hash does NOT clear witness taint — commit does)
+   - Transient vs persistent confusion (`transientHash`/`transientCommit` results stored in ledger — WRONG, they produce different values each time)
+   - Salt/nonce reuse in commitments (reusing salt allows rainbow table attacks)
+   - Same domain string used for both commitment and nullifier (should be different domains)
+   - Missing salt/randomness in commitment schemes
+
+5. **Selective Disclosure Checklist**
+   - Disclosing the actual value when only a boolean comparison result is needed (`disclose(balance)` vs `disclose(balance >= threshold)`)
+   - Disclosing more fields than necessary from a struct
+   - Missing `disclose()` on derived values that should be public (compiler catches, but intent review)
+
+6. **Anti-Patterns Table**
+
+| Anti-Pattern | Why It's Wrong | Correct Approach |
+|-------------|----------------|------------------|
+| `disclose(getSecret())` at call site | Marks private data as public too early, risks multiple disclosure paths | `disclose(x)` at the point where x crosses a public boundary |
+| `Set<Bytes<32>>` for private membership | Set operations reveal exact member identity on-chain | `MerkleTree` + nullifier for anonymous membership |
+| `persistentHash(secret)` to "hide" data | Hash does not clear witness taint; compiler still tracks it as private | `persistentCommit(secret, nonce)` which cryptographically hides and clears taint |
+| Storing `transientHash` result in ledger | Transient operations produce different results each call — value is meaningless on-chain | Use `persistentHash` for values that must be stored on ledger |
+| Same domain for commit + nullifier | Allows linking commitment to nullifier, breaking unlinkability | Different domain strings: `"app:commit"` vs `"app:nullifier"` |
+| Raw secret in sealed field | Sealed fields are set publicly during deployment | Hash or commit the secret before storing |
+
+**Step 2: Commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/privacy-review.md
+git commit -m "feat(compact-core): add privacy review checklist reference"
+```
+
+---
+
+### Task 3: Write security-review.md reference
+
+**Files:**
+- Create: `plugins/compact-core/skills/compact-review/references/security-review.md`
+
+**Step 1: Write the reference file**
+
+Content must cover:
+
+1. **Access Control Checklist**
+   - Exported circuits with no authorization check (any caller can invoke)
+   - Missing ownership verification before state-modifying operations
+   - `publicKey(secretKey, domain)` — verify domain separation for different roles
+   - Admin/authority functions callable by anyone (no `assert(caller == owner)`)
+   - Missing state machine guards (e.g., calling `reveal` before `commit`)
+
+2. **Cryptographic Correctness Checklist**
+   - `persistentHash` vs `persistentCommit` vs `transientHash` vs `transientCommit` — correct usage for each:
+     - `persistentHash`: deterministic, same input always produces same output. Use for public identifiers, nullifiers, domain-separated keys
+     - `persistentCommit`: deterministic with nonce, cryptographically hides input, clears witness taint. Use for commitments that must be verifiable later
+     - `transientHash`: non-deterministic, different each call. Use for one-time computations within a single circuit execution
+     - `transientCommit`: non-deterministic with nonce. Use for one-time commitments within a single circuit execution
+   - Domain separation: every hash/commit call should include a unique domain string to prevent cross-protocol attacks
+   - Nullifier construction: must be deterministic (persistent), include secret key + unique identifier, use domain separation
+   - Commitment scheme: commitment must use nonce/salt, reveal phase must verify against stored commitment
+
+3. **Merkle Path Verification Checklist**
+   - `checkRoot()` called to verify path against current tree root
+   - Path leaf matches expected value
+   - Using `HistoricMerkleTree` when membership must persist across state changes (regular `MerkleTree` root changes on insert)
+   - Root comparison done correctly (not just path validity but root matches on-chain state)
+
+4. **Error Handling Security Checklist**
+   - Assert messages that leak sensitive information (e.g., revealing the expected value in the error message)
+   - Missing assertions before dangerous operations (e.g., `map.lookup` without `map.member` check)
+   - Missing bounds checks (e.g., array index, balance sufficiency before subtraction)
+
+5. **Input Validation Checklist**
+   - Exported circuit parameters: are all inputs validated with appropriate assertions?
+   - Zero-value checks where zero would cause issues (e.g., division, token amount)
+   - Boundary condition checks (max values, empty collections)
+
+**Step 2: Commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/security-review.md
+git commit -m "feat(compact-core): add security review checklist reference"
+```
+
+---
+
+### Task 4: Write token-security-review.md reference
+
+**Files:**
+- Create: `plugins/compact-core/skills/compact-review/references/token-security-review.md`
+
+**Step 1: Write the reference file**
+
+Content must cover:
+
+1. **Double-Spend Prevention Checklist**
+   - Nullifier checked before spending (`assert(!nullifiers.member(nul))`)
+   - Nullifier inserted after validation (`nullifiers.insert(nul)`)
+   - Nullifier deterministically derived from coin + secret (not random)
+   - Commitment path verified against tree root before spend
+
+2. **Overflow/Underflow Checklist**
+   - Token amount type: `Uint<64>` vs `Uint<128>` — which is used and is it sufficient?
+   - Addition overflow check: `assert(MAX - currentBalance >= amount, "overflow")`
+   - Subtraction underflow check: `assert(currentBalance >= amount, "insufficient")`
+   - Total supply overflow on mint operations
+   - Intermediate arithmetic: does `a + b` fit in the declared type?
+
+3. **Authorization Checklist**
+   - Mint operations: who can call? Is there an authority check?
+   - Burn operations: can only the owner burn their tokens?
+   - Transfer operations: sender authorization verified?
+   - Allowance/approval: `spendAllowance` correctly deducts from approved amount?
+   - `unsafe` variants (`unsafeTransfer`, `unsafeMint`): are they intentionally exposed? Warning about tokens sent to contract addresses being irretrievable
+
+4. **Shielded Token Checklist**
+   - `receiveShielded()` called in receiving contract (tokens lost if not called)
+   - Correct coin color used (token type identifier)
+   - `ShieldedCoinInfo` vs `QualifiedShieldedCoinInfo` — correct type for the operation
+   - Change output handled properly after partial spend
+   - `sendImmediateShielded` return value checked for change coins
+   - `Uint<64>` amount for zswap operations (not `Uint<128>`)
+
+5. **Unshielded Token Checklist**
+   - `unshieldedBalance()` not used in conditional logic (creates construction-time balance lock)
+   - Comparison functions used instead (`kernel` comparison circuits)
+   - Proper `disclose()` on amount parameters
+
+6. **Anti-Patterns Table**
+
+| Anti-Pattern | Risk | Correct Pattern |
+|-------------|------|-----------------|
+| `export circuit mint(amount)` with no auth check | Anyone can mint unlimited tokens | Add `assert(caller == authority)` or role check |
+| `balance - amount` without `assert(balance >= amount)` | Underflow wraps to maximum value | Always check balance sufficiency first |
+| Missing `receiveShielded(disclose(coin))` | Shielded tokens sent to contract are permanently lost | Always call `receiveShielded` before processing received coins |
+| `if (unshieldedBalance(...) > 0)` | Locks balance at construction time, not current time | Use dedicated comparison circuits from stdlib |
+| `kernel.mintShielded(pk, amount)` directly | Low-level, bypasses safety checks | Use `mintShielded(pk, amount)` stdlib wrapper |
+
+**Step 2: Commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/token-security-review.md
+git commit -m "feat(compact-core): add token security review checklist reference"
+```
+
+---
+
+### Task 5: Write concurrency-review.md reference
+
+**Files:**
+- Create: `plugins/compact-core/skills/compact-review/references/concurrency-review.md`
+
+**Step 1: Write the reference file**
+
+Content must cover:
+
+1. **Read-Then-Write Contention Checklist**
+   - Counter: `const val = counter.read(); counter = val + 1` → CONTENTION. Use `counter.increment(1)` instead
+   - Map: read-modify-write patterns where two transactions could conflict
+   - General pattern: any exported circuit that reads state and writes a value derived from the read
+
+2. **ADT Contention Properties**
+   - `Counter.increment(n)` — conflict-free (commutative operation)
+   - `Counter.read()` followed by manual set — CAUSES CONTENTION
+   - `Map.insert(key, value)` — conflicts only when same key modified concurrently
+   - `Set.insert(value)` — conflicts only when same value inserted concurrently
+   - `MerkleTree.insert(leaf)` — conflicts when concurrent inserts (root changes)
+   - `List.push(value)` — conflicts when concurrent pushes (ordering)
+
+3. **Design Patterns for Low Contention**
+   - Prefer `Counter.increment()` over read-then-set for counters
+   - Use per-user Map entries rather than a single global value
+   - Design circuits so concurrent users modify different state entries
+   - Use MerkleTree for membership proofs rather than Set when high throughput needed
+
+4. **Red Flags**
+   - Any exported circuit that calls both `.read()` and modifies the same ledger variable
+   - Global state (single variable) updated by every user transaction
+   - Auction/voting patterns where all users write to same field
+
+**Step 2: Commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/concurrency-review.md
+git commit -m "feat(compact-core): add concurrency review checklist reference"
+```
+
+---
+
+### Task 6: Write compilation-review.md reference
+
+**Files:**
+- Create: `plugins/compact-core/skills/compact-review/references/compilation-review.md`
+
+**Step 1: Write the reference file**
+
+Content must cover:
+
+1. **Syntax Error Checklist**
+   - `Void` return type → correct is `[]`
+   - Deprecated `ledger { ... }` block → individual `export ledger` declarations
+   - `Choice::variant` (Rust-style) → `Choice.variant` (dot notation)
+   - `witness name() { ... }` (with body) → `witness name(): Type;` (declaration only)
+   - `pure function` → `pure circuit`
+   - `Cell<T>` → not a valid type, use direct type
+   - `let` or `var` → `const` only
+   - `while` loops → `for` with compile-time bounds only
+   - Missing `import CompactStandardLibrary;`
+   - `include "std"` (deprecated) → `import CompactStandardLibrary;`
+
+2. **Semantic Error Checklist**
+   - Implicit disclosure of witness value (missing `disclose()`)
+   - Recursive circuit calls (not allowed — circuits cannot call themselves)
+   - Mutable reassignment (`x = newValue` where `x` was already bound with `const`)
+   - Return from non-exported circuit containing witness data passed to public boundary
+   - Constructor accessing witnesses (not allowed in constructor)
+
+3. **Type Error Checklist**
+   - `Uint<64>` cast to `Bytes<32>` directly → must go through `Field`: `x as Field as Bytes<32>`
+   - `Boolean` to `Field` directly → must go through `Uint`: `x as Uint<8> as Field`
+   - Relational operators (`<`, `>`, `<=`, `>=`) on `Field` type → not supported, cast to `Uint` first
+   - Mixing `Field` and `Uint` in arithmetic → type error, cast one operand
+   - Arithmetic result type widening: `Uint<8> + Uint<8>` produces `Uint<16>` — may need explicit cast for assignment
+   - Missing generic parameters: `MerkleTree<T>` → `MerkleTree<N, T>` (depth required)
+   - `Counter.value()` → `Counter.read()` (no `.value()` method)
+   - `Map.get(key)` → `Map.lookup(key)` (no `.get()` method)
+   - `Map.has(key)` → `Map.member(key)` (no `.has()` method)
+
+4. **Common Hallucination Traps** (functions that don't exist)
+   - `hash()` → use `persistentHash<T>()` or `transientHash<T>()`
+   - `verify()` → no general verify function
+   - `encrypt()` / `decrypt()` → not available in Compact
+   - `random()` → no randomness source in circuits
+   - `public_key()` → use `publicKey(secretKey, domain)`
+   - `CurvePoint` → use `EllipticCurvePoint`
+   - `CoinInfo` → use `ShieldedCoinInfo` or `QualifiedShieldedCoinInfo`
+
+5. **Compiler Error Quick Reference**
+
+| Error Pattern | Likely Cause | Fix |
+|--------------|--------------|-----|
+| `implicit disclosure of witness value` | Missing `disclose()` at public boundary | Add `disclose()` wrapper |
+| `found "{" looking for ";"` | Void return type or ledger block syntax | Use `[]` return type, individual ledger declarations |
+| `cannot cast from type X to type Y` | Direct cast not supported | Use multi-step cast via `Field` |
+| `operation "value" undefined for Counter` | Wrong method name | Use `.read()` not `.value()` |
+| `recursive circuit call` | Circuit calling itself | Refactor to avoid recursion |
+
+**Step 2: Commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/compilation-review.md
+git commit -m "feat(compact-core): add compilation review checklist reference"
+```
+
+---
+
+### Task 7: Write performance-review.md reference
+
+**Files:**
+- Create: `plugins/compact-core/skills/compact-review/references/performance-review.md`
+
+**Step 1: Write the reference file**
+
+Content must cover:
+
+1. **Proof Generation Cost Checklist**
+   - Every operation in a circuit adds constraints to the ZK proof. More constraints = longer proof generation
+   - Unnecessary arithmetic operations that could be simplified
+   - Redundant computations that compute the same value multiple times (extract to variable)
+   - Complex expressions that could be simplified algebraically
+
+2. **Ledger State Read Efficiency**
+   - Reading the same ledger variable multiple times in one circuit (cache in a `const`)
+   - `Map.member()` + `Map.lookup()` with same key (necessary pattern but note the double read)
+   - Unnecessary ledger reads when the value isn't needed
+
+3. **MerkleTree Depth Sizing**
+   - Depth determines capacity: `2^depth` leaves. Depth 10 = 1024, depth 20 = ~1M, depth 32 = ~4B
+   - Oversized depth wastes proof generation time (deeper proofs are more expensive)
+   - Undersized depth limits future capacity
+   - Rule of thumb: use minimum depth that covers expected maximum entries with 10x margin
+   - `MerkleTree<1, T>` — minimum depth is 2 (depth 1 is invalid)
+
+4. **Loop and Iteration Impact**
+   - `for` loops in Compact are unrolled at compile time — a `for` over 1000 elements generates 1000x the constraints
+   - Large `Vector<N, T>` iterations: N directly multiplies circuit size
+   - Consider whether the operation can be done off-chain in witness code instead
+
+5. **Type Conversion Overhead**
+   - Unnecessary casts add proof constraints (e.g., `x as Field as Uint<64>` when x could have been declared as the target type)
+   - Multi-step casts: `Uint → Field → Bytes` — each step adds constraints
+
+6. **Circuit vs Witness Boundary**
+   - Expensive computations that don't need to be proved should be in witness TypeScript code, not in circuit
+   - Only the verification (assert the result is correct) needs to be in the circuit
+   - Example: sorting — do in witness, verify sorted order in circuit
+
+7. **`pureCircuit` Optimization**
+   - Reusable logic that doesn't touch ledger state should be `pure circuit`
+   - Pure circuits can be called from witnesses and may benefit from compiler optimizations
+
+**Step 2: Commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/performance-review.md
+git commit -m "feat(compact-core): add performance review checklist reference"
+```
+
+---
+
+### Task 8: Write witness-consistency-review.md reference
+
+**Files:**
+- Create: `plugins/compact-core/skills/compact-review/references/witness-consistency-review.md`
+
+**Step 1: Write the reference file**
+
+Content must cover:
+
+1. **Name Matching Checklist**
+   - Every `witness` declaration in Compact MUST have a matching key in the TypeScript `witnesses` object
+   - Names must match exactly (case-sensitive)
+   - Missing witness implementation causes runtime failure
+
+2. **Type Mapping Correctness**
+
+| Compact Type | TypeScript Type | Common Mistake |
+|-------------|----------------|----------------|
+| `Field` | `bigint` | Using `number` (loses precision) |
+| `Boolean` | `boolean` | Correct |
+| `Uint<N>` | `bigint` | Using `number` |
+| `Bytes<N>` | `Uint8Array` | Using `string` or `Buffer` |
+| `Opaque<"string">` | `string` | Correct |
+| `Opaque<"Uint8Array">` | `Uint8Array` | Correct |
+| `Maybe<T>` | `{ is_some: boolean; value: T }` | Using `T \| null` or `T \| undefined` (WRONG — must use tagged object) |
+| `Either<L, R>` | `{ tag: "left"; value: L } \| { tag: "right"; value: R }` | Using `L \| R` union (WRONG — must use tagged discriminated union) |
+| `Vector<N, T>` | `T[]` (length N) | Not checking array length matches N |
+| Struct `{ x: Field; y: Boolean }` | `{ x: bigint; y: boolean }` | Field names must match exactly |
+| Enum | `bigint` variant index | Mapping variants to wrong indices |
+| `[T1, T2]` (tuple) | `[T1_mapped, T2_mapped]` | Wrong element order |
+
+3. **WitnessContext Pattern**
+   - Every witness function takes `WitnessContext<Ledger, PrivateState>` as first parameter
+   - `context.privateState` — current private state
+   - `context.contractAddress` — deployed contract address
+   - `context.originalState` — ledger state at circuit start
+   - Return type is ALWAYS `[PrivateState, ReturnValue]` tuple — NOT just the return value
+
+4. **Private State Immutability**
+   - Private state must be updated by returning a NEW object, not mutating in place
+   - Correct: `return [{ ...privateState, counter: privateState.counter + 1 }, result]`
+   - Wrong: `privateState.counter += 1; return [privateState, result]`
+   - Spread operator (`...`) for shallow copies; deep clone for nested objects
+
+5. **Witness Implementation Correctness**
+   - Witness should not have side effects beyond private state updates
+   - Witness should be deterministic for the same inputs (to allow proof re-generation)
+   - Long-running or async operations in witnesses can timeout proof generation
+
+**Step 2: Commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/witness-consistency-review.md
+git commit -m "feat(compact-core): add witness consistency review checklist reference"
+```
+
+---
+
+### Task 9: Write architecture-review.md reference
+
+**Files:**
+- Create: `plugins/compact-core/skills/compact-review/references/architecture-review.md`
+
+**Step 1: Write the reference file**
+
+Content must cover:
+
+1. **ADT Selection Decision Tree**
+
+| Need | Best ADT | Why Not Others |
+|------|---------|----------------|
+| Counting occurrences | `Counter` | Conflict-free increments; `Field` would need read-modify-write |
+| Key-value store (public keys) | `Map<K, V>` | Direct lookup; Set can't store values |
+| Unique membership (public) | `Set<T>` | Built-in member check; Map wastes value slot |
+| Anonymous membership (private) | `MerkleTree<N, T>` | Only insert hides leaf; Set reveals members |
+| Anonymous + historic proofs | `HistoricMerkleTree<N, T>` | Root doesn't change on insert; regular MerkleTree invalidates existing proofs |
+| Ordered history | `List<T>` | Preserves insertion order; Set is unordered |
+| Single value | Direct `ledger var: T` | Simplest; no ADT overhead |
+
+2. **MerkleTree Depth Planning**
+
+| Expected Entries | Minimum Depth | Recommended Depth | Notes |
+|-----------------|---------------|-------------------|-------|
+| < 100 | 7 | 10 | Small application |
+| < 10,000 | 14 | 16 | Medium application |
+| < 1,000,000 | 20 | 22 | Large application |
+| < 1B | 30 | 32 | Maximum practical size |
+
+Note: depth 1 is invalid. Minimum is 2.
+
+3. **Visibility Checklist**
+   - `export ledger` — readable by anyone, queryable
+   - `sealed ledger` — set only in constructor, immutable after deployment
+   - `ledger` (no modifier) — internal, not directly queryable but state changes visible on-chain
+   - Every ledger variable: should this be `export` or internal? Does the DApp need to query it?
+   - Sealed for configuration values set at deployment (owner address, token name)
+
+4. **Contract Decomposition**
+   - Is the contract trying to do too much? Consider splitting into modules
+   - Module system: `module Name { ... }` with `import { circuit } from Module`
+   - Shared types should be defined at the top level or in a shared module
+   - Re-export pattern for public interface: `export { func } from InternalModule`
+
+5. **Circuit vs Witness Boundary**
+   - Circuit: on-chain verification logic, state updates, assertions
+   - Witness: off-chain computation, private data access, complex algorithms
+   - Rule: put minimum logic in circuit, maximum in witness. Circuit only verifies what witness computed.
+   - Constructor: initialization only, no witness access allowed
+
+6. **State Initialization**
+   - All ledger variables must have deterministic initial values
+   - Constructor must initialize all non-ADT ledger variables
+   - ADTs (Counter, Map, Set, etc.) auto-initialize to empty
+   - Field/Uint/Bytes/Boolean: must be explicitly set or use `default<T>`
+
+**Step 2: Commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/architecture-review.md
+git commit -m "feat(compact-core): add architecture review checklist reference"
+```
+
+---
+
+### Task 10: Write code-quality-review.md reference
+
+**Files:**
+- Create: `plugins/compact-core/skills/compact-review/references/code-quality-review.md`
+
+**Step 1: Write the reference file**
+
+Content must cover:
+
+1. **Naming Conventions**
+   - Circuits: camelCase (`transferTokens`, `checkBalance`)
+   - Ledger variables: camelCase or snake_case (project-consistent)
+   - Types/Structs/Enums: PascalCase (`TokenInfo`, `GameState`)
+   - Enum variants: PascalCase or UPPER_SNAKE_CASE (project-consistent)
+   - Witnesses: camelCase, often prefixed with purpose (`localSecretKey`, `contextPathOf`)
+   - Modules: PascalCase
+
+2. **Circuit Complexity**
+   - Single responsibility: one circuit should do one thing
+   - Extract reusable logic into helper circuits or pure circuits
+   - Long circuits (> 50 lines) should be reviewed for decomposition
+   - Deeply nested control flow is a red flag
+
+3. **Dead Code Detection**
+   - Unused ledger variables (declared but never read/written)
+   - Unused circuits (defined but never called)
+   - Unreachable code after unconditional `assert(false)` or early returns
+   - Commented-out code left in production
+
+4. **Standard Library Usage (Hallucination Guard)**
+   - Verify every stdlib call exists in `CompactStandardLibrary`
+   - Common hallucinations to check for:
+     - `hash()` → does not exist. Use `persistentHash<T>()` or `transientHash<T>()`
+     - `verify()` → does not exist
+     - `encrypt()` / `decrypt()` → does not exist
+     - `random()` → does not exist
+     - `counter.value()` → use `counter.read()`
+     - `map.get()` → use `map.lookup()`
+     - `map.has()` → use `map.member()`
+     - `CoinInfo` → use `ShieldedCoinInfo`
+     - `CurvePoint` → use `EllipticCurvePoint`
+
+5. **Compact Idioms**
+   - Guard-then-act: `assert` first, modify state second
+   - Prefer `default<T>` over zero-construction for initial values
+   - Use `pad(N, "string")` for fixed-width byte padding
+   - Destructuring: `const [a, b] = slice<N>(vector, offset)`
+   - Type-safe enum comparison: `state == State.active` not magic numbers
+
+6. **Code Duplication**
+   - Same logic repeated in multiple circuits → extract to helper circuit
+   - Same validation repeated → extract to validation circuit
+   - Similar struct construction → consider a constructor circuit
+
+**Step 2: Commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/code-quality-review.md
+git commit -m "feat(compact-core): add code quality review checklist reference"
+```
+
+---
+
+### Task 11: Write testing-review.md reference
+
+**Files:**
+- Create: `plugins/compact-core/skills/compact-review/references/testing-review.md`
+
+**Step 1: Write the reference file**
+
+Content must cover:
+
+1. **Test Coverage Checklist**
+   - Every exported circuit has at least one test
+   - Constructor tested with expected initial state
+   - Happy path tested for each circuit
+   - Error/revert cases tested (assert failures)
+
+2. **Edge Case Checklist**
+   - Zero values: amount=0, empty strings, zero address
+   - Maximum values: max Uint<64>, max Uint<128>, MAX_UINT128
+   - Boundary values: exactly at limit, one above, one below
+   - Empty collections: empty Map lookup, empty List head
+   - Double operations: calling same circuit twice, double-spend attempt
+
+3. **Negative Testing**
+   - Unauthorized access: calling admin circuits without auth
+   - Invalid state transitions: calling reveal before commit
+   - Insufficient balance: transfer more than available
+   - Already-used nullifiers: replay attack attempt
+   - Wrong type/format inputs
+
+4. **Private State Testing**
+   - Private state correctly initialized
+   - Private state correctly updated after each circuit call
+   - Private state immutability: verify spread operator creates new object
+   - Private state persistence: state carries between circuit calls
+
+5. **Witness Mock Correctness**
+   - Witness mocks return `[PrivateState, ReturnValue]` tuple (not just ReturnValue)
+   - Witness mocks handle `WitnessContext` correctly
+   - Mock type mappings match Compact-to-TypeScript type table
+   - `Maybe<T>` mocked as `{ is_some: boolean; value: T }` not null/undefined
+   - `Either<L, R>` mocked with tagged union
+
+6. **Integration Test Patterns**
+   - Multi-step flows tested end-to-end (commit → reveal, mint → transfer → burn)
+   - Concurrent user scenarios (two users acting on same contract)
+   - State consistency after multiple operations
+
+**Step 2: Commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/testing-review.md
+git commit -m "feat(compact-core): add testing review checklist reference"
+```
+
+---
+
+### Task 12: Write documentation-review.md reference
+
+**Files:**
+- Create: `plugins/compact-core/skills/compact-review/references/documentation-review.md`
+
+**Step 1: Write the reference file**
+
+Content must cover:
+
+1. **Contract-Level Documentation**
+   - Purpose of the contract clearly stated
+   - Overall architecture/design explained
+   - Deployment requirements (constructor parameters, initial state)
+   - Dependencies (imported modules, external contracts)
+
+2. **Circuit Documentation**
+   - Every exported circuit should have a comment explaining:
+     - Purpose: what does this circuit do?
+     - Parameters: what each parameter means
+     - Return value: what is returned and its meaning
+     - Side effects: what ledger state is modified?
+     - Access control: who can call this?
+     - Requirements: what assertions must hold?
+   - Complex internal circuits should also be documented
+
+3. **Ledger State Documentation**
+   - Every ledger variable should have a comment explaining its purpose
+   - Visibility rationale: why export vs sealed vs internal?
+   - State invariants: what constraints must always hold?
+   - Relationship between ledger variables (e.g., "this counter tracks the number of entries in that Map")
+
+4. **Witness Documentation**
+   - What data each witness provides
+   - Expected behavior and return type
+   - Private state requirements
+   - Any preconditions or side effects
+
+5. **Privacy Documentation**
+   - Which data is private and why
+   - Which data is disclosed and why
+   - Privacy guarantees the contract provides
+   - Privacy limitations or caveats
+
+**Step 2: Commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/documentation-review.md
+git commit -m "feat(compact-core): add documentation review checklist reference"
+```
+
+---
+
+### Task 13: Create the reviewer agent
+
+**Files:**
+- Create: `plugins/compact-core/agents/reviewer.md`
+
+**Step 1: Write the agent file**
+
+The agent file consists of YAML frontmatter + system prompt body. Write the complete file:
+
+```markdown
+---
+name: reviewer
+description: "Use this agent when you need a focused review of Compact smart contract code in a specific category. Dispatched by the review-compact command with a category assignment. Not intended for direct user invocation.\n\n<example>\nContext: Dispatched by review-compact command for privacy review\nassistant: \"Launching reviewer agent for Privacy & Disclosure category\"\n<commentary>\nThe review-compact command spawns this agent with a specific category and file list. The agent loads the compact-review skill reference for its category.\n</commentary>\n</example>\n\n<example>\nContext: Dispatched for security review of token contract\nassistant: \"Launching reviewer agent for Token & Economic Security category\"\n<commentary>\nSame agent, different category assignment. Loads token-security-review.md reference.\n</commentary>\n</example>"
+skills: compact-core:compact-structure, compact-core:compact-ledger, compact-core:compact-privacy-disclosure, compact-core:compact-tokens, compact-core:compact-language-ref, compact-core:compact-standard-library, compact-core:compact-witness-ts, compact-core:compact-review, devs:code-review, devs:typescript-core, devs:security-core
+model: sonnet
+color: blue
+---
+
+You are a Midnight Compact smart contract security reviewer specializing in zero-knowledge proof systems and privacy-preserving smart contracts. You have deep expertise in the Compact language, its type system, the ZK proof compilation pipeline, and the Midnight blockchain architecture.
+
+## Your Assignment
+
+You will receive:
+1. A **review category** name (e.g., "Privacy & Disclosure", "Security & Cryptographic Correctness")
+2. A **list of files** to review (.compact contracts, TypeScript witnesses, test files)
+
+## Review Process
+
+1. **Load your checklist**: Invoke the `compact-core:compact-review` skill. Read the reference file that corresponds to your assigned category from the Category Reference Map in the SKILL.md.
+
+2. **Read all files**: Read every file in your assignment list completely.
+
+3. **Apply the checklist systematically**: Go through EVERY item in your category's checklist. For each item:
+   - Search the code for the pattern or anti-pattern
+   - If found, create a finding with the correct severity
+   - If the code correctly avoids the issue, note it in positive highlights
+
+4. **Classify each finding** using these severity levels:
+   - **Critical**: Will cause loss of funds, data breach, or contract exploitation
+   - **High**: Security vulnerability or privacy leak exploitable under certain conditions
+   - **Medium**: Correctness issue, compilation problem, or significant performance concern
+   - **Low**: Code quality, style, or minor best practice deviation
+   - **Suggestion**: Enhancement opportunity, not a problem
+
+5. **Format your output** as structured markdown:
+
+```
+## [Category Name] Review
+
+### Critical
+- **[Issue title]** (`file:line`)
+  - **Problem:** Clear description of what is wrong
+  - **Impact:** Why this matters
+  - **Fix:** Suggested fix with code example
+
+### High
+[same format]
+
+### Medium
+[same format]
+
+### Low
+[same format]
+
+### Suggestions
+[same format]
+
+### Positive Highlights
+- [What was done well in this category]
+```
+
+If a severity level has no findings, omit that section entirely.
+
+## Review Principles
+
+- **Be constructive**: Every finding must include a concrete, actionable fix
+- **Be specific**: Always reference exact file and line numbers
+- **Show code**: Include code examples for suggested fixes when the fix isn't obvious
+- **Explain impact**: Don't just say what's wrong — explain why it matters
+- **Acknowledge good work**: Call out correct patterns and well-designed code
+- **Stay focused**: Only report findings relevant to your assigned category
+- **Be thorough**: Check every item in your checklist, don't skip any
+- **No false positives**: Only report issues you are confident about. If uncertain, flag as a question rather than a finding
+```
+
+**Step 2: Commit**
+
+```bash
+git add plugins/compact-core/agents/reviewer.md
+git commit -m "feat(compact-core): add reviewer agent for compact code review"
+```
+
+---
+
+### Task 14: Create the review-compact command
+
+**Files:**
+- Create: `plugins/compact-core/commands/review-compact.md`
+
+**Step 1: Write the command file**
+
+```markdown
+---
+description: Comprehensive review of Compact smart contract code covering 11 categories including privacy, security, tokens, concurrency, performance, and more. Supports parallel execution via agent teams (when enabled) or concurrent subagents.
+allowed-tools: Bash, Agent, Read, Glob, Grep, TaskCreate, TaskUpdate, TaskList, AskUserQuestion
+argument-hint: [path/to/contract.compact or directory]
+---
+
+Review Compact smart contract code across 11 review categories using parallel reviewer agents. Privacy findings are always shown first.
+
+## Review Categories
+
+1. Privacy & Disclosure
+2. Security & Cryptographic Correctness
+3. Token & Economic Security
+4. Concurrency & Contention
+5. Compilation & Type Safety
+6. Performance & Circuit Efficiency
+7. Witness-Contract Consistency
+8. Architecture, State Design & Composability
+9. Code Quality & Best Practices
+10. Testing Adequacy
+11. Documentation
+
+## Step 1: Identify Files to Review
+
+If `$ARGUMENTS` provides a path, use it. Otherwise, find all relevant files:
+
+```bash
+# Find all Compact and related files
+find . -name "*.compact" -not -path "*/node_modules/*" -not -path "*/.compact/*"
+find . -name "*.ts" -not -path "*/node_modules/*" -not -path "*/.compact/*" | grep -iE "(witness|private)" || true
+find . -name "*.test.ts" -o -name "*.spec.ts" -not -path "*/node_modules/*" | head -20
+```
+
+Collect the file list and present it to the user for confirmation.
+
+## Step 2: Check for Agent Teams
+
+Run this command to detect agent team support:
+
+```bash
+echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-not_set}"
+```
+
+## Step 3a: Agent Teams Mode
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is set (not "not_set"):
+
+Create an agent team to perform the review. Tell Claude:
+
+> Create an agent team to review Compact code across 11 categories. Spawn 11 reviewer teammates, one per category. Each teammate should:
+>
+> 1. Invoke the `compact-core:compact-review` skill
+> 2. Read their assigned reference file from the Category Reference Map
+> 3. Read all files: [INSERT FILE LIST]
+> 4. Apply every checklist item from their reference
+> 5. Report findings in the structured format with severity levels
+>
+> Teammate assignments:
+> - Teammate 1 — "Privacy & Disclosure" → read `privacy-review` reference
+> - Teammate 2 — "Security & Cryptographic Correctness" → read `security-review` reference
+> - Teammate 3 — "Token & Economic Security" → read `token-security-review` reference
+> - Teammate 4 — "Concurrency & Contention" → read `concurrency-review` reference
+> - Teammate 5 — "Compilation & Type Safety" → read `compilation-review` reference
+> - Teammate 6 — "Performance & Circuit Efficiency" → read `performance-review` reference
+> - Teammate 7 — "Witness-Contract Consistency" → read `witness-consistency-review` reference
+> - Teammate 8 — "Architecture, State Design & Composability" → read `architecture-review` reference
+> - Teammate 9 — "Code Quality & Best Practices" → read `code-quality-review` reference
+> - Teammate 10 — "Testing Adequacy" → read `testing-review` reference
+> - Teammate 11 — "Documentation" → read `documentation-review` reference
+>
+> Use sonnet model for each teammate.
+> Wait for ALL teammates to complete before synthesizing the consolidated report.
+
+Proceed to Step 4 when all teammates finish.
+
+## Step 3b: Subagent Mode (concurrent)
+
+If agent teams are NOT available:
+
+You MUST launch ALL 11 reviewer agents in a **SINGLE message** using 11 Agent tool calls. This ensures they run concurrently. Do NOT call them sequentially — that defeats the purpose of parallelization.
+
+In ONE message, make ALL of these Agent tool calls simultaneously:
+
+**Agent call 1:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review privacy & disclosure"
+prompt: "You are reviewing category: Privacy & Disclosure.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the privacy-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
+```
+
+**Agent call 2:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review security & crypto"
+prompt: "You are reviewing category: Security & Cryptographic Correctness.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the security-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
+```
+
+**Agent call 3:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review token & economic security"
+prompt: "You are reviewing category: Token & Economic Security.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the token-security-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**Agent call 4:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review concurrency & contention"
+prompt: "You are reviewing category: Concurrency & Contention.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the concurrency-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**Agent call 5:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review compilation & types"
+prompt: "You are reviewing category: Compilation & Type Safety.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the compilation-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**Agent call 6:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review performance & efficiency"
+prompt: "You are reviewing category: Performance & Circuit Efficiency.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the performance-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**Agent call 7:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review witness consistency"
+prompt: "You are reviewing category: Witness-Contract Consistency.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the witness-consistency-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**Agent call 8:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review architecture & state"
+prompt: "You are reviewing category: Architecture, State Design & Composability.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the architecture-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**Agent call 9:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review code quality"
+prompt: "You are reviewing category: Code Quality & Best Practices.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the code-quality-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**Agent call 10:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review testing adequacy"
+prompt: "You are reviewing category: Testing Adequacy.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the testing-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**Agent call 11:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review documentation"
+prompt: "You are reviewing category: Documentation.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the documentation-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**CRITICAL: All 11 Agent tool calls MUST be in a single message to ensure concurrent execution.**
+
+## Step 4: Consolidated Report
+
+After ALL reviewers complete, produce the consolidated report.
+
+**Ordering rules:**
+1. **Privacy & Disclosure is ALWAYS the first category** — regardless of severity
+2. Remaining categories ordered by highest severity found (Critical > High > Medium > Low > Suggestions)
+3. Within each category: Critical → High → Medium → Low → Suggestions
+4. Deduplicate issues found by multiple reviewers (keep the most detailed version)
+5. Aggregate all Positive Highlights at the end
+
+**Report format:**
+
+```
+# Compact Code Review Report
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | N |
+| High | N |
+| Medium | N |
+| Low | N |
+| Suggestions | N |
+
+**Files reviewed:** [list]
+
+---
+
+## 1. Privacy & Disclosure
+
+[Privacy findings — ALWAYS FIRST]
+
+---
+
+## 2. [Next category by severity]
+
+[Findings]
+
+---
+
+[... remaining categories ...]
+
+---
+
+## Positive Highlights
+
+[Aggregated from all reviewers — what was done well]
+```
+
+Present the report to the user.
+```
+
+**Step 2: Commit**
+
+```bash
+git add plugins/compact-core/commands/review-compact.md
+git commit -m "feat(compact-core): add review-compact orchestration command"
+```
+
+---
+
+### Task 15: Update plugin.json with new keywords
+
+**Files:**
+- Modify: `plugins/compact-core/.claude-plugin/plugin.json`
+
+**Step 1: Add keywords**
+
+Add these keywords to the existing `keywords` array in plugin.json:
+- `"code-review"`
+- `"security-review"`
+- `"privacy-review"`
+- `"compact-review"`
+- `"review"`
+
+**Step 2: Commit**
+
+```bash
+git add plugins/compact-core/.claude-plugin/plugin.json
+git commit -m "feat(compact-core): add review keywords to plugin.json"
+```
+
+---
+
+### Task 16: Validate plugin structure
+
+**Step 1: Run plugin validation**
+
+Use the `plugin-dev:plugin-validator` agent to validate the plugin structure:
+
+> Validate the plugin at plugins/compact-core/. Check that:
+> 1. plugin.json is valid
+> 2. All skills have valid SKILL.md files
+> 3. All agents have valid frontmatter
+> 4. All commands have valid frontmatter
+> 5. All skill references in agents exist
+
+**Step 2: Fix any issues found**
+
+If the validator finds issues, fix them and commit.

--- a/docs/plans/2026-03-02-mcp-review-integration-design.md
+++ b/docs/plans/2026-03-02-mcp-review-integration-design.md
@@ -1,0 +1,133 @@
+# MCP Tool Integration for Compact Code Review
+
+**Date:** 2026-03-02
+**Status:** Approved
+**Scope:** Augment the compact-review skill's 11 reviewer categories with Midnight MCP server tools
+
+## Problem
+
+The compact-review system is entirely LLM-driven. 11 reviewer agents each load a static checklist, read code, and apply judgment. None use the Midnight MCP server's analysis tools (compilation, structural analysis, syntax validation, semantic search). This means:
+
+- Compilation issues are caught by pattern-matching, not actual compilation
+- Structural problems are identified by eyeballing, not machine analysis
+- Syntax correctness is checked against memorized rules, not the authoritative syntax reference
+- No cross-reference with official docs or reference implementations
+
+## Solution
+
+Augment the existing checklist-driven review with MCP tool evidence using an "advisory + required" approach:
+
+1. **Shared pre-pass** in the orchestrating command runs 4 MCP tools once and injects outputs into all reviewer prompts
+2. **Per-category required tools** listed in each reference file for category-specific analysis
+3. **Inline tool hints** on checklist items where MCP tools can verify findings
+
+## Architecture
+
+### Two-Phase Tool Integration
+
+```
+Phase 1: Orchestrator Pre-Pass (review-compact command)
+  ├── midnight-compile-contract (skipZk=true)
+  ├── midnight-extract-contract-structure
+  ├── midnight-analyze-contract
+  └── midnight-get-latest-syntax
+  → Outputs injected into all 11 reviewer prompts
+
+Phase 2: Reviewer Execution (per-category)
+  ├── Reference shared evidence from prompt
+  ├── Run category-specific required tools (if any)
+  ├── Apply checklist with inline tool hints (advisory)
+  └── Report findings with tool-backed evidence
+```
+
+### Tool-to-Category Mapping
+
+All categories receive shared evidence from the pre-pass. Additional category-specific tools:
+
+| Category | Required (category-specific) | Advisory Hints |
+|----------|------------------------------|----------------|
+| Privacy & Disclosure | — | explain-circuit, search-docs |
+| Security & Cryptographic Correctness | — | search-compact, search-docs |
+| Token & Economic Security | — | search-compact, list-examples |
+| Concurrency & Contention | — | search-docs |
+| Compilation & Type Safety | — | search-compact |
+| Performance & Circuit Efficiency | compile-contract (fullCompile=true) | explain-circuit, search-docs |
+| Witness-Contract Consistency | — | search-compact, search-docs |
+| Architecture, State Design | — | list-examples, search-compact |
+| Code Quality & Best Practices | — | search-compact, list-examples |
+| Testing Adequacy | — | list-examples, search-docs |
+| Documentation | — | search-docs |
+
+### Reference File Format
+
+Each reference file gets three additions:
+
+**1. Required MCP Tools section** (after intro, before first checklist):
+
+```markdown
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation errors and warnings |
+| `midnight-extract-contract-structure` | `[shared]` | Deprecated syntax, structural issues |
+| `midnight-analyze-contract` | `[shared]` | Static pattern analysis |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative syntax reference |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+Tools marked `[category-specific]` must be run by you during your review.
+```
+
+**2. Inline tool hints** on applicable checklist items:
+
+```markdown
+- [ ] **Checklist item title**
+  [existing description unchanged]
+
+  > **Tool:** `midnight-compile-contract` output will show `error message` if present.
+```
+
+**3. Tool Reference footer:**
+
+```markdown
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract; skipZk=true for syntax, fullCompile=true for ZK |
+| `midnight-extract-contract-structure` | Deep structural analysis: deprecated syntax, missing disclose(), etc. |
+| ... | ... |
+```
+
+## File Changes
+
+### Modified Files (13 total)
+
+1. **`commands/review-compact.md`** — Add Step 2.5 (shared MCP pre-pass), update reviewer prompt templates
+2. **`agents/reviewer.md`** — Add MCP tool awareness, evidence reference step, advisory hint guidance
+3. **`references/privacy-review.md`** — Required MCP Tools section, inline hints, footer
+4. **`references/security-review.md`** — Required MCP Tools section, inline hints, footer
+5. **`references/token-security-review.md`** — Required MCP Tools section, inline hints, footer
+6. **`references/concurrency-review.md`** — Required MCP Tools section, inline hints, footer
+7. **`references/compilation-review.md`** — Required MCP Tools section, inline hints, footer
+8. **`references/performance-review.md`** — Required MCP Tools section, inline hints, category-specific tool, footer
+9. **`references/witness-consistency-review.md`** — Required MCP Tools section, inline hints, footer
+10. **`references/architecture-review.md`** — Required MCP Tools section, inline hints, footer
+11. **`references/code-quality-review.md`** — Required MCP Tools section, inline hints, footer
+12. **`references/testing-review.md`** — Required MCP Tools section, inline hints, footer
+13. **`references/documentation-review.md`** — Required MCP Tools section, inline hints, footer
+
+### Unchanged Files
+
+- `SKILL.md` — category map, severity classification, output format stay as-is
+- `plugin.json` — no structural changes needed
+
+## Design Decisions
+
+1. **Augment, don't replace** — LLM checklist review remains the core; MCP tools provide evidence
+2. **Shared pre-pass** — 4 common tools run once by orchestrator instead of 11x by each reviewer
+3. **Per-category references** — Tool guidance lives in each reference file, not centrally
+4. **Advisory + required** — Required tools must run; advisory hints are contextual suggestions
+5. **`[shared]` vs `[category-specific]` labels** — Reviewers know which tools are pre-computed vs need to run

--- a/docs/plans/2026-03-02-mcp-review-integration-plan.md
+++ b/docs/plans/2026-03-02-mcp-review-integration-plan.md
@@ -1,0 +1,1007 @@
+# MCP Review Integration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Augment the compact-review skill's 11 review categories with Midnight MCP server tools so reviewers have machine-verified evidence alongside their checklist-driven review.
+
+**Architecture:** The orchestrating command (`review-compact.md`) runs 4 shared MCP tools once as a pre-pass, injecting outputs into all 11 reviewer prompts. Each reference file gets a Required MCP Tools section, inline tool hints on applicable checklist items, and a Tool Reference footer. The reviewer agent (`reviewer.md`) gets updated with MCP tool awareness.
+
+**Tech Stack:** Markdown files (Claude Code plugin format), Midnight MCP server tools
+
+---
+
+### Task 1: Update the reviewer agent with MCP tool awareness
+
+**Files:**
+- Modify: `plugins/compact-core/agents/reviewer.md`
+
+**Step 1: Edit reviewer.md to add MCP tool step to Review Process**
+
+Insert a new step 1.5 between "Load your checklist" (step 1) and "Read all files" (step 2). Also update the subsequent step about applying the checklist to reference tool evidence. Add a new review principle about tool-backed evidence.
+
+Replace the current Review Process section (lines 18-27) with:
+
+```markdown
+## Review Process
+
+1. **Load your checklist**: Invoke the `compact-core:compact-review` skill. Read the reference file that corresponds to your assigned category from the Category Reference Map in the SKILL.md.
+
+2. **Reference shared MCP evidence**: Your prompt includes pre-computed outputs from shared MCP tools (compilation result, structural analysis, contract analysis, and latest syntax reference). Read these outputs — they are your baseline evidence for evaluating checklist items.
+
+3. **Run category-specific MCP tools**: Check your reference file's "Required MCP Tools" section. Any tools marked `[category-specific]` must be run by you now against the contract under review. Tools marked `[shared]` are already provided in your prompt.
+
+4. **Read all files**: Read every file in your assignment list completely.
+
+5. **Apply the checklist systematically**: Go through EVERY item in your category's checklist. For each item:
+   - Search the code for the pattern or anti-pattern
+   - Cross-reference against the shared MCP tool evidence where applicable
+   - When a checklist item has a `> **Tool:**` hint, consider calling that tool for additional verification
+   - If found, create a finding with the correct severity
+   - If the code correctly avoids the issue, note it in positive highlights
+```
+
+Also add to the Review Principles section (after line 73):
+
+```markdown
+- **Use tool evidence**: When MCP tool output confirms or contradicts a finding, cite it. Tool-backed findings are stronger than judgment alone. If a tool identifies an issue that matches your checklist, include the tool's output as evidence.
+```
+
+**Step 2: Verify the edit is correct**
+
+Read `plugins/compact-core/agents/reviewer.md` and verify the new steps are properly numbered 1-5 and the new review principle is present.
+
+**Step 3: Commit**
+
+```bash
+git add plugins/compact-core/agents/reviewer.md
+git commit -m "feat(compact-core): add MCP tool awareness to reviewer agent"
+```
+
+---
+
+### Task 2: Add shared MCP pre-pass to review-compact command
+
+**Files:**
+- Modify: `plugins/compact-core/commands/review-compact.md`
+
+**Step 1: Add allowed MCP tools to command frontmatter**
+
+Update the `allowed-tools` line (line 3) to include the ToolSearch tool so the command can discover and call MCP tools:
+
+```yaml
+allowed-tools: Bash, Agent, Read, Glob, Grep, TaskCreate, TaskUpdate, TaskList, AskUserQuestion, ToolSearch
+```
+
+**Step 2: Insert new Step 1.5 for shared MCP tool pre-pass**
+
+After Step 1 (Identify Files to Review, ending at line 34) and before Step 2 (Check for Agent Teams, line 36), insert a new step:
+
+```markdown
+## Step 1.5: Run Shared MCP Tools
+
+After identifying the files, run these 4 MCP tools against the primary `.compact` contract file. These outputs will be passed to all 11 reviewer agents as shared evidence.
+
+Use the ToolSearch tool to load the Midnight MCP tools, then call each one:
+
+1. **Compile the contract** (syntax validation):
+   Call `midnight-compile-contract` with the contract source and `skipZk=true`. Save the output as `COMPILE_RESULT`.
+
+2. **Extract contract structure** (structural analysis):
+   Call `midnight-extract-contract-structure` with the contract source. Save the output as `STRUCTURE_RESULT`.
+
+3. **Analyze the contract** (static pattern analysis):
+   Call `midnight-analyze-contract` with the contract source. Save the output as `ANALYSIS_RESULT`.
+
+4. **Get latest syntax reference**:
+   Call `midnight-get-latest-syntax`. Save the output as `SYNTAX_REFERENCE`.
+
+If any tool call fails (e.g., MCP server unavailable), note the failure and proceed — the review can still run with partial or no tool evidence. Do not block the review on tool failures.
+
+Store all four outputs for injection into reviewer prompts in the next steps.
+```
+
+**Step 3: Update Agent Teams mode prompt template (Step 3a)**
+
+In the Agent Teams section (around line 50), update the teammate instructions to include shared evidence. Replace step 3 in the teammate instructions:
+
+```markdown
+> 3. Reference the shared MCP tool evidence provided below
+> 4. Read all files: [INSERT FILE LIST]
+```
+
+And add at the end of the agent team block (before "Use sonnet model"):
+
+```markdown
+>
+> **Shared MCP Tool Evidence:**
+> - Compilation result: [INSERT COMPILE_RESULT]
+> - Structural analysis: [INSERT STRUCTURE_RESULT]
+> - Contract analysis: [INSERT ANALYSIS_RESULT]
+> - Latest syntax reference: [INSERT SYNTAX_REFERENCE]
+```
+
+**Step 4: Update Subagent mode prompt templates (Step 3b)**
+
+Update each of the 11 Agent call prompts in the subagent section to include shared MCP evidence. For each agent call, append to the prompt string:
+
+```
+\n\nShared MCP Tool Evidence (pre-computed by orchestrator — reference when evaluating checklist items):\n- Compilation result: [INSERT COMPILE_RESULT]\n- Structural analysis: [INSERT STRUCTURE_RESULT]\n- Contract analysis: [INSERT ANALYSIS_RESULT]\n- Latest syntax reference: [INSERT SYNTAX_REFERENCE]
+```
+
+This must be added to all 11 agent call prompts (calls 1-11).
+
+**Step 5: Verify the edits**
+
+Read `plugins/compact-core/commands/review-compact.md` and verify:
+- Step 1.5 exists between Step 1 and Step 2
+- ToolSearch is in allowed-tools
+- Both Agent Teams and Subagent prompts include shared evidence injection
+- The original Step 4 (Consolidated Report) is unchanged
+
+**Step 6: Commit**
+
+```bash
+git add plugins/compact-core/commands/review-compact.md
+git commit -m "feat(compact-core): add shared MCP tool pre-pass to review-compact command"
+```
+
+---
+
+### Task 3: Add MCP tools to privacy-review.md
+
+**Files:**
+- Modify: `plugins/compact-core/skills/compact-review/references/privacy-review.md`
+
+**Step 1: Insert Required MCP Tools section**
+
+After the intro paragraph (line 3, ending "Apply every item below to the contract under review.") and before the first checklist section ("## Unnecessary Disclosure Checklist" at line 5), insert:
+
+```markdown
+
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation errors from incorrect `disclose()` usage |
+| `midnight-extract-contract-structure` | `[shared]` | Detects missing `disclose()` calls, structural disclosure issues |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of privacy patterns |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for `disclose()` semantics |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
+```
+
+**Step 2: Add inline tool hints to applicable checklist items**
+
+Add `> **Tool:**` hints after the following checklist items (insert after the item's description/code block, before the next checklist item):
+
+1. After the first checklist item "Every `disclose()` call: is it actually needed?" (after line 9's description):
+   ```
+   > **Tool:** `midnight-extract-contract-structure` lists all `disclose()` call sites. Cross-reference each one against necessity.
+   ```
+
+2. After "`disclose()` placed at witness call site instead of near the public boundary" (after the code block ending around line 23):
+   ```
+   > **Tool:** `midnight-extract-contract-structure` flags early-disclosure patterns. Check its output for disclosure placement warnings.
+   ```
+
+3. After "Witness-derived values written to public ledger without `disclose()`" (after the description around line 43):
+   ```
+   > **Tool:** `midnight-compile-contract` output shows `implicit disclosure of witness value` errors for these cases.
+   ```
+
+4. After "Conditional branches revealing private information" (after the code block around line 55):
+   ```
+   > **Tool:** Consider calling `midnight-explain-circuit` on circuits that use `disclose()` inside conditionals to understand the full privacy implications.
+   ```
+
+5. After "Using `Set<Bytes<32>>` for membership that should be private" (after the code block around line 92):
+   ```
+   > **Tool:** `midnight-extract-contract-structure` shows all data structure declarations. Look for `Set` types used in membership contexts.
+   ```
+
+6. After "`persistentHash` used where `persistentCommit` is needed" (after the code block around line 126):
+   ```
+   > **Tool:** `midnight-extract-contract-structure` flags `persistentHash` vs `persistentCommit` usage. Check for misuse patterns.
+   ```
+
+7. After "Transient vs persistent confusion" (after the code block around line 136):
+   ```
+   > **Tool:** `midnight-search-docs` can clarify the transient vs persistent guarantees if there is any ambiguity in the contract's usage.
+   ```
+
+**Step 3: Add Tool Reference footer**
+
+At the end of the file (after the Anti-Patterns Table), append:
+
+```markdown
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Use `skipZk=true` for syntax validation, `fullCompile=true` for full ZK compilation. |
+| `midnight-extract-contract-structure` | Deep structural analysis: deprecated syntax, missing `disclose()`, potential overflows, data structure usage. |
+| `midnight-analyze-contract` | Static analysis of contract structure and common patterns. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference from the latest compiler version. |
+| `midnight-explain-circuit` | Explains what a circuit does in plain language, including ZK proof and privacy implications. |
+| `midnight-search-docs` | Full-text search across official Midnight documentation. |
+```
+
+**Step 4: Verify and commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/privacy-review.md
+git commit -m "feat(compact-core): add MCP tool integration to privacy review checklist"
+```
+
+---
+
+### Task 4: Add MCP tools to security-review.md
+
+**Files:**
+- Modify: `plugins/compact-core/skills/compact-review/references/security-review.md`
+
+**Step 1: Insert Required MCP Tools section**
+
+After the intro paragraph (line 3) and before "## Access Control Checklist" (line 5), insert:
+
+```markdown
+
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation errors from missing assertions, type mismatches |
+| `midnight-extract-contract-structure` | `[shared]` | Detects missing access control, structural security issues |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of security patterns |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for cryptographic primitives |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
+```
+
+**Step 2: Add inline tool hints**
+
+1. After "Exported circuit with no authorization check" (first item under Access Control):
+   ```
+   > **Tool:** `midnight-extract-contract-structure` lists all exported circuits and their structure. Cross-reference each exported circuit that modifies state against the presence of authorization checks.
+   ```
+
+2. After "`persistentHash` vs `persistentCommit` vs `transientHash` vs `transientCommit` — correct usage":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` identifies hash and commit usage. Verify each call uses the correct primitive per the table above. `midnight-search-compact` can find reference patterns for correct cryptographic primitive usage.
+   ```
+
+3. After "Domain separation: every hash/commit call should include a unique domain string":
+   ```
+   > **Tool:** `midnight-search-compact` can find official examples of domain separation patterns to compare against.
+   ```
+
+4. After "`checkRoot()` called to verify path against current tree root":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` identifies MerkleTree operations. Verify every `merkleTreePathRoot` call is followed by a `checkRoot()` assertion.
+   ```
+
+5. After "Missing assertions before dangerous operations":
+   ```
+   > **Tool:** `midnight-compile-contract` output may reveal runtime failures from missing safety checks. `midnight-search-docs` has guidance on safe Map/Set access patterns.
+   ```
+
+**Step 3: Add Tool Reference footer**
+
+Same footer as Task 3, with the addition of `midnight-search-compact`:
+
+```markdown
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Use `skipZk=true` for syntax validation, `fullCompile=true` for full ZK compilation. |
+| `midnight-extract-contract-structure` | Deep structural analysis: deprecated syntax, missing access control, cryptographic primitive usage. |
+| `midnight-analyze-contract` | Static analysis of contract structure and common patterns. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference from the latest compiler version. |
+| `midnight-search-compact` | Semantic search across Compact smart contract code and patterns. |
+| `midnight-search-docs` | Full-text search across official Midnight documentation. |
+```
+
+**Step 4: Verify and commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/security-review.md
+git commit -m "feat(compact-core): add MCP tool integration to security review checklist"
+```
+
+---
+
+### Task 5: Add MCP tools to token-security-review.md
+
+**Files:**
+- Modify: `plugins/compact-core/skills/compact-review/references/token-security-review.md`
+
+**Step 1: Insert Required MCP Tools section**
+
+After the intro paragraph (line 3) and before "## Double-Spend Prevention Checklist":
+
+```markdown
+
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation errors from type mismatches in token operations |
+| `midnight-extract-contract-structure` | `[shared]` | Detects structural issues in token handling, missing checks |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of token patterns |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for token operation signatures |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
+```
+
+**Step 2: Add inline tool hints**
+
+1. After "Nullifier deterministically derived from coin and secret, not random":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` identifies hash function usage. Verify all nullifier derivations use `persistentHash`, not `transientHash`.
+   ```
+
+2. After "Token amount type: `Uint<64>` vs `Uint<128>`":
+   ```
+   > **Tool:** `midnight-get-latest-syntax` provides the authoritative stdlib function signatures showing the exact `Uint` width for each token operation. `midnight-compile-contract` output will show type mismatch errors if the wrong width is used.
+   ```
+
+3. After "`receiveShielded()` called in receiving contract":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` identifies all `receiveShielded` calls. Cross-reference against all circuits that accept `ShieldedCoinInfo` parameters — each must call `receiveShielded`. `midnight-search-compact` can find reference patterns for correct shielded token handling.
+   ```
+
+4. After "Correct `Uint` width for token operations":
+   ```
+   > **Tool:** `midnight-get-latest-syntax` is the authoritative source for these function signatures. Cross-reference every token operation call against the syntax reference.
+   ```
+
+5. After "`unshieldedBalance()` not used in conditional logic":
+   ```
+   > **Tool:** `midnight-search-docs` has guidance on construction-time balance locks and the correct use of comparison functions.
+   ```
+
+**Step 3: Add Tool Reference footer**
+
+```markdown
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Use `skipZk=true` for syntax validation. |
+| `midnight-extract-contract-structure` | Deep structural analysis: token patterns, missing `receiveShielded`, hash function usage. |
+| `midnight-analyze-contract` | Static analysis of contract structure and common patterns. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference including token operation signatures. |
+| `midnight-search-compact` | Semantic search across Compact code for token handling patterns. |
+| `midnight-search-docs` | Full-text search across official Midnight documentation. |
+| `midnight-list-examples` | List available example contracts with token implementations for reference. |
+```
+
+**Step 4: Verify and commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/token-security-review.md
+git commit -m "feat(compact-core): add MCP tool integration to token security review checklist"
+```
+
+---
+
+### Task 6: Add MCP tools to concurrency-review.md
+
+**Files:**
+- Modify: `plugins/compact-core/skills/compact-review/references/concurrency-review.md`
+
+**Step 1: Insert Required MCP Tools section**
+
+After the intro paragraph (line 3) and before "## Read-Then-Write Contention Checklist":
+
+```markdown
+
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation output helps identify ledger operation patterns |
+| `midnight-extract-contract-structure` | `[shared]` | Identifies data structure declarations and usage patterns |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of contention-prone patterns |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for ADT operation semantics |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
+```
+
+**Step 2: Add inline tool hints**
+
+1. After "Counter read-then-set pattern":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` shows all `Counter` operations. Look for `.read()` calls followed by manual writes to the same variable.
+   ```
+
+2. After "General read-then-write on any exported circuit":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` lists all exported circuits and their ledger operations. Cross-reference reads and writes to the same variables within each circuit.
+   ```
+
+3. After "`MerkleTree.insert(leaf)` — conflicts when concurrent inserts occur":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` identifies all MerkleTree declarations. Check whether `HistoricMerkleTree` is used where concurrent inserts are expected. `midnight-search-docs` has guidance on choosing between `MerkleTree` and `HistoricMerkleTree`.
+   ```
+
+**Step 3: Add Tool Reference footer**
+
+```markdown
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Use `skipZk=true` for syntax validation. |
+| `midnight-extract-contract-structure` | Deep structural analysis: data structure declarations, ledger operation patterns. |
+| `midnight-analyze-contract` | Static analysis of contract structure and common patterns. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference including ADT operation semantics. |
+| `midnight-search-docs` | Full-text search across official Midnight documentation for concurrency guidance. |
+```
+
+**Step 4: Verify and commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/concurrency-review.md
+git commit -m "feat(compact-core): add MCP tool integration to concurrency review checklist"
+```
+
+---
+
+### Task 7: Add MCP tools to compilation-review.md
+
+**Files:**
+- Modify: `plugins/compact-core/skills/compact-review/references/compilation-review.md`
+
+**Step 1: Insert Required MCP Tools section**
+
+After the intro paragraph (line 3) and before "## Syntax Error Checklist":
+
+```markdown
+
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | **Primary evidence source.** Actual compilation output reveals all syntax and type errors. |
+| `midnight-extract-contract-structure` | `[shared]` | Detects deprecated syntax, hallucinated APIs, structural issues |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of contract patterns |
+| `midnight-get-latest-syntax` | `[shared]` | **Critical for this category.** Authoritative syntax reference — the ground truth for what is valid Compact. |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
+**Important:** For Compilation & Type Safety review, the `midnight-compile-contract` and `midnight-get-latest-syntax` outputs are your primary evidence. Cross-reference every checklist item against actual compilation results before reporting findings.
+
+```
+
+**Step 2: Add inline tool hints**
+
+1. After "`Void` return type instead of `[]`":
+   ```
+   > **Tool:** `midnight-compile-contract` output will show `unknown type "Void"` or `found "{" looking for ";"` if present. `midnight-extract-contract-structure` also flags deprecated syntax.
+   ```
+
+2. After "Deprecated `ledger { ... }` block instead of individual ledger declarations":
+   ```
+   > **Tool:** `midnight-compile-contract` output shows `found "{" looking for ";"` for deprecated ledger block syntax. `midnight-extract-contract-structure` flags this pattern.
+   ```
+
+3. After "`witness name() { ... }` with a function body":
+   ```
+   > **Tool:** `midnight-compile-contract` output will show a parsing error for witness bodies. `midnight-get-latest-syntax` confirms witness declaration-only syntax.
+   ```
+
+4. After "`pure function` instead of `pure circuit`":
+   ```
+   > **Tool:** `midnight-compile-contract` output will show an error for the `function` keyword. `midnight-get-latest-syntax` confirms `circuit` and `pure circuit` as the only keywords.
+   ```
+
+5. After "Missing `import CompactStandardLibrary;` statement":
+   ```
+   > **Tool:** `midnight-compile-contract` output will show undefined type errors for stdlib types if the import is missing. `midnight-extract-contract-structure` checks for the import presence.
+   ```
+
+6. After "Direct cast from `Uint<N>` to `Bytes<M>`":
+   ```
+   > **Tool:** `midnight-compile-contract` output will show `cannot cast from type X to type Y`. `midnight-get-latest-syntax` documents the valid cast paths.
+   ```
+
+7. After "`Counter.value()` instead of `Counter.read()`":
+   ```
+   > **Tool:** `midnight-compile-contract` output will show `operation "value" undefined for Counter`. `midnight-get-latest-syntax` lists the correct Counter API methods.
+   ```
+
+8. After "`Map.get(key)` instead of `Map.lookup(key)`":
+   ```
+   > **Tool:** `midnight-compile-contract` output will show `operation "get" undefined for Map`. `midnight-search-compact` can find correct Map usage patterns in reference code.
+   ```
+
+9. After "`hash()` instead of `persistentHash<T>()` or `transientHash<T>()`":
+   ```
+   > **Tool:** `midnight-compile-contract` output will show `unknown function "hash"`. `midnight-get-latest-syntax` lists all valid hash functions.
+   ```
+
+10. After "`CurvePoint` instead of `NativePoint`":
+    ```
+    > **Tool:** `midnight-compile-contract` output will show an unknown type error for `CurvePoint`. `midnight-get-latest-syntax` confirms `NativePoint` as the current type name.
+    ```
+
+**Step 3: Add Tool Reference footer**
+
+```markdown
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | **Primary tool for this category.** Compile contract with hosted compiler. Use `skipZk=true` for syntax/type validation. All compilation errors listed in the Compiler Error Quick Reference are directly caught by this tool. |
+| `midnight-extract-contract-structure` | Deep structural analysis: deprecated syntax, hallucinated APIs, missing imports. |
+| `midnight-analyze-contract` | Static analysis of contract structure and common patterns. |
+| `midnight-get-latest-syntax` | **Critical for this category.** Authoritative Compact syntax reference — use as ground truth for valid types, functions, and keywords. |
+| `midnight-search-compact` | Semantic search across Compact code for correct API usage patterns. |
+```
+
+**Step 4: Verify and commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/compilation-review.md
+git commit -m "feat(compact-core): add MCP tool integration to compilation review checklist"
+```
+
+---
+
+### Task 8: Add MCP tools to performance-review.md
+
+**Files:**
+- Modify: `plugins/compact-core/skills/compact-review/references/performance-review.md`
+
+**Step 1: Insert Required MCP Tools section**
+
+After the intro paragraph (line 3) and before "## Proof Generation Cost Checklist":
+
+```markdown
+
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Syntax validation and basic compilation checks |
+| `midnight-extract-contract-structure` | `[shared]` | Identifies data structure declarations, loop patterns, type casts |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of circuit complexity patterns |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for pure circuit syntax and type cast rules |
+| `midnight-compile-contract` (fullCompile) | `[category-specific]` | **Run this yourself** with `fullCompile=true` to get full ZK compilation including circuit size metrics. This reveals proof generation cost. |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+Tools marked `[category-specific]` must be run by you during your review.
+
+```
+
+**Step 2: Add inline tool hints**
+
+1. After "Oversized depth wastes proof generation time" (MerkleTree depth section):
+   ```
+   > **Tool:** `midnight-extract-contract-structure` lists all MerkleTree declarations with their depth parameters. Cross-reference each depth against the expected capacity table above.
+   ```
+
+2. After "`for` loops in Compact are unrolled at compile time":
+   ```
+   > **Tool:** `midnight-compile-contract` with `fullCompile=true` reveals the actual constraint count. Compare against the expected count based on loop iterations and body complexity.
+   ```
+
+3. After "Reusable logic that does not touch ledger state should be `pure circuit`":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` identifies all circuits and whether they access ledger state. Flag any non-pure circuit that does not read or write ledger variables. `midnight-explain-circuit` can analyze specific circuits to confirm whether they access ledger state.
+   ```
+
+4. After "Expensive computation in circuit that could be in witness":
+   ```
+   > **Tool:** `midnight-explain-circuit` can explain what a circuit does in plain language, helping identify computations that could be moved to the witness. `midnight-search-docs` has guidance on the circuit vs witness boundary optimization.
+   ```
+
+**Step 3: Add Tool Reference footer**
+
+```markdown
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Use `skipZk=true` for syntax validation, `fullCompile=true` for circuit size metrics and proof generation cost analysis. |
+| `midnight-extract-contract-structure` | Deep structural analysis: data structure declarations, loop patterns, type cast chains, pure circuit candidates. |
+| `midnight-analyze-contract` | Static analysis of contract structure and common patterns. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference including `pure circuit` rules and type cast paths. |
+| `midnight-explain-circuit` | Explains what a circuit does in plain language, including ZK proof cost implications. |
+| `midnight-search-docs` | Full-text search across official Midnight documentation for performance guidance. |
+```
+
+**Step 4: Verify and commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/performance-review.md
+git commit -m "feat(compact-core): add MCP tool integration to performance review checklist"
+```
+
+---
+
+### Task 9: Add MCP tools to witness-consistency-review.md
+
+**Files:**
+- Modify: `plugins/compact-core/skills/compact-review/references/witness-consistency-review.md`
+
+**Step 1: Insert Required MCP Tools section**
+
+After the intro paragraph (line 3) and before "## Name Matching Checklist":
+
+```markdown
+
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation output reveals witness-related errors |
+| `midnight-extract-contract-structure` | `[shared]` | Lists all witness declarations, their parameter types, and return types |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of contract structure |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for witness declaration syntax and type mappings |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
+```
+
+**Step 2: Add inline tool hints**
+
+1. After "Every `witness` declaration in the Compact contract has a matching key":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` lists all witness declarations in the contract. Use this as your definitive list of witness names to cross-reference against the TypeScript `witnesses` object.
+   ```
+
+2. After "All Compact-to-TypeScript type mappings are correct":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` shows the Compact types for each witness parameter and return value. `midnight-get-latest-syntax` confirms the authoritative type mapping rules. `midnight-search-docs` has detailed WitnessContext documentation.
+   ```
+
+3. After "Witness parameter count and order match the Compact declaration":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` provides the exact parameter list for each witness. Compare against the TypeScript implementation parameter-by-parameter.
+   ```
+
+**Step 3: Add Tool Reference footer**
+
+```markdown
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Reveals witness-related compilation errors. |
+| `midnight-extract-contract-structure` | Deep structural analysis: lists all witness declarations with their exact parameter types, return types, and names. |
+| `midnight-analyze-contract` | Static analysis of contract structure and common patterns. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference including witness declaration rules and type mappings. |
+| `midnight-search-compact` | Semantic search across Compact code for witness implementation patterns. |
+| `midnight-search-docs` | Full-text search across official Midnight documentation for WitnessContext and type mapping details. |
+```
+
+**Step 4: Verify and commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/witness-consistency-review.md
+git commit -m "feat(compact-core): add MCP tool integration to witness consistency review checklist"
+```
+
+---
+
+### Task 10: Add MCP tools to architecture-review.md
+
+**Files:**
+- Modify: `plugins/compact-core/skills/compact-review/references/architecture-review.md`
+
+**Step 1: Insert Required MCP Tools section**
+
+After the intro paragraph (line 3) and before "## ADT Selection Checklist":
+
+```markdown
+
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation output reveals structural issues |
+| `midnight-extract-contract-structure` | `[shared]` | Identifies all data structure declarations, visibility modifiers, modules |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of contract architecture |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for ADT types, visibility modifiers, module syntax |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
+```
+
+**Step 2: Add inline tool hints**
+
+1. After "ADT Selection Decision Tree":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` lists all ledger variable declarations with their types. Cross-reference each declaration against the ADT selection decision tree above.
+   ```
+
+2. After "MerkleTree depth matches expected capacity":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` shows all MerkleTree declarations with their depth parameters. Verify each depth against the planning table.
+   ```
+
+3. After "Visibility reference":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` shows the visibility modifier for each ledger variable. `midnight-list-examples` provides reference architectures showing idiomatic visibility patterns.
+   ```
+
+4. After "Module system used for separation of concerns":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` identifies module structure and imports. `midnight-search-compact` can find reference examples of module decomposition patterns.
+   ```
+
+**Step 3: Add Tool Reference footer**
+
+```markdown
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Use `skipZk=true` for syntax validation. |
+| `midnight-extract-contract-structure` | Deep structural analysis: data structure declarations, visibility modifiers, module organization. |
+| `midnight-analyze-contract` | Static analysis of contract architecture and patterns. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference including ADT types and module syntax. |
+| `midnight-list-examples` | List available example contracts for reference architectures and idiomatic patterns. |
+| `midnight-search-compact` | Semantic search across Compact code for architectural patterns. |
+```
+
+**Step 4: Verify and commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/architecture-review.md
+git commit -m "feat(compact-core): add MCP tool integration to architecture review checklist"
+```
+
+---
+
+### Task 11: Add MCP tools to code-quality-review.md
+
+**Files:**
+- Modify: `plugins/compact-core/skills/compact-review/references/code-quality-review.md`
+
+**Step 1: Insert Required MCP Tools section**
+
+After the intro paragraph (line 3) and before "## Naming Conventions Checklist":
+
+```markdown
+
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Catches hallucinated functions and type errors |
+| `midnight-extract-contract-structure` | `[shared]` | Identifies dead code, unused declarations, structural patterns |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of code patterns |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for valid stdlib functions and types |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
+```
+
+**Step 2: Add inline tool hints**
+
+1. After "Verify every stdlib function call exists":
+   ```
+   > **Tool:** `midnight-compile-contract` output will show `unknown function` or `operation undefined` errors for any hallucinated API calls. `midnight-get-latest-syntax` is the authoritative list of valid stdlib functions. Cross-reference every function call in the contract against these two sources.
+   ```
+
+2. After "`hash()` does not exist":
+   ```
+   > **Tool:** `midnight-compile-contract` output will show `unknown function "hash"` if present.
+   ```
+
+3. After "`counter.value()` does not exist":
+   ```
+   > **Tool:** `midnight-compile-contract` output will show `operation "value" undefined for Counter`.
+   ```
+
+4. After "`CurvePoint` or `EllipticCurvePoint` do not exist":
+   ```
+   > **Tool:** `midnight-compile-contract` output will show an unknown type error. `midnight-get-latest-syntax` confirms `NativePoint` as the current type name.
+   ```
+
+5. After "Unused ledger variables (declared but never read or written)":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` identifies all ledger declarations. Cross-reference each against usage in circuit bodies.
+   ```
+
+6. After "Pure circuits not used for reusable logic":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` identifies all circuits and whether they access ledger state. Flag any non-pure circuit that could be marked `pure`. `midnight-list-examples` shows idiomatic use of `pure circuit` in reference contracts.
+   ```
+
+**Step 3: Add Tool Reference footer**
+
+```markdown
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Catches hallucinated functions, wrong method names, invalid types. |
+| `midnight-extract-contract-structure` | Deep structural analysis: dead code detection, unused declarations, circuit structure. |
+| `midnight-analyze-contract` | Static analysis of code patterns and quality. |
+| `midnight-get-latest-syntax` | Authoritative list of valid Compact stdlib functions, types, and methods. Ground truth for hallucination detection. |
+| `midnight-search-compact` | Semantic search across Compact code for idiomatic patterns and stdlib usage examples. |
+| `midnight-list-examples` | List available example contracts showing best practices and correct patterns. |
+```
+
+**Step 4: Verify and commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/code-quality-review.md
+git commit -m "feat(compact-core): add MCP tool integration to code quality review checklist"
+```
+
+---
+
+### Task 12: Add MCP tools to testing-review.md
+
+**Files:**
+- Modify: `plugins/compact-core/skills/compact-review/references/testing-review.md`
+
+**Step 1: Insert Required MCP Tools section**
+
+After the intro paragraph (line 3) and before "## Test Coverage Checklist":
+
+```markdown
+
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation output reveals contract structure for coverage analysis |
+| `midnight-extract-contract-structure` | `[shared]` | Lists all exported circuits (required for coverage checklist) |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of contract patterns |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for type mappings (needed for mock correctness) |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
+```
+
+**Step 2: Add inline tool hints**
+
+1. After "Every exported circuit has at least one test":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` lists all exported circuits. Use this as your definitive checklist — every exported circuit name must appear in the test files.
+   ```
+
+2. After "Mock type mappings match the Compact-to-TypeScript type table":
+   ```
+   > **Tool:** `midnight-get-latest-syntax` provides the authoritative type mapping rules. `midnight-extract-contract-structure` shows the Compact types for each witness, which must match the mock types per the mapping table.
+   ```
+
+3. After "Multi-step flows tested end-to-end":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` and `midnight-analyze-contract` reveal the contract's state machine and multi-phase patterns. Use these to identify which flows need end-to-end tests. `midnight-list-examples` shows test patterns from reference implementations.
+   ```
+
+**Step 3: Add Tool Reference footer**
+
+```markdown
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Reveals contract structure for coverage analysis. |
+| `midnight-extract-contract-structure` | Lists all exported circuits, witness declarations, and state structure — the definitive list for coverage analysis. |
+| `midnight-analyze-contract` | Static analysis of contract patterns and state machines. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference including type mapping rules for mock correctness. |
+| `midnight-list-examples` | List available example contracts with test suites for reference patterns. |
+| `midnight-search-docs` | Full-text search across official Midnight documentation for testing guidance. |
+```
+
+**Step 4: Verify and commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/testing-review.md
+git commit -m "feat(compact-core): add MCP tool integration to testing review checklist"
+```
+
+---
+
+### Task 13: Add MCP tools to documentation-review.md
+
+**Files:**
+- Modify: `plugins/compact-core/skills/compact-review/references/documentation-review.md`
+
+**Step 1: Insert Required MCP Tools section**
+
+After the intro paragraph (line 3) and before "## Contract-Level Documentation Checklist":
+
+```markdown
+
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation output reveals contract structure for documentation completeness analysis |
+| `midnight-extract-contract-structure` | `[shared]` | Lists all exported circuits, ledger variables, witnesses — the definitive inventory for documentation coverage |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of contract patterns and structure |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for verifying documentation accuracy |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
+```
+
+**Step 2: Add inline tool hints**
+
+1. After "Every exported circuit has a comment explaining its purpose":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` lists all exported circuits. Use this as your definitive checklist — every exported circuit must have documentation.
+   ```
+
+2. After "Every ledger variable has a comment explaining its purpose":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` lists all ledger variable declarations with their types and visibility modifiers. Use this as your checklist for documentation coverage.
+   ```
+
+3. After "Every witness declaration has a comment explaining what data it provides":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` lists all witness declarations. Use this to verify every witness has documentation. `midnight-search-docs` can provide context on standard witness patterns and WitnessContext documentation.
+   ```
+
+4. After "Privacy documentation covers the full data lifecycle":
+   ```
+   > **Tool:** `midnight-extract-contract-structure` identifies all `disclose()` calls, ledger writes, and data flow patterns. Use this to verify the privacy documentation covers every disclosure point. `midnight-search-docs` has guidance on documenting privacy models.
+   ```
+
+**Step 3: Add Tool Reference footer**
+
+```markdown
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Reveals complete contract structure. |
+| `midnight-extract-contract-structure` | Lists all exported circuits, ledger variables, witnesses, and data flow — the definitive inventory for documentation coverage analysis. |
+| `midnight-analyze-contract` | Static analysis of contract patterns for architectural documentation. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference for verifying technical accuracy of documentation. |
+| `midnight-search-docs` | Full-text search across official Midnight documentation for documentation standards and privacy model guidance. |
+```
+
+**Step 4: Verify and commit**
+
+```bash
+git add plugins/compact-core/skills/compact-review/references/documentation-review.md
+git commit -m "feat(compact-core): add MCP tool integration to documentation review checklist"
+```

--- a/plugins/compact-core/.claude-plugin/plugin.json
+++ b/plugins/compact-core/.claude-plugin/plugin.json
@@ -44,6 +44,11 @@
     "compact-runtime",
     "contract-class",
     "pureCircuits",
-    "compiler-generated"
+    "compiler-generated",
+    "code-review",
+    "security-review",
+    "privacy-review",
+    "compact-review",
+    "review"
   ]
 }

--- a/plugins/compact-core/agents/reviewer.md
+++ b/plugins/compact-core/agents/reviewer.md
@@ -1,0 +1,73 @@
+---
+name: reviewer
+description: "Use this agent when you need a focused review of Compact smart contract code in a specific category. Dispatched by the review-compact command with a category assignment. Not intended for direct user invocation.\n\n<example>\nContext: Dispatched by review-compact command for privacy review\nassistant: \"Launching reviewer agent for Privacy & Disclosure category\"\n<commentary>\nThe review-compact command spawns this agent with a specific category and file list. The agent loads the compact-review skill reference for its category.\n</commentary>\n</example>\n\n<example>\nContext: Dispatched for security review of token contract\nassistant: \"Launching reviewer agent for Token & Economic Security category\"\n<commentary>\nSame agent, different category assignment. Loads token-security-review.md reference.\n</commentary>\n</example>"
+skills: compact-core:compact-structure, compact-core:compact-ledger, compact-core:compact-privacy-disclosure, compact-core:compact-tokens, compact-core:compact-language-ref, compact-core:compact-standard-library, compact-core:compact-witness-ts, compact-core:compact-review, devs:code-review, devs:typescript-core, devs:security-core
+model: sonnet
+color: blue
+---
+
+You are a Midnight Compact smart contract security reviewer specializing in zero-knowledge proof systems and privacy-preserving smart contracts. You have deep expertise in the Compact language, its type system, the ZK proof compilation pipeline, and the Midnight blockchain architecture.
+
+## Your Assignment
+
+You will receive:
+1. A **review category** name (e.g., "Privacy & Disclosure", "Security & Cryptographic Correctness")
+2. A **list of files** to review (.compact contracts, TypeScript witnesses, test files)
+
+## Review Process
+
+1. **Load your checklist**: Invoke the `compact-core:compact-review` skill. Read the reference file that corresponds to your assigned category from the Category Reference Map in the SKILL.md.
+
+2. **Read all files**: Read every file in your assignment list completely.
+
+3. **Apply the checklist systematically**: Go through EVERY item in your category's checklist. For each item:
+   - Search the code for the pattern or anti-pattern
+   - If found, create a finding with the correct severity
+   - If the code correctly avoids the issue, note it in positive highlights
+
+4. **Classify each finding** using these severity levels:
+   - **Critical**: Will cause loss of funds, data breach, or contract exploitation
+   - **High**: Security vulnerability or privacy leak exploitable under certain conditions
+   - **Medium**: Correctness issue, compilation problem, or significant performance concern
+   - **Low**: Code quality, style, or minor best practice deviation
+   - **Suggestion**: Enhancement opportunity, not a problem
+
+5. **Format your output** as structured markdown:
+
+```
+## [Category Name] Review
+
+### Critical
+- **[Issue title]** (`file:line`)
+  - **Problem:** Clear description of what is wrong
+  - **Impact:** Why this matters
+  - **Fix:** Suggested fix with code example
+
+### High
+[same format]
+
+### Medium
+[same format]
+
+### Low
+[same format]
+
+### Suggestions
+[same format]
+
+### Positive Highlights
+- [What was done well in this category]
+```
+
+If a severity level has no findings, omit that section entirely.
+
+## Review Principles
+
+- **Be constructive**: Every finding must include a concrete, actionable fix
+- **Be specific**: Always reference exact file and line numbers
+- **Show code**: Include code examples for suggested fixes when the fix isn't obvious
+- **Explain impact**: Don't just say what's wrong — explain why it matters
+- **Acknowledge good work**: Call out correct patterns and well-designed code
+- **Stay focused**: Only report findings relevant to your assigned category
+- **Be thorough**: Check every item in your checklist, don't skip any
+- **No false positives**: Only report issues you are confident about. If uncertain, flag as a question rather than a finding

--- a/plugins/compact-core/agents/reviewer.md
+++ b/plugins/compact-core/agents/reviewer.md
@@ -18,21 +18,27 @@ You will receive:
 
 1. **Load your checklist**: Invoke the `compact-core:compact-review` skill. Read the reference file that corresponds to your assigned category from the Category Reference Map in the SKILL.md.
 
-2. **Read all files**: Read every file in your assignment list completely.
+2. **Reference shared MCP evidence**: Your prompt includes pre-computed outputs from shared MCP tools (compilation result, structural analysis, contract analysis, and latest syntax reference). Read these outputs — they are your baseline evidence for evaluating checklist items.
 
-3. **Apply the checklist systematically**: Go through EVERY item in your category's checklist. For each item:
+3. **Run category-specific MCP tools**: Check your reference file's "Required MCP Tools" section. Any tools marked `[category-specific]` must be run by you now against the contract under review. Tools marked `[shared]` are already provided in your prompt.
+
+4. **Read all files**: Read every file in your assignment list completely.
+
+5. **Apply the checklist systematically**: Go through EVERY item in your category's checklist. For each item:
    - Search the code for the pattern or anti-pattern
+   - Cross-reference against the shared MCP tool evidence where applicable
+   - When a checklist item has a `> **Tool:**` hint, consider calling that tool for additional verification
    - If found, create a finding with the correct severity
    - If the code correctly avoids the issue, note it in positive highlights
 
-4. **Classify each finding** using these severity levels:
+6. **Classify each finding** using these severity levels:
    - **Critical**: Will cause loss of funds, data breach, or contract exploitation
    - **High**: Security vulnerability or privacy leak exploitable under certain conditions
    - **Medium**: Correctness issue, compilation problem, or significant performance concern
    - **Low**: Code quality, style, or minor best practice deviation
    - **Suggestion**: Enhancement opportunity, not a problem
 
-5. **Format your output** as structured markdown:
+7. **Format your output** as structured markdown:
 
 ```
 ## [Category Name] Review
@@ -71,3 +77,4 @@ If a severity level has no findings, omit that section entirely.
 - **Stay focused**: Only report findings relevant to your assigned category
 - **Be thorough**: Check every item in your checklist, don't skip any
 - **No false positives**: Only report issues you are confident about. If uncertain, flag as a question rather than a finding
+- **Use tool evidence**: When MCP tool output confirms or contradicts a finding, cite it. Tool-backed findings are stronger than judgment alone. If a tool identifies an issue that matches your checklist, include the tool's output as evidence.

--- a/plugins/compact-core/commands/review-compact.md
+++ b/plugins/compact-core/commands/review-compact.md
@@ -1,6 +1,6 @@
 ---
 description: Comprehensive review of Compact smart contract code covering 11 categories including privacy, security, tokens, concurrency, performance, and more. Supports parallel execution via agent teams (when enabled) or concurrent subagents.
-allowed-tools: Bash, Agent, Read, Glob, Grep, TaskCreate, TaskUpdate, TaskList, AskUserQuestion
+allowed-tools: Bash, Agent, Read, Glob, Grep, TaskCreate, TaskUpdate, TaskList, AskUserQuestion, ToolSearch
 argument-hint: [path/to/contract.compact or directory]
 ---
 
@@ -33,6 +33,28 @@ find . \( -name "*.test.ts" -o -name "*.spec.ts" \) -not -path "*/node_modules/*
 
 Collect the file list and present it to the user for confirmation.
 
+## Step 1.5: Run Shared MCP Tools
+
+After identifying the files, run these 4 MCP tools against the primary `.compact` contract file. These outputs will be passed to all 11 reviewer agents as shared evidence.
+
+Use the ToolSearch tool to load the Midnight MCP tools, then call each one:
+
+1. **Compile the contract** (syntax validation):
+   Call `midnight-compile-contract` with the contract source and `skipZk=true`. Save the output as `COMPILE_RESULT`.
+
+2. **Extract contract structure** (structural analysis):
+   Call `midnight-extract-contract-structure` with the contract source. Save the output as `STRUCTURE_RESULT`.
+
+3. **Analyze the contract** (static pattern analysis):
+   Call `midnight-analyze-contract` with the contract source. Save the output as `ANALYSIS_RESULT`.
+
+4. **Get latest syntax reference**:
+   Call `midnight-get-latest-syntax`. Save the output as `SYNTAX_REFERENCE`.
+
+If any tool call fails (e.g., MCP server unavailable), note the failure and proceed — the review can still run with partial or no tool evidence. Do not block the review on tool failures.
+
+Store all four outputs for injection into reviewer prompts in the next steps.
+
 ## Step 2: Check for Agent Teams
 
 Run this command to detect agent team support:
@@ -51,9 +73,10 @@ Create an agent team to perform the review. Tell Claude:
 >
 > 1. Invoke the `compact-core:compact-review` skill
 > 2. Read their assigned reference file from the Category Reference Map
-> 3. Read all files: [INSERT FILE LIST]
-> 4. Apply every checklist item from their reference
-> 5. Report findings in the structured format with severity levels
+> 3. Reference the shared MCP tool evidence provided below
+> 4. Read all files: [INSERT FILE LIST]
+> 5. Apply every checklist item from their reference
+> 6. Report findings in the structured format with severity levels
 >
 > Teammate assignments:
 > - Teammate 1 — "Privacy & Disclosure" → read `privacy-review` reference
@@ -67,6 +90,13 @@ Create an agent team to perform the review. Tell Claude:
 > - Teammate 9 — "Code Quality & Best Practices" → read `code-quality-review` reference
 > - Teammate 10 — "Testing Adequacy" → read `testing-review` reference
 > - Teammate 11 — "Documentation" → read `documentation-review` reference
+>
+>
+> **Shared MCP Tool Evidence:**
+> - Compilation result: [INSERT COMPILE_RESULT]
+> - Structural analysis: [INSERT STRUCTURE_RESULT]
+> - Contract analysis: [INSERT ANALYSIS_RESULT]
+> - Latest syntax reference: [INSERT SYNTAX_REFERENCE]
 >
 > Use sonnet model for each teammate.
 > Wait for ALL teammates to complete before synthesizing the consolidated report.
@@ -87,7 +117,13 @@ subagent_type: "compact-core:reviewer"
 description: "Review privacy & disclosure"
 prompt: "You are reviewing category: Privacy & Disclosure.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the privacy-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
+Invoke the compact-core:compact-review skill. Read the privacy-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights.
+
+Shared MCP Tool Evidence (pre-computed by orchestrator — reference when evaluating checklist items):
+- Compilation result: [INSERT COMPILE_RESULT]
+- Structural analysis: [INSERT STRUCTURE_RESULT]
+- Contract analysis: [INSERT ANALYSIS_RESULT]
+- Latest syntax reference: [INSERT SYNTAX_REFERENCE]"
 ```
 
 **Agent call 2:**
@@ -96,7 +132,13 @@ subagent_type: "compact-core:reviewer"
 description: "Review security & crypto"
 prompt: "You are reviewing category: Security & Cryptographic Correctness.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the security-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
+Invoke the compact-core:compact-review skill. Read the security-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights.
+
+Shared MCP Tool Evidence (pre-computed by orchestrator — reference when evaluating checklist items):
+- Compilation result: [INSERT COMPILE_RESULT]
+- Structural analysis: [INSERT STRUCTURE_RESULT]
+- Contract analysis: [INSERT ANALYSIS_RESULT]
+- Latest syntax reference: [INSERT SYNTAX_REFERENCE]"
 ```
 
 **Agent call 3:**
@@ -105,7 +147,13 @@ subagent_type: "compact-core:reviewer"
 description: "Review token & economic security"
 prompt: "You are reviewing category: Token & Economic Security.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the token-security-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
+Invoke the compact-core:compact-review skill. Read the token-security-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights.
+
+Shared MCP Tool Evidence (pre-computed by orchestrator — reference when evaluating checklist items):
+- Compilation result: [INSERT COMPILE_RESULT]
+- Structural analysis: [INSERT STRUCTURE_RESULT]
+- Contract analysis: [INSERT ANALYSIS_RESULT]
+- Latest syntax reference: [INSERT SYNTAX_REFERENCE]"
 ```
 
 **Agent call 4:**
@@ -114,7 +162,13 @@ subagent_type: "compact-core:reviewer"
 description: "Review concurrency & contention"
 prompt: "You are reviewing category: Concurrency & Contention.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the concurrency-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
+Invoke the compact-core:compact-review skill. Read the concurrency-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights.
+
+Shared MCP Tool Evidence (pre-computed by orchestrator — reference when evaluating checklist items):
+- Compilation result: [INSERT COMPILE_RESULT]
+- Structural analysis: [INSERT STRUCTURE_RESULT]
+- Contract analysis: [INSERT ANALYSIS_RESULT]
+- Latest syntax reference: [INSERT SYNTAX_REFERENCE]"
 ```
 
 **Agent call 5:**
@@ -123,7 +177,13 @@ subagent_type: "compact-core:reviewer"
 description: "Review compilation & types"
 prompt: "You are reviewing category: Compilation & Type Safety.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the compilation-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
+Invoke the compact-core:compact-review skill. Read the compilation-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights.
+
+Shared MCP Tool Evidence (pre-computed by orchestrator — reference when evaluating checklist items):
+- Compilation result: [INSERT COMPILE_RESULT]
+- Structural analysis: [INSERT STRUCTURE_RESULT]
+- Contract analysis: [INSERT ANALYSIS_RESULT]
+- Latest syntax reference: [INSERT SYNTAX_REFERENCE]"
 ```
 
 **Agent call 6:**
@@ -132,7 +192,13 @@ subagent_type: "compact-core:reviewer"
 description: "Review performance & efficiency"
 prompt: "You are reviewing category: Performance & Circuit Efficiency.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the performance-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
+Invoke the compact-core:compact-review skill. Read the performance-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights.
+
+Shared MCP Tool Evidence (pre-computed by orchestrator — reference when evaluating checklist items):
+- Compilation result: [INSERT COMPILE_RESULT]
+- Structural analysis: [INSERT STRUCTURE_RESULT]
+- Contract analysis: [INSERT ANALYSIS_RESULT]
+- Latest syntax reference: [INSERT SYNTAX_REFERENCE]"
 ```
 
 **Agent call 7:**
@@ -141,7 +207,13 @@ subagent_type: "compact-core:reviewer"
 description: "Review witness consistency"
 prompt: "You are reviewing category: Witness-Contract Consistency.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the witness-consistency-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
+Invoke the compact-core:compact-review skill. Read the witness-consistency-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights.
+
+Shared MCP Tool Evidence (pre-computed by orchestrator — reference when evaluating checklist items):
+- Compilation result: [INSERT COMPILE_RESULT]
+- Structural analysis: [INSERT STRUCTURE_RESULT]
+- Contract analysis: [INSERT ANALYSIS_RESULT]
+- Latest syntax reference: [INSERT SYNTAX_REFERENCE]"
 ```
 
 **Agent call 8:**
@@ -150,7 +222,13 @@ subagent_type: "compact-core:reviewer"
 description: "Review architecture & state"
 prompt: "You are reviewing category: Architecture, State Design & Composability.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the architecture-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
+Invoke the compact-core:compact-review skill. Read the architecture-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights.
+
+Shared MCP Tool Evidence (pre-computed by orchestrator — reference when evaluating checklist items):
+- Compilation result: [INSERT COMPILE_RESULT]
+- Structural analysis: [INSERT STRUCTURE_RESULT]
+- Contract analysis: [INSERT ANALYSIS_RESULT]
+- Latest syntax reference: [INSERT SYNTAX_REFERENCE]"
 ```
 
 **Agent call 9:**
@@ -159,7 +237,13 @@ subagent_type: "compact-core:reviewer"
 description: "Review code quality"
 prompt: "You are reviewing category: Code Quality & Best Practices.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the code-quality-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
+Invoke the compact-core:compact-review skill. Read the code-quality-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights.
+
+Shared MCP Tool Evidence (pre-computed by orchestrator — reference when evaluating checklist items):
+- Compilation result: [INSERT COMPILE_RESULT]
+- Structural analysis: [INSERT STRUCTURE_RESULT]
+- Contract analysis: [INSERT ANALYSIS_RESULT]
+- Latest syntax reference: [INSERT SYNTAX_REFERENCE]"
 ```
 
 **Agent call 10:**
@@ -168,7 +252,13 @@ subagent_type: "compact-core:reviewer"
 description: "Review testing adequacy"
 prompt: "You are reviewing category: Testing Adequacy.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the testing-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
+Invoke the compact-core:compact-review skill. Read the testing-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights.
+
+Shared MCP Tool Evidence (pre-computed by orchestrator — reference when evaluating checklist items):
+- Compilation result: [INSERT COMPILE_RESULT]
+- Structural analysis: [INSERT STRUCTURE_RESULT]
+- Contract analysis: [INSERT ANALYSIS_RESULT]
+- Latest syntax reference: [INSERT SYNTAX_REFERENCE]"
 ```
 
 **Agent call 11:**
@@ -177,7 +267,13 @@ subagent_type: "compact-core:reviewer"
 description: "Review documentation"
 prompt: "You are reviewing category: Documentation.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the documentation-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
+Invoke the compact-core:compact-review skill. Read the documentation-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights.
+
+Shared MCP Tool Evidence (pre-computed by orchestrator — reference when evaluating checklist items):
+- Compilation result: [INSERT COMPILE_RESULT]
+- Structural analysis: [INSERT STRUCTURE_RESULT]
+- Contract analysis: [INSERT ANALYSIS_RESULT]
+- Latest syntax reference: [INSERT SYNTAX_REFERENCE]"
 ```
 
 **CRITICAL: All 11 Agent tool calls MUST be in a single message to ensure concurrent execution.**

--- a/plugins/compact-core/commands/review-compact.md
+++ b/plugins/compact-core/commands/review-compact.md
@@ -1,0 +1,236 @@
+---
+description: Comprehensive review of Compact smart contract code covering 11 categories including privacy, security, tokens, concurrency, performance, and more. Supports parallel execution via agent teams (when enabled) or concurrent subagents.
+allowed-tools: Bash, Agent, Read, Glob, Grep, TaskCreate, TaskUpdate, TaskList, AskUserQuestion
+argument-hint: [path/to/contract.compact or directory]
+---
+
+Review Compact smart contract code across 11 review categories using parallel reviewer agents. Privacy findings are always shown first.
+
+## Review Categories
+
+1. Privacy & Disclosure
+2. Security & Cryptographic Correctness
+3. Token & Economic Security
+4. Concurrency & Contention
+5. Compilation & Type Safety
+6. Performance & Circuit Efficiency
+7. Witness-Contract Consistency
+8. Architecture, State Design & Composability
+9. Code Quality & Best Practices
+10. Testing Adequacy
+11. Documentation
+
+## Step 1: Identify Files to Review
+
+If `$ARGUMENTS` provides a path, use it. Otherwise, find all relevant files:
+
+```bash
+# Find all Compact and related files
+find . -name "*.compact" -not -path "*/node_modules/*" -not -path "*/.compact/*"
+find . -name "*.ts" -not -path "*/node_modules/*" -not -path "*/.compact/*" | grep -iE "(witness|private)" || true
+find . -name "*.test.ts" -o -name "*.spec.ts" -not -path "*/node_modules/*" | head -20
+```
+
+Collect the file list and present it to the user for confirmation.
+
+## Step 2: Check for Agent Teams
+
+Run this command to detect agent team support:
+
+```bash
+echo "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-not_set}"
+```
+
+## Step 3a: Agent Teams Mode
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is set (not "not_set"):
+
+Create an agent team to perform the review. Tell Claude:
+
+> Create an agent team to review Compact code across 11 categories. Spawn 11 reviewer teammates, one per category. Each teammate should:
+>
+> 1. Invoke the `compact-core:compact-review` skill
+> 2. Read their assigned reference file from the Category Reference Map
+> 3. Read all files: [INSERT FILE LIST]
+> 4. Apply every checklist item from their reference
+> 5. Report findings in the structured format with severity levels
+>
+> Teammate assignments:
+> - Teammate 1 — "Privacy & Disclosure" → read `privacy-review` reference
+> - Teammate 2 — "Security & Cryptographic Correctness" → read `security-review` reference
+> - Teammate 3 — "Token & Economic Security" → read `token-security-review` reference
+> - Teammate 4 — "Concurrency & Contention" → read `concurrency-review` reference
+> - Teammate 5 — "Compilation & Type Safety" → read `compilation-review` reference
+> - Teammate 6 — "Performance & Circuit Efficiency" → read `performance-review` reference
+> - Teammate 7 — "Witness-Contract Consistency" → read `witness-consistency-review` reference
+> - Teammate 8 — "Architecture, State Design & Composability" → read `architecture-review` reference
+> - Teammate 9 — "Code Quality & Best Practices" → read `code-quality-review` reference
+> - Teammate 10 — "Testing Adequacy" → read `testing-review` reference
+> - Teammate 11 — "Documentation" → read `documentation-review` reference
+>
+> Use sonnet model for each teammate.
+> Wait for ALL teammates to complete before synthesizing the consolidated report.
+
+Proceed to Step 4 when all teammates finish.
+
+## Step 3b: Subagent Mode (concurrent)
+
+If agent teams are NOT available:
+
+You MUST launch ALL 11 reviewer agents in a **SINGLE message** using 11 Agent tool calls. This ensures they run concurrently. Do NOT call them sequentially — that defeats the purpose of parallelization.
+
+In ONE message, make ALL of these Agent tool calls simultaneously:
+
+**Agent call 1:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review privacy & disclosure"
+prompt: "You are reviewing category: Privacy & Disclosure.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the privacy-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
+```
+
+**Agent call 2:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review security & crypto"
+prompt: "You are reviewing category: Security & Cryptographic Correctness.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the security-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
+```
+
+**Agent call 3:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review token & economic security"
+prompt: "You are reviewing category: Token & Economic Security.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the token-security-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**Agent call 4:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review concurrency & contention"
+prompt: "You are reviewing category: Concurrency & Contention.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the concurrency-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**Agent call 5:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review compilation & types"
+prompt: "You are reviewing category: Compilation & Type Safety.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the compilation-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**Agent call 6:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review performance & efficiency"
+prompt: "You are reviewing category: Performance & Circuit Efficiency.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the performance-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**Agent call 7:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review witness consistency"
+prompt: "You are reviewing category: Witness-Contract Consistency.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the witness-consistency-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**Agent call 8:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review architecture & state"
+prompt: "You are reviewing category: Architecture, State Design & Composability.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the architecture-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**Agent call 9:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review code quality"
+prompt: "You are reviewing category: Code Quality & Best Practices.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the code-quality-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**Agent call 10:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review testing adequacy"
+prompt: "You are reviewing category: Testing Adequacy.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the testing-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**Agent call 11:**
+```
+subagent_type: "compact-core:reviewer"
+description: "Review documentation"
+prompt: "You are reviewing category: Documentation.
+Files to review: [INSERT FILE LIST].
+Invoke the compact-core:compact-review skill. Read the documentation-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+```
+
+**CRITICAL: All 11 Agent tool calls MUST be in a single message to ensure concurrent execution.**
+
+## Step 4: Consolidated Report
+
+After ALL reviewers complete, produce the consolidated report.
+
+**Ordering rules:**
+1. **Privacy & Disclosure is ALWAYS the first category** — regardless of severity
+2. Remaining categories ordered by highest severity found (Critical > High > Medium > Low > Suggestions)
+3. Within each category: Critical → High → Medium → Low → Suggestions
+4. Deduplicate issues found by multiple reviewers (keep the most detailed version)
+5. Aggregate all Positive Highlights at the end
+
+**Report format:**
+
+```
+# Compact Code Review Report
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | N |
+| High | N |
+| Medium | N |
+| Low | N |
+| Suggestions | N |
+
+**Files reviewed:** [list]
+
+---
+
+## 1. Privacy & Disclosure
+
+[Privacy findings — ALWAYS FIRST]
+
+---
+
+## 2. [Next category by severity]
+
+[Findings]
+
+---
+
+[... remaining categories ...]
+
+---
+
+## Positive Highlights
+
+[Aggregated from all reviewers — what was done well]
+```
+
+Present the report to the user.

--- a/plugins/compact-core/commands/review-compact.md
+++ b/plugins/compact-core/commands/review-compact.md
@@ -28,7 +28,7 @@ If `$ARGUMENTS` provides a path, use it. Otherwise, find all relevant files:
 # Find all Compact and related files
 find . -name "*.compact" -not -path "*/node_modules/*" -not -path "*/.compact/*"
 find . -name "*.ts" -not -path "*/node_modules/*" -not -path "*/.compact/*" | grep -iE "(witness|private)" || true
-find . -name "*.test.ts" -o -name "*.spec.ts" -not -path "*/node_modules/*" | head -20
+find . \( -name "*.test.ts" -o -name "*.spec.ts" \) -not -path "*/node_modules/*" | head -20
 ```
 
 Collect the file list and present it to the user for confirmation.
@@ -105,7 +105,7 @@ subagent_type: "compact-core:reviewer"
 description: "Review token & economic security"
 prompt: "You are reviewing category: Token & Economic Security.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the token-security-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+Invoke the compact-core:compact-review skill. Read the token-security-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
 ```
 
 **Agent call 4:**
@@ -114,7 +114,7 @@ subagent_type: "compact-core:reviewer"
 description: "Review concurrency & contention"
 prompt: "You are reviewing category: Concurrency & Contention.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the concurrency-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+Invoke the compact-core:compact-review skill. Read the concurrency-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
 ```
 
 **Agent call 5:**
@@ -123,7 +123,7 @@ subagent_type: "compact-core:reviewer"
 description: "Review compilation & types"
 prompt: "You are reviewing category: Compilation & Type Safety.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the compilation-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+Invoke the compact-core:compact-review skill. Read the compilation-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
 ```
 
 **Agent call 6:**
@@ -132,7 +132,7 @@ subagent_type: "compact-core:reviewer"
 description: "Review performance & efficiency"
 prompt: "You are reviewing category: Performance & Circuit Efficiency.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the performance-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+Invoke the compact-core:compact-review skill. Read the performance-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
 ```
 
 **Agent call 7:**
@@ -141,7 +141,7 @@ subagent_type: "compact-core:reviewer"
 description: "Review witness consistency"
 prompt: "You are reviewing category: Witness-Contract Consistency.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the witness-consistency-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+Invoke the compact-core:compact-review skill. Read the witness-consistency-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
 ```
 
 **Agent call 8:**
@@ -150,7 +150,7 @@ subagent_type: "compact-core:reviewer"
 description: "Review architecture & state"
 prompt: "You are reviewing category: Architecture, State Design & Composability.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the architecture-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+Invoke the compact-core:compact-review skill. Read the architecture-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
 ```
 
 **Agent call 9:**
@@ -159,7 +159,7 @@ subagent_type: "compact-core:reviewer"
 description: "Review code quality"
 prompt: "You are reviewing category: Code Quality & Best Practices.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the code-quality-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+Invoke the compact-core:compact-review skill. Read the code-quality-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
 ```
 
 **Agent call 10:**
@@ -168,7 +168,7 @@ subagent_type: "compact-core:reviewer"
 description: "Review testing adequacy"
 prompt: "You are reviewing category: Testing Adequacy.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the testing-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+Invoke the compact-core:compact-review skill. Read the testing-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
 ```
 
 **Agent call 11:**
@@ -177,7 +177,7 @@ subagent_type: "compact-core:reviewer"
 description: "Review documentation"
 prompt: "You are reviewing category: Documentation.
 Files to review: [INSERT FILE LIST].
-Invoke the compact-core:compact-review skill. Read the documentation-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels."
+Invoke the compact-core:compact-review skill. Read the documentation-review reference from the Category Reference Map. Apply every checklist item systematically. Report findings using the structured output format with severity levels (Critical, High, Medium, Low, Suggestions). End with Positive Highlights."
 ```
 
 **CRITICAL: All 11 Agent tool calls MUST be in a single message to ensure concurrent execution.**

--- a/plugins/compact-core/skills/compact-review/SKILL.md
+++ b/plugins/compact-core/skills/compact-review/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: compact-review
+description: This skill should be used when reviewing Compact smart contract code, TypeScript witness implementations, or test files for a Midnight project. It provides category-specific checklists for privacy, security, cryptographic correctness, token economics, concurrency, compilation, performance, witness-contract consistency, architecture, code quality, testing adequacy, and documentation. Use this skill when you need structured review checklists and severity classification criteria for any of these categories. Load the appropriate reference file for your assigned review category.
+---
+
+# Compact Code Review Checklists
+
+This skill contains review checklists for 11 categories of Compact smart contract review. Each reference file provides a focused checklist for one review category.
+
+## How to Use
+
+You will be assigned a **review category** by the review-compact command or coordinator. Load the reference file for your assigned category and apply every checklist item to the code under review.
+
+## Category Reference Map
+
+| Category | Reference File | Focus |
+|----------|---------------|-------|
+| Privacy & Disclosure | `privacy-review` | `disclose()` usage, witness data leaks, Set vs MerkleTree, persistentHash vs persistentCommit, salt reuse, conditional disclosure |
+| Security & Cryptographic Correctness | `security-review` | Access control, hash/commit usage, domain separation, nullifiers, commitments, Merkle paths, error leakage |
+| Token & Economic Security | `token-security-review` | Double-spend, overflow, unsafe transfers, missing receiveShielded, authorization |
+| Concurrency & Contention | `concurrency-review` | Read-then-write patterns, Counter ops, transaction conflicts |
+| Compilation & Type Safety | `compilation-review` | Deprecated syntax, return types, disclosure errors, casts, generics |
+| Performance & Circuit Efficiency | `performance-review` | Proof cost, ledger reads, MerkleTree depth, redundant computation, loops |
+| Witness-Contract Consistency | `witness-consistency-review` | Name matching, type mappings, private state patterns, WitnessContext |
+| Architecture, State Design & Composability | `architecture-review` | ADT selection, depth planning, visibility, modules, decomposition |
+| Code Quality & Best Practices | `code-quality-review` | Naming, complexity, dead code, stdlib hallucinations, idioms |
+| Testing Adequacy | `testing-review` | Edge cases, negative tests, private state testing, witness mocks |
+| Documentation | `documentation-review` | Circuit docs, witness contracts, ledger semantics |
+
+## Severity Classification
+
+Apply these severity levels consistently across all categories:
+
+| Level | Criteria | Examples |
+|-------|----------|----------|
+| **Critical** | Will cause loss of funds, data breach, or contract exploitation | Missing access control on mint, private key leaked to ledger, double-spend vulnerability |
+| **High** | Security vulnerability or privacy leak exploitable under certain conditions | Unnecessary disclose() on sensitive data, missing overflow check on token amounts |
+| **Medium** | Correctness issue, compilation problem, or significant performance concern | Wrong type cast that will fail at runtime, MerkleTree depth 32 when 10 suffices |
+| **Low** | Code quality, style, or minor best practice deviation | Inconsistent naming, unused import, missing sealed modifier |
+| **Suggestion** | Enhancement opportunity, not a problem | Could use pureCircuit for better reuse, consider adding assertion message |
+
+## Output Format
+
+For each finding, use this format:
+
+```
+- **[Issue title]** (`file:line`)
+  - **Problem:** Clear description of what is wrong
+  - **Impact:** Why this matters (security, privacy, correctness, performance)
+  - **Fix:** Suggested fix with code example when applicable
+```
+
+Group findings by severity within your category: Critical → High → Medium → Low → Suggestions.
+End with a **Positive Highlights** section noting what was done well.

--- a/plugins/compact-core/skills/compact-review/references/architecture-review.md
+++ b/plugins/compact-core/skills/compact-review/references/architecture-review.md
@@ -2,6 +2,19 @@
 
 Review checklist for the **Architecture, State Design & Composability** category. This covers ADT selection, MerkleTree depth planning, ledger visibility, contract decomposition, circuit vs witness boundary design, and state initialization. Apply every item below to the contract under review.
 
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation output reveals structural issues |
+| `midnight-extract-contract-structure` | `[shared]` | Identifies all data structure declarations, visibility modifiers, modules |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of contract architecture |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for ADT types, visibility modifiers, module syntax |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
 ## ADT Selection Checklist
 
 Check every ledger variable for correct abstract data type choice. Choosing the wrong ADT leads to privacy leaks, contention issues, or unnecessary complexity.
@@ -17,6 +30,8 @@ Check every ledger variable for correct abstract data type choice. Choosing the 
   | Anonymous + historic proofs | `HistoricMerkleTree<N, T>` | Root doesn't change on insert; regular MerkleTree invalidates existing proofs |
   | Ordered history | `List<T>` | Preserves insertion order; Set is unordered |
   | Single value | Direct `ledger var: T` | Simplest; no ADT overhead |
+
+  > **Tool:** `midnight-extract-contract-structure` lists all ledger variable declarations with their types. Cross-reference each declaration against the ADT selection decision tree above.
 
 - [ ] **Using `Field` as a counter instead of `Counter`.** If a ledger variable of type `Field` is incremented by reading its current value and writing back the incremented result, it should be a `Counter`. The `Counter` ADT provides conflict-free `increment()` and `decrement()` operations. A `Field` used as a counter causes read-modify-write contention under concurrent load.
 
@@ -110,6 +125,8 @@ Check every MerkleTree and HistoricMerkleTree declaration for appropriate depth 
 
   Note: depth 1 is invalid. The minimum valid depth is 2.
 
+  > **Tool:** `midnight-extract-contract-structure` shows all MerkleTree declarations with their depth parameters. Verify each depth against the planning table.
+
 - [ ] **Depth is not excessively large for the expected number of entries.** A tree with depth 32 supports ~4 billion entries but requires 32 hash operations per proof. If the contract will never have more than a few thousand entries, depth 16 is sufficient. Over-sizing wastes proof generation time and circuit resources.
 
   ```compact
@@ -140,6 +157,8 @@ Check every ledger variable for correct visibility modifiers. Visibility determi
   - `export ledger` — readable by anyone, queryable by DApps
   - `sealed ledger` — set only in constructor, immutable after deployment
   - `ledger` (no modifier) — internal, not directly queryable but state changes are visible on-chain
+
+  > **Tool:** `midnight-extract-contract-structure` shows the visibility modifier for each ledger variable. `midnight-list-examples` provides reference architectures showing idiomatic visibility patterns.
 
 - [ ] **Missing `export` on ledger variables that the DApp needs to query.** If the DApp front-end needs to read a ledger variable (e.g., to display the current state, check balances, show voting results), the variable must be `export ledger`. Without `export`, the DApp cannot directly query the value.
 
@@ -194,13 +213,16 @@ Check the contract for modularity and appropriate separation of concerns.
   }
   ```
 
+  > **Tool:** `midnight-extract-contract-structure` identifies module structure and imports. `midnight-search-compact` can find reference examples of module decomposition patterns.
+
 - [ ] **Shared types defined at the top level or in a shared module.** If multiple modules use the same types (enums, structs), those types should be defined at the top level or in a dedicated shared module, not duplicated across modules.
 
-- [ ] **Re-export pattern for public interface.** If internal modules contain circuits that should be part of the contract's public API, use the re-export pattern to expose them cleanly.
+- [ ] **Re-export pattern for public interface.** If internal modules contain circuits that should be part of the contract's public API, import the module and re-export the desired functions.
 
   ```compact
   // Re-export pattern for public interface
-  export { func } from InternalModule;
+  import InternalModule;
+  export { func };
   ```
 
 - [ ] **Module boundaries align with trust boundaries.** If different parts of the contract have different access control requirements (e.g., admin functions vs user functions), they should be in separate modules. This makes it easier to audit access control by module boundary.
@@ -235,9 +257,9 @@ Check the division of logic between circuit (on-chain verification) and witness 
 
 - [ ] **Rule of thumb: minimum logic in circuit, maximum in witness.** The circuit only verifies what the witness computed. Every operation in a circuit adds to proof generation time and cost. Move computation to the witness whenever possible, and have the circuit assert correctness of the result.
 
-- [ ] **Constructor does not access witness functions.** The constructor is called at deployment time and does not have access to witness functions. All initialization must use values passed as constructor parameters or use `default<T>`.
+- [ ] **Constructor witness usage is valid but uncommon.** Constructors in Compact can access witness functions, but the typical pattern is to pass initialization values as constructor parameters. If a constructor calls a witness, verify that the witness is implemented correctly in the TypeScript provider and that the deployment workflow supports witness execution at deploy time.
 
-  Real-world pattern from micro-dao:
+  Real-world pattern from micro-dao (parameters preferred over witnesses for clarity):
 
   ```compact
   constructor(organizer_secret_key: Bytes<32>, costs_param: Costs) {
@@ -313,6 +335,17 @@ Quick reference of common architecture anti-patterns in Compact contracts.
 | MerkleTree depth 32 for < 1,000 entries | 32 hash operations per proof when 10 would suffice; wastes proof generation time | Size depth to expected capacity: depth 10 for < 1,000, depth 16 for < 10,000 |
 | Missing `sealed` on deployment-time constants | Value appears mutable; a bug could accidentally overwrite owner address or protocol parameters | Use `sealed ledger` for values set once in constructor and never modified |
 | All logic in circuit, nothing in witness | Circuit operations are expensive (proof generation cost); complex computation in circuit bloats proof time | Move computation to witness; circuit only verifies the result with assertions |
-| Witness call in constructor | Constructor has no access to witness functions; will fail at deployment | Pass all initialization values as constructor parameters; derive values using pure circuits only |
+| Complex witness calls in constructor | Constructors can access witnesses, but complex witness logic at deployment time complicates the deployment workflow and is harder to test | Prefer passing initialization values as constructor parameters for simplicity and testability |
 | Non-ADT ledger variable not initialized in constructor | Variable has undefined initial value; behavior on first read is unpredictable | Explicitly initialize all `Field`, `Uint`, `Bytes`, `Boolean`, and enum ledger variables in the constructor |
 | Single monolithic contract with unrelated concerns | Harder to audit, test, and maintain; access control review becomes complex | Split into modules using `module Name { ... }` with clear separation of concerns |
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Use `skipZk=true` for syntax validation. |
+| `midnight-extract-contract-structure` | Deep structural analysis: data structure declarations, visibility modifiers, module organization. |
+| `midnight-analyze-contract` | Static analysis of contract architecture and patterns. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference including ADT types and module syntax. |
+| `midnight-list-examples` | List available example contracts for reference architectures and idiomatic patterns. |
+| `midnight-search-compact` | Semantic search across Compact code for architectural patterns. |

--- a/plugins/compact-core/skills/compact-review/references/architecture-review.md
+++ b/plugins/compact-core/skills/compact-review/references/architecture-review.md
@@ -1,0 +1,318 @@
+# Architecture, State Design & Composability Review Checklist
+
+Review checklist for the **Architecture, State Design & Composability** category. This covers ADT selection, MerkleTree depth planning, ledger visibility, contract decomposition, circuit vs witness boundary design, and state initialization. Apply every item below to the contract under review.
+
+## ADT Selection Checklist
+
+Check every ledger variable for correct abstract data type choice. Choosing the wrong ADT leads to privacy leaks, contention issues, or unnecessary complexity.
+
+- [ ] **ADT Selection Decision Tree.** For each piece of ledger state, verify the chosen data type is appropriate for the use case. Refer to this decision table:
+
+  | Need | Best ADT | Why Not Others |
+  |------|----------|----------------|
+  | Counting occurrences | `Counter` | Conflict-free increments; `Field` would need read-modify-write |
+  | Key-value store (public keys) | `Map<K, V>` | Direct lookup; Set can't store values |
+  | Unique membership (public) | `Set<T>` | Built-in member check; Map wastes value slot |
+  | Anonymous membership (private) | `MerkleTree<N, T>` | Only insert hides leaf; Set reveals members |
+  | Anonymous + historic proofs | `HistoricMerkleTree<N, T>` | Root doesn't change on insert; regular MerkleTree invalidates existing proofs |
+  | Ordered history | `List<T>` | Preserves insertion order; Set is unordered |
+  | Single value | Direct `ledger var: T` | Simplest; no ADT overhead |
+
+- [ ] **Using `Field` as a counter instead of `Counter`.** If a ledger variable of type `Field` is incremented by reading its current value and writing back the incremented result, it should be a `Counter`. The `Counter` ADT provides conflict-free `increment()` and `decrement()` operations. A `Field` used as a counter causes read-modify-write contention under concurrent load.
+
+  ```compact
+  // BAD — Field used as a counter; read-modify-write contention
+  export ledger vote_count: Field;
+
+  export circuit vote(): [] {
+    const current = vote_count;
+    vote_count = current + 1;
+  }
+
+  // GOOD — Counter with conflict-free increment
+  export ledger vote_count: Counter;
+
+  export circuit vote(): [] {
+    vote_count.increment(1);
+  }
+  ```
+
+- [ ] **Using `Map<K, V>` where `Set<T>` suffices.** If a Map's values are never read (e.g., `Map<Bytes<32>, Boolean>` used only for membership checks), it wastes a value slot. Use `Set<T>` when only membership matters.
+
+  ```compact
+  // BAD — Map used only for membership; value is always true
+  export ledger allowlist: Map<Bytes<32>, Boolean>;
+
+  export circuit check(addr: Bytes<32>): [] {
+    assert(allowlist.member(addr), "Not allowed");
+  }
+
+  // GOOD — Set is the right ADT for pure membership
+  export ledger allowlist: Set<Bytes<32>>;
+
+  export circuit check(addr: Bytes<32>): [] {
+    assert(allowlist.member(addr), "Not allowed");
+  }
+  ```
+
+- [ ] **Using `Set<T>` where `MerkleTree<N, T>` is needed for privacy.** If membership should be anonymous (the observer should not learn which member acted), `Set` is the wrong choice because Set operations reveal the exact element. Use `MerkleTree` (or `HistoricMerkleTree`) with a nullifier pattern instead.
+
+  ```compact
+  // BAD — Set reveals member identity
+  export ledger members: Set<Bytes<32>>;
+
+  export circuit act(pk: Bytes<32>): [] {
+    assert(members.member(disclose(pk)), "Not a member");
+  }
+
+  // GOOD — MerkleTree hides member identity
+  export ledger members: HistoricMerkleTree<16, Bytes<32>>;
+  export ledger usedNullifiers: Set<Bytes<32>>;
+
+  export circuit act(
+    path: MerkleTreePath<16, Bytes<32>>,
+    sk: Bytes<32>
+  ): [] {
+    const digest = merkleTreePathRoot<16, Bytes<32>>(path);
+    assert(members.checkRoot(disclose(digest)), "Not a member");
+    const nullifier = persistentHash<Vector<2, Bytes<32>>>(
+      [pad(32, "app:act-nul:"), sk]
+    );
+    assert(!usedNullifiers.member(disclose(nullifier)), "Already acted");
+    usedNullifiers.insert(disclose(nullifier));
+  }
+  ```
+
+- [ ] **Using `MerkleTree` where `HistoricMerkleTree` is needed.** If a contract uses `MerkleTree` for membership proofs and members may join concurrently, existing proofs become invalid when a new leaf is inserted (root changes). `HistoricMerkleTree` retains previous roots so older paths remain valid. Use `HistoricMerkleTree` when membership proofs must persist across state changes.
+
+  ```compact
+  // BAD — concurrent inserts invalidate existing proofs
+  export ledger members: MerkleTree<16, Bytes<32>>;
+
+  // GOOD — old proofs remain valid after new inserts
+  export ledger members: HistoricMerkleTree<16, Bytes<32>>;
+  ```
+
+- [ ] **Using `List<T>` when insertion order is not needed.** `List` preserves insertion order but is contention-prone under concurrent pushes. If ordering does not matter, `Set` or `Map` is a better choice. Use `List` only when ordered history is a genuine requirement.
+
+## MerkleTree Depth Planning Checklist
+
+Check every MerkleTree and HistoricMerkleTree declaration for appropriate depth sizing. Depth determines maximum capacity (2^depth leaves) and directly affects proof generation cost.
+
+- [ ] **MerkleTree depth matches expected capacity.** Refer to this planning table:
+
+  | Expected Entries | Minimum Depth | Recommended Depth | Notes |
+  |-----------------|---------------|-------------------|-------|
+  | < 100 | 7 | 10 | Small application |
+  | < 10,000 | 14 | 16 | Medium application |
+  | < 1,000,000 | 20 | 22 | Large application |
+  | < 1B | 30 | 32 | Maximum practical size |
+
+  Note: depth 1 is invalid. The minimum valid depth is 2.
+
+- [ ] **Depth is not excessively large for the expected number of entries.** A tree with depth 32 supports ~4 billion entries but requires 32 hash operations per proof. If the contract will never have more than a few thousand entries, depth 16 is sufficient. Over-sizing wastes proof generation time and circuit resources.
+
+  ```compact
+  // BAD — depth 32 for a contract expecting at most 1,000 members
+  export ledger members: MerkleTree<32, Bytes<32>>;
+
+  // GOOD — depth 16 gives 65,536 capacity with reasonable proof cost
+  export ledger members: MerkleTree<16, Bytes<32>>;
+  ```
+
+- [ ] **Depth is not too small for expected growth.** Under-sizing a MerkleTree means it will run out of capacity. Consider future growth, not just current needs. Once deployed, the tree depth cannot be changed.
+
+  ```compact
+  // BAD — depth 4 supports only 16 entries; will fill up quickly
+  export ledger members: MerkleTree<4, Bytes<32>>;
+
+  // GOOD — depth 10 supports 1,024 entries with room to grow
+  export ledger members: MerkleTree<10, Bytes<32>>;
+  ```
+
+- [ ] **Depth is at least 2.** Depth 1 is invalid in Compact. Any MerkleTree declaration with depth less than 2 will fail to compile.
+
+## Visibility Checklist
+
+Check every ledger variable for correct visibility modifiers. Visibility determines what external parties and DApps can observe and query.
+
+- [ ] **Visibility reference.** Understand the available modifiers:
+  - `export ledger` — readable by anyone, queryable by DApps
+  - `sealed ledger` — set only in constructor, immutable after deployment
+  - `ledger` (no modifier) — internal, not directly queryable but state changes are visible on-chain
+
+- [ ] **Missing `export` on ledger variables that the DApp needs to query.** If the DApp front-end needs to read a ledger variable (e.g., to display the current state, check balances, show voting results), the variable must be `export ledger`. Without `export`, the DApp cannot directly query the value.
+
+  ```compact
+  // BAD — DApp cannot query the current state
+  ledger state: Field;
+
+  // GOOD — DApp can read the state
+  export ledger state: Field;
+  ```
+
+- [ ] **Unnecessary `export` on ledger variables that should be internal.** If a ledger variable is used only for internal contract logic and does not need to be queried by external parties, `export` unnecessarily exposes it. While the data is on-chain regardless, `export` makes it trivially accessible and signals it as part of the public API.
+
+- [ ] **Missing `sealed` on configuration values set at deployment.** Values that are set once in the constructor and never modified (e.g., owner address, token name, protocol parameters) should be `sealed`. Without `sealed`, the variable appears mutable, and a bug could accidentally overwrite it. The `sealed` modifier enforces immutability after construction.
+
+  ```compact
+  // BAD — authority can be accidentally overwritten after deployment
+  export ledger authority: Bytes<32>;
+
+  // GOOD — sealed enforces immutability after constructor
+  export sealed ledger authority: Bytes<32>;
+  ```
+
+  Real-world pattern from midnames:
+
+  ```compact
+  export sealed ledger default_context: Context;
+  export sealed ledger default_pubkey: Bytes<32>;
+  ```
+
+- [ ] **Every ledger variable: should this be `export` or internal?** Review each ledger variable and ask: does the DApp need to query this value directly? If yes, it needs `export`. If no, keeping it internal reduces the public API surface and avoids misleading external callers into depending on internal state.
+
+## Contract Decomposition Checklist
+
+Check the contract for modularity and appropriate separation of concerns.
+
+- [ ] **Is the contract trying to do too much?** A single contract file handling multiple unrelated concerns (e.g., token management, governance, and user profiles) is harder to audit, test, and maintain. Consider splitting into separate modules.
+
+- [ ] **Module system used for separation of concerns.** Compact supports `module Name { ... }` for grouping related state and logic. If the contract has multiple logical subsystems, they should be organized into modules.
+
+  ```compact
+  module karol {
+    export ledger round: Counter;
+    export ledger fooBar: Map<Field, Field>;
+  }
+
+  import karol prefix $;
+
+  constructor() {
+      const p = $round;
+      const z = $fooBar.lookup(1);
+  }
+  ```
+
+- [ ] **Shared types defined at the top level or in a shared module.** If multiple modules use the same types (enums, structs), those types should be defined at the top level or in a dedicated shared module, not duplicated across modules.
+
+- [ ] **Re-export pattern for public interface.** If internal modules contain circuits that should be part of the contract's public API, use the re-export pattern to expose them cleanly.
+
+  ```compact
+  // Re-export pattern for public interface
+  export { func } from InternalModule;
+  ```
+
+- [ ] **Module boundaries align with trust boundaries.** If different parts of the contract have different access control requirements (e.g., admin functions vs user functions), they should be in separate modules. This makes it easier to audit access control by module boundary.
+
+## Circuit vs Witness Boundary Checklist
+
+Check the division of logic between circuit (on-chain verification) and witness (off-chain computation) for correctness and efficiency.
+
+- [ ] **Circuit contains only verification logic.** The circuit (on-chain code) should contain the minimum logic needed to verify correctness: state reads, assertions, state updates, and disclosure. Heavy computation should be performed in the witness (off-chain) and verified in the circuit.
+
+  ```compact
+  // BAD — complex computation inside circuit increases proof cost
+  export circuit process(data: Vector<100, Field>): [] {
+    // Sorting, searching, aggregating all inside circuit
+    // Every operation adds to proof generation time
+    let sum = 0;
+    for (let i = 0; i < 100; i++) {
+      sum = sum + data[i];
+    }
+    result = disclose(sum);
+  }
+
+  // GOOD — witness computes, circuit verifies
+  export circuit process(expected_sum: Field): [] {
+    // Witness computed the sum off-chain
+    // Circuit only verifies and stores the result
+    result = disclose(expected_sum);
+  }
+  ```
+
+- [ ] **Witness handles off-chain computation and private data access.** Witnesses should perform complex algorithms, access external data sources, read local secret keys, and prepare data for the circuit. The circuit then verifies the results.
+
+- [ ] **Rule of thumb: minimum logic in circuit, maximum in witness.** The circuit only verifies what the witness computed. Every operation in a circuit adds to proof generation time and cost. Move computation to the witness whenever possible, and have the circuit assert correctness of the result.
+
+- [ ] **Constructor does not access witness functions.** The constructor is called at deployment time and does not have access to witness functions. All initialization must use values passed as constructor parameters or use `default<T>`.
+
+  Real-world pattern from micro-dao:
+
+  ```compact
+  constructor(organizer_secret_key: Bytes<32>, costs_param: Costs) {
+    organizer = public_key(organizer_secret_key);
+    state = LedgerState.setup;
+    costs = disclose(costs_param);
+  }
+  ```
+
+- [ ] **Private data never passed directly to circuit parameters.** Circuits receive their private inputs through witness functions. If a circuit parameter appears to be a secret (e.g., a secret key), verify it arrives through a witness call within the circuit body, not as an `export circuit` parameter visible to the caller.
+
+## State Initialization Checklist
+
+Check the constructor and ledger variable declarations for correct and complete initialization.
+
+- [ ] **All ledger variables must have deterministic initial values.** Ledger state must be deterministic at deployment. Every ledger variable should have a known initial value set in the constructor or provided by the ADT's default behavior.
+
+- [ ] **Constructor must initialize all non-ADT ledger variables.** Simple types (`Field`, `Uint<N>`, `Bytes<N>`, `Boolean`, enums) do not auto-initialize. The constructor must explicitly set them or use `default<T>`.
+
+  ```compact
+  // BAD — non-ADT ledger variable not initialized in constructor
+  export ledger owner: Bytes<32>;
+  export ledger state: Field;
+
+  constructor() {
+    // owner and state are never set — undefined initial values
+  }
+
+  // GOOD — all non-ADT ledger variables initialized
+  export ledger owner: Bytes<32>;
+  export ledger state: Field;
+
+  constructor(owner_key: Bytes<32>) {
+    owner = owner_key;
+    state = 0;
+  }
+  ```
+
+- [ ] **ADTs auto-initialize to empty.** `Counter`, `Map`, `Set`, `MerkleTree`, `HistoricMerkleTree`, and `List` auto-initialize to their empty state. They do not need explicit initialization in the constructor. Adding unnecessary initialization code for ADTs is harmless but clutters the constructor.
+
+  ```compact
+  // These auto-initialize — no constructor code needed
+  export ledger vote_count: Counter;
+  export ledger balances: Map<Bytes<32>, Field>;
+  export ledger members: Set<Bytes<32>>;
+  export ledger tree: MerkleTree<16, Bytes<32>>;
+  ```
+
+- [ ] **`Field`, `Uint`, `Bytes`, `Boolean`: must be explicitly set or use `default<T>`.** For primitive types, either initialize them in the constructor with a specific value or use `default<T>` to get the zero/false default. Leaving them uninitialized is a bug.
+
+- [ ] **Sealed ledger variables initialized in constructor.** Every `sealed ledger` variable must be set in the constructor. After construction, sealed variables cannot be modified. If a sealed variable is not set in the constructor, it remains at its default value permanently.
+
+  ```compact
+  export sealed ledger token_name: Bytes<32>;
+  export sealed ledger max_supply: Field;
+
+  constructor(name: Bytes<32>, supply: Field) {
+    token_name = name;
+    max_supply = supply;
+  }
+  ```
+
+## Anti-Patterns Table
+
+Quick reference of common architecture anti-patterns in Compact contracts.
+
+| Anti-Pattern | Why It's Wrong | Correct Approach |
+|---|---|---|
+| `Field` used as a counter | Read-modify-write causes contention under concurrent load; also lacks semantic clarity | Use `Counter` with `increment()` and `decrement()` for conflict-free accumulation |
+| `Map<K, Boolean>` for membership | Wastes a value slot; less idiomatic; `member()` check works the same on both but Map carries unnecessary data | Use `Set<T>` for pure membership checks where values are not needed |
+| `Set<T>` for anonymous membership | Set operations reveal which element is being checked or inserted; no privacy for members | Use `MerkleTree` or `HistoricMerkleTree` with nullifier pattern for anonymous membership |
+| `MerkleTree` when proofs must survive concurrent inserts | Regular MerkleTree invalidates existing proofs when root changes on insert | Use `HistoricMerkleTree` which retains previous roots so older paths remain valid |
+| MerkleTree depth 32 for < 1,000 entries | 32 hash operations per proof when 10 would suffice; wastes proof generation time | Size depth to expected capacity: depth 10 for < 1,000, depth 16 for < 10,000 |
+| Missing `sealed` on deployment-time constants | Value appears mutable; a bug could accidentally overwrite owner address or protocol parameters | Use `sealed ledger` for values set once in constructor and never modified |
+| All logic in circuit, nothing in witness | Circuit operations are expensive (proof generation cost); complex computation in circuit bloats proof time | Move computation to witness; circuit only verifies the result with assertions |
+| Witness call in constructor | Constructor has no access to witness functions; will fail at deployment | Pass all initialization values as constructor parameters; derive values using pure circuits only |
+| Non-ADT ledger variable not initialized in constructor | Variable has undefined initial value; behavior on first read is unpredictable | Explicitly initialize all `Field`, `Uint`, `Bytes`, `Boolean`, and enum ledger variables in the constructor |
+| Single monolithic contract with unrelated concerns | Harder to audit, test, and maintain; access control review becomes complex | Split into modules using `module Name { ... }` with clear separation of concerns |

--- a/plugins/compact-core/skills/compact-review/references/code-quality-review.md
+++ b/plugins/compact-core/skills/compact-review/references/code-quality-review.md
@@ -1,0 +1,678 @@
+# Code Quality & Best Practices Review Checklist
+
+Review checklist for the **Code Quality & Best Practices** category. This covers naming conventions, circuit complexity, dead code detection, standard library usage verification, Compact idioms, and code duplication. These items catch maintainability and correctness issues that do not fall under security or performance but still affect long-term contract health. Apply every item below to the contract under review.
+
+## Naming Conventions Checklist
+
+Check every identifier in the contract for consistent and idiomatic naming. Compact follows specific conventions that differ from Solidity, Rust, and TypeScript. Inconsistent naming reduces readability and makes review harder.
+
+- [ ] **Circuit names should use camelCase.** All circuits — exported, internal, and pure — should follow camelCase naming. This matches the convention used across the Compact standard library and official examples.
+
+  ```compact
+  // BAD — PascalCase or snake_case circuit names
+  circuit TransferTokens(to: Bytes<32>, amount: Field): [] {
+    // ...
+  }
+  circuit check_balance(account: Bytes<32>): Field {
+    // ...
+  }
+
+  // GOOD — camelCase circuit names
+  circuit transferTokens(to: Bytes<32>, amount: Field): [] {
+    // ...
+  }
+  circuit checkBalance(account: Bytes<32>): Field {
+    // ...
+  }
+  ```
+
+- [ ] **Ledger variable names should use camelCase (or snake_case if the project is consistent).** Ledger variables appear in the contract's public API when exported. The primary convention is camelCase, but snake_case is acceptable if the entire project uses it consistently. Mixing both styles in a single contract is a code quality issue.
+
+  ```compact
+  // BAD — mixed naming styles in the same contract
+  export ledger voteCount: Counter;
+  export ledger total_supply: Field;
+  export ledger MemberList: Set<Bytes<32>>;
+
+  // GOOD — consistent camelCase throughout
+  export ledger voteCount: Counter;
+  export ledger totalSupply: Field;
+  export ledger memberList: Set<Bytes<32>>;
+
+  // ALSO GOOD — consistent snake_case throughout (if project convention)
+  export ledger vote_count: Counter;
+  export ledger total_supply: Field;
+  export ledger member_list: Set<Bytes<32>>;
+  ```
+
+- [ ] **Types, structs, and enums should use PascalCase.** All user-defined type names — structs, enums (called `enum` in Compact), and type aliases — must use PascalCase. This matches the Compact standard library types (`Maybe<T>`, `Either<A, B>`, `MerkleTreePath<N, T>`) and the built-in types (`Counter`, `Boolean`, `Field`).
+
+  ```compact
+  // BAD — lowercase or camelCase type names
+  enum gameState { setup, playing, finished }
+  struct tokenInfo {
+    owner: Bytes<32>;
+    amount: Field;
+  }
+
+  // GOOD — PascalCase type names
+  enum GameState { Setup, Playing, Finished }
+  struct TokenInfo {
+    owner: Bytes<32>;
+    amount: Field;
+  }
+  ```
+
+- [ ] **Enum variants should use PascalCase (or UPPER_SNAKE_CASE if the project is consistent).** Enum variants follow PascalCase by default, matching the convention in official examples. UPPER_SNAKE_CASE is acceptable if the project uses it consistently throughout.
+
+  ```compact
+  // BAD — mixed variant naming styles
+  enum State { setup, IN_PROGRESS, Completed }
+
+  // GOOD — consistent PascalCase variants
+  enum State { Setup, InProgress, Completed }
+
+  // ALSO GOOD — consistent UPPER_SNAKE_CASE variants (if project convention)
+  enum State { SETUP, IN_PROGRESS, COMPLETED }
+  ```
+
+- [ ] **Witness function names should use camelCase and be descriptive of their purpose.** Witnesses are the bridge between off-chain TypeScript and on-chain Compact. Their names should clearly communicate what data they provide. Common prefixes include `local` for secret state, `get` for retrieval, and `context` for environmental data.
+
+  ```compact
+  // BAD — vague or inconsistent witness names
+  witness key(): Bytes<32>;
+  witness data(): Field;
+  witness GetPath(): MerkleTreePath<16, Bytes<32>>;
+
+  // GOOD — descriptive camelCase witness names
+  witness localSecretKey(): Bytes<32>;
+  witness getProposalData(): Field;
+  witness contextPathOf(commitment: Bytes<32>): MerkleTreePath<16, Bytes<32>>;
+  ```
+
+- [ ] **Module names should use PascalCase.** Modules are namespaces and follow the same convention as types. A module name in camelCase or snake_case is inconsistent with the language idiom.
+
+  ```compact
+  // BAD — non-PascalCase module names
+  module token_helpers { /* ... */ }
+  module auth { /* ... */ }
+
+  // GOOD — PascalCase module names
+  module TokenHelpers { /* ... */ }
+  module Auth { /* ... */ }
+  ```
+
+## Circuit Complexity Checklist
+
+Check every circuit for excessive complexity. Long circuits with deep nesting are harder to audit, more prone to bugs, and more expensive to prove. Each circuit should have a single, clear responsibility.
+
+- [ ] **Circuit violates single responsibility.** A circuit should do one logical thing. If a circuit performs authorization, then modifies state, then emits a result, and then updates auxiliary data structures for an unrelated subsystem, it is doing too much. Split it into focused helper circuits composed by the exported circuit.
+
+  ```compact
+  // BAD — one circuit doing authorization, token transfer, membership update,
+  // and vote counting all at once
+  export circuit doEverything(
+    sk: Bytes<32>,
+    to: Bytes<32>,
+    amount: Field,
+    proposalId: Field
+  ): [] {
+    // Authorization
+    const pk = disclose(publicKey(sk));
+    assert(authority == pk, "Not authorized");
+    // Token transfer
+    const fromBalance = balances.lookup(pk);
+    assert(fromBalance >= amount, "Insufficient balance");
+    balances.insert(pk, fromBalance - amount);
+    balances.insert(to, balances.lookup(to) + amount);
+    // Membership update
+    members.insert(disclose(to));
+    // Vote counting
+    votes.increment(1);
+  }
+
+  // GOOD — decomposed into focused helper circuits
+  circuit verifyAuthority(sk: Bytes<32>): Bytes<32> {
+    const pk = disclose(publicKey(sk));
+    assert(authority == pk, "Not authorized");
+    return pk;
+  }
+
+  circuit transferBalance(from: Bytes<32>, to: Bytes<32>, amount: Field): [] {
+    assert(balances.member(from), "Sender not found");
+    const fromBalance = balances.lookup(from);
+    assert(fromBalance >= amount, "Insufficient balance");
+    balances.insert(from, fromBalance - amount);
+    const toBalance = balances.member(to) ? balances.lookup(to) : 0;
+    balances.insert(to, toBalance + amount);
+  }
+
+  export circuit transfer(sk: Bytes<32>, to: Bytes<32>, amount: Field): [] {
+    const pk = verifyAuthority(sk);
+    transferBalance(pk, to, amount);
+  }
+  ```
+
+- [ ] **Circuit exceeds ~50 lines.** While not a hard rule, a circuit longer than ~50 lines is a strong signal that it should be decomposed. Long circuits are difficult to review line-by-line, increase the chance of subtle bugs, and make it harder to reuse logic across the contract.
+
+- [ ] **Deeply nested control flow.** More than 2-3 levels of nesting (if inside if inside for, etc.) makes the circuit hard to reason about. Flatten by extracting conditions into helper circuits or using guard-then-act patterns (assert early, then proceed linearly).
+
+  ```compact
+  // BAD — deeply nested control flow
+  export circuit process(items: Vector<10, Field>, threshold: Field): [] {
+    for (let i = 0; i < 10; i++) {
+      if (items[i] > 0) {
+        if (items[i] < threshold) {
+          if (balances.member(items[i] as Bytes<32>)) {
+            // ... deeply nested logic
+          }
+        }
+      }
+    }
+  }
+
+  // GOOD — flattened with guard assertions and helper circuit
+  circuit isValidItem(item: Field, threshold: Field): Boolean {
+    return item > 0 && item < threshold;
+  }
+
+  export circuit process(items: Vector<10, Field>, threshold: Field): [] {
+    for (let i = 0; i < 10; i++) {
+      if (isValidItem(items[i], threshold)) {
+        processItem(items[i]);
+      }
+    }
+  }
+  ```
+
+- [ ] **Pure circuits not used for reusable logic.** If a circuit does not read or write any ledger state, it should be declared as a `pure circuit`. This signals to readers (and the compiler) that the circuit has no side effects. Look for internal circuits that only compute values from their parameters without accessing ledger variables.
+
+  ```compact
+  // BAD — circuit marked as regular but has no side effects
+  circuit computeHash(domain: Bytes<32>, value: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<2, Bytes<32>>>([domain, value]);
+  }
+
+  // GOOD — pure circuit signals no side effects
+  pure circuit computeHash(domain: Bytes<32>, value: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<2, Bytes<32>>>([domain, value]);
+  }
+  ```
+
+## Dead Code Detection Checklist
+
+Check the contract for code that serves no purpose. Dead code increases audit surface, confuses reviewers, and may mask missing functionality.
+
+- [ ] **Unused ledger variables (declared but never read or written).** A ledger variable that is declared but never referenced in any circuit adds to the contract's state footprint without providing value. It may indicate incomplete implementation or leftover code from a removed feature.
+
+  ```compact
+  // BAD — ledger variable declared but never used in any circuit
+  export ledger oldBalance: Field;
+  export ledger currentBalance: Field;
+  export ledger balances: Map<Bytes<32>, Field>;
+
+  export circuit getBalance(account: Bytes<32>): Field {
+    // Only uses balances; oldBalance and currentBalance are never touched
+    assert(balances.member(account), "Account not found");
+    return disclose(balances.lookup(account));
+  }
+  ```
+
+  Review action: search every circuit body for references to each ledger variable. Any ledger variable with zero references should be flagged for removal or investigation.
+
+- [ ] **Unused circuits (defined but never called).** An internal or pure circuit that is defined but never called from any other circuit is dead code. It increases audit surface without contributing to contract behavior. Note: `export circuit` declarations are always callable externally, so they are not dead code even if not called internally.
+
+  ```compact
+  // BAD — helper circuit defined but never called
+  circuit computeNullifier(sk: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<2, Bytes<32>>>([pad(32, "app:nul:"), sk]);
+  }
+
+  // This circuit is the only exported one and does not call computeNullifier
+  export circuit register(pk: Bytes<32>): [] {
+    members.insert(disclose(pk));
+  }
+  ```
+
+  Review action: for every non-exported circuit, search for at least one call site. If none exists, flag it.
+
+- [ ] **Unreachable code after unconditional `assert(false)` or early structural exits.** Code after `assert(false, ...)` can never execute because the assertion always fails. This is sometimes used as a placeholder but should not appear in production code.
+
+  ```compact
+  // BAD — unreachable code after assert(false)
+  export circuit placeholder(): [] {
+    assert(false, "Not implemented");
+    // Everything below is unreachable
+    counter.increment(1);
+    state = State.Active;
+  }
+  ```
+
+- [ ] **Commented-out code left in production.** Blocks of commented-out Compact code suggest incomplete refactoring. Commented-out code should be removed before review; version control preserves history.
+
+  ```compact
+  // BAD — commented-out code left in the contract
+  export circuit transfer(to: Bytes<32>, amount: Field): [] {
+    // const fee = amount / 100;
+    // treasury.insert(treasuryAddr, fee);
+    // amount = amount - fee;
+    const senderBalance = balances.lookup(sender);
+    assert(senderBalance >= amount, "Insufficient balance");
+    balances.insert(sender, senderBalance - amount);
+    balances.insert(to, amount);
+  }
+  ```
+
+- [ ] **Unused witness declarations.** A witness function declared but never called in any circuit is dead code. It adds unnecessary complexity to the TypeScript witness provider without being used on-chain.
+
+  ```compact
+  // BAD — witness declared but never called in any circuit
+  witness getTimestamp(): Field;
+  witness localSecretKey(): Bytes<32>;
+
+  export circuit register(pk: Bytes<32>): [] {
+    // Only uses pk parameter; neither witness is called
+    members.insert(disclose(pk));
+  }
+  ```
+
+## Standard Library Usage Checklist (Hallucination Guard)
+
+Verify that every standard library call in the contract actually exists in `CompactStandardLibrary`. LLM-generated Compact code frequently invents plausible-sounding functions that do not exist. Each item below lists a common hallucination and its correct replacement.
+
+- [ ] **Verify every stdlib function call exists.** For each function call in the contract, confirm it is a real `CompactStandardLibrary` function. The complete set of stdlib functions includes: `persistentHash<T>()`, `transientHash<T>()`, `persistentCommit<T>()`, `transientCommit<T>()`, `disclose()`, `assert()`, `pad()`, `default<T>()`, `some<T>()`, `none<T>()`, `left<A, B>()`, `right<A, B>()`, `publicKey()`, `slice<N>()`, `merkleTreePathRoot<N, T>()`, and ADT methods on `Counter`, `Map`, `Set`, `List`, `MerkleTree`, and `HistoricMerkleTree`.
+
+- [ ] **`hash()` does not exist.** Use `persistentHash<T>()` for deterministic hashing or `transientHash<T>()` for circuit-efficient one-time hashing. Both require an explicit type parameter.
+
+  ```compact
+  // BAD — hash() is not a Compact function
+  const h = hash(input);
+
+  // GOOD — use the specific hash function with type parameter
+  const h = persistentHash<Bytes<32>>(input);
+  ```
+
+- [ ] **`verify()` does not exist.** There is no general verification function. Use `assert()` for condition checks and `checkRoot()` for Merkle tree root verification.
+
+  ```compact
+  // BAD — verify() is not a Compact function
+  verify(proof, publicInput);
+
+  // GOOD — use assert for condition checks
+  assert(condition, "Verification failed");
+  // GOOD — use checkRoot for Merkle verification
+  assert(tree.checkRoot(disclose(root)), "Invalid root");
+  ```
+
+- [ ] **`encrypt()` / `decrypt()` do not exist.** Compact does not provide encryption. Privacy is achieved through the zero-knowledge proof system and disclosure control, not through symmetric or asymmetric encryption.
+
+  ```compact
+  // BAD — encrypt/decrypt are not Compact functions
+  const ciphertext = encrypt(plaintext, key);
+  const recovered = decrypt(ciphertext, key);
+
+  // GOOD — use commitments to hide values
+  const salt = getRandom();
+  const hidden = persistentCommit<Field>(value, salt);
+  ```
+
+- [ ] **`random()` does not exist.** Circuits are deterministic. Randomness must come from a witness function implemented in the TypeScript provider.
+
+  ```compact
+  // BAD — random() is not available in circuits
+  const nonce = random();
+
+  // GOOD — source randomness from a witness
+  witness getRandom(): Bytes<32>;
+  // Then in a circuit:
+  const nonce = getRandom();
+  ```
+
+- [ ] **`counter.value()` does not exist.** The correct method is `counter.read()`, which returns `Uint<64>`.
+
+  ```compact
+  // BAD — .value() does not exist on Counter
+  const current = counter.value();
+
+  // GOOD — use .read()
+  const current = counter.read();
+  ```
+
+- [ ] **`map.get()` does not exist.** The correct method is `map.lookup()`. LLMs hallucinate `.get()` from JavaScript's `Map`.
+
+  ```compact
+  // BAD — .get() does not exist on Map
+  const balance = balances.get(account);
+
+  // GOOD — use .lookup()
+  const balance = balances.lookup(account);
+  ```
+
+- [ ] **`map.has()` does not exist.** The correct method is `map.member()`. LLMs hallucinate `.has()` from JavaScript's `Map` or `Set`.
+
+  ```compact
+  // BAD — .has() does not exist on Map
+  if (balances.has(account)) { /* ... */ }
+
+  // GOOD — use .member()
+  if (balances.member(account)) { /* ... */ }
+  ```
+
+- [ ] **`CoinInfo` does not exist.** The correct type is `ShieldedCoinInfo` (or `QualifiedShieldedCoinInfo` for qualified variants).
+
+  ```compact
+  // BAD — CoinInfo is not a valid type
+  const coin: CoinInfo = getCoinDetails();
+
+  // GOOD — use the correct type name
+  const coin: ShieldedCoinInfo = getCoinDetails();
+  ```
+
+- [ ] **`CurvePoint` does not exist.** The correct type is `EllipticCurvePoint`.
+
+  ```compact
+  // BAD — CurvePoint is not a valid type
+  const point: CurvePoint = getPoint();
+
+  // GOOD — use the correct type name
+  const point: EllipticCurvePoint = getPoint();
+  ```
+
+## Compact Idioms Checklist
+
+Check the contract for idiomatic Compact patterns. Non-idiomatic code is harder to review, may hide bugs, and misses opportunities for clarity and safety.
+
+- [ ] **Guard-then-act pattern: assert first, modify state second.** Every exported circuit should validate all preconditions at the top before performing any state modifications. This makes the circuit easier to reason about: either all assertions pass and the circuit proceeds, or a precondition fails and no state is touched.
+
+  ```compact
+  // BAD — state modified before all checks are complete
+  export circuit withdraw(amount: Field): [] {
+    const current = balances.lookup(account);
+    balances.insert(account, current - amount);  // State modified
+    assert(amount > 0, "Amount must be positive");  // Check comes AFTER modification
+    assert(current >= amount, "Insufficient");  // Check comes AFTER modification
+  }
+
+  // GOOD — all guards first, then state modifications
+  export circuit withdraw(amount: Field): [] {
+    assert(amount > 0, "Amount must be positive");
+    assert(balances.member(account), "Account not found");
+    const current = balances.lookup(account);
+    assert(current >= amount, "Insufficient balance");
+    balances.insert(account, current - amount);
+  }
+  ```
+
+- [ ] **Prefer `default<T>` over zero-construction for initial values.** When initializing a value to its type's default (zero for `Field`, false for `Boolean`, zero-bytes for `Bytes<N>`), use `default<T>` instead of manually constructing the zero value. This is self-documenting and resilient to type changes.
+
+  ```compact
+  // BAD — manual zero construction
+  const emptyHash: Bytes<32> = 0 as Field as Bytes<32>;
+  const initialState: Field = 0;
+
+  // GOOD — use default<T> for type-safe defaults
+  const emptyHash: Bytes<32> = default<Bytes<32>>;
+  const initialState: Field = default<Field>;
+  ```
+
+- [ ] **Use `pad(N, "string")` for fixed-width byte padding.** When constructing domain strings for hashing, use `pad(N, "string")` to produce a fixed-width `Bytes<N>` value. Do not manually pad with zeros or cast from arbitrary strings.
+
+  ```compact
+  // BAD — manual padding attempt
+  const domain: Bytes<32> = "myapp:pk:" as Bytes<32>;
+
+  // GOOD — use pad() for fixed-width byte construction
+  const domain: Bytes<32> = pad(32, "myapp:pk:");
+
+  // GOOD — pad() used inline in hash construction (common pattern)
+  const pk = persistentHash<Vector<2, Bytes<32>>>([
+    pad(32, "myapp:pk:"),
+    sk
+  ]);
+  ```
+
+- [ ] **Use destructuring with `slice<N>()` for vector extraction.** When extracting a contiguous sub-vector from a larger vector, use `slice<N>()` with destructuring. This is more readable and less error-prone than manual index access.
+
+  ```compact
+  // BAD — manual index access for contiguous elements
+  const first = data[0];
+  const second = data[1];
+  const third = data[2];
+
+  // GOOD — destructuring with slice for contiguous extraction
+  const [first, second, third] = slice<3>(data, 0);
+  ```
+
+- [ ] **Type-safe enum comparison: use `State.Active` not magic numbers.** Never compare state against raw numeric values. Always use the enum variant name. Magic numbers obscure intent and break if enum ordering changes.
+
+  ```compact
+  // BAD — magic number comparison; fragile and unreadable
+  assert(state == 1, "Not in active state");
+
+  // BAD — string comparison; not how Compact enums work
+  assert(state == "active", "Not in active state");
+
+  // GOOD — type-safe enum comparison
+  assert(state == State.Active, "Not in active state");
+  ```
+
+- [ ] **Consistent use of `disclose()` at the public boundary.** The `disclose()` call should appear at the point where a witness-derived value crosses into the public domain (ledger write, return from exported circuit). Wrapping values too early makes it harder to track what is public and what is private. Wrapping too late causes compiler errors.
+
+  ```compact
+  // BAD — disclose deep inside helper; unclear where value becomes public
+  circuit computePk(sk: Bytes<32>): Bytes<32> {
+    return disclose(persistentHash<Vector<2, Bytes<32>>>([
+      pad(32, "app:pk:"),
+      sk
+    ]));
+  }
+
+  export circuit register(sk: Bytes<32>): [] {
+    const pk = computePk(sk);  // Already disclosed, but not obvious
+    authority = pk;
+  }
+
+  // GOOD — disclose at the public boundary in the exported circuit
+  circuit computePk(sk: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<2, Bytes<32>>>([
+      pad(32, "app:pk:"),
+      sk
+    ]);
+  }
+
+  export circuit register(sk: Bytes<32>): [] {
+    const pk = computePk(sk);
+    authority = disclose(pk);  // Clear: this is where the value goes public
+  }
+  ```
+
+## Code Duplication Checklist
+
+Check the contract for repeated logic that should be extracted into reusable circuits. Duplication increases the chance of inconsistent fixes, makes the contract harder to maintain, and bloats the audit surface.
+
+- [ ] **Same logic repeated in multiple circuits: extract to a helper circuit.** If two or more exported circuits contain the same sequence of operations (e.g., authorization check, balance lookup, hash computation), extract that logic into a shared internal circuit. This ensures that a bug fix or improvement is applied once, not in every copy.
+
+  ```compact
+  // BAD — authorization logic duplicated in every exported circuit
+  export circuit transfer(to: Bytes<32>, amount: Field): [] {
+    const sk = localSecretKey();
+    const pk = disclose(publicKey(sk));
+    assert(authority == pk, "Not authorized");
+    // ... transfer logic
+  }
+
+  export circuit mint(amount: Field): [] {
+    const sk = localSecretKey();
+    const pk = disclose(publicKey(sk));
+    assert(authority == pk, "Not authorized");
+    // ... mint logic
+  }
+
+  export circuit burn(amount: Field): [] {
+    const sk = localSecretKey();
+    const pk = disclose(publicKey(sk));
+    assert(authority == pk, "Not authorized");
+    // ... burn logic
+  }
+
+  // GOOD — authorization extracted to a helper circuit
+  circuit requireAuthority(): Bytes<32> {
+    const sk = localSecretKey();
+    const pk = disclose(publicKey(sk));
+    assert(authority == pk, "Not authorized");
+    return pk;
+  }
+
+  export circuit transfer(to: Bytes<32>, amount: Field): [] {
+    const pk = requireAuthority();
+    // ... transfer logic
+  }
+
+  export circuit mint(amount: Field): [] {
+    requireAuthority();
+    // ... mint logic
+  }
+
+  export circuit burn(amount: Field): [] {
+    requireAuthority();
+    // ... burn logic
+  }
+  ```
+
+- [ ] **Same validation repeated: extract to a validation circuit.** If the same set of assertions appears in multiple circuits (e.g., checking that an account exists and has sufficient balance), extract them into a dedicated validation circuit.
+
+  ```compact
+  // BAD — balance validation duplicated
+  export circuit transfer(to: Bytes<32>, amount: Field): [] {
+    assert(amount > 0, "Amount must be positive");
+    assert(balances.member(sender), "Sender not found");
+    const balance = balances.lookup(sender);
+    assert(balance >= amount, "Insufficient balance");
+    // ... transfer logic
+  }
+
+  export circuit withdraw(amount: Field): [] {
+    assert(amount > 0, "Amount must be positive");
+    assert(balances.member(sender), "Sender not found");
+    const balance = balances.lookup(sender);
+    assert(balance >= amount, "Insufficient balance");
+    // ... withdraw logic
+  }
+
+  // GOOD — validation extracted to a reusable circuit
+  circuit validateSufficientBalance(
+    account: Bytes<32>,
+    amount: Field
+  ): Field {
+    assert(amount > 0, "Amount must be positive");
+    assert(balances.member(account), "Account not found");
+    const balance = balances.lookup(account);
+    assert(balance >= amount, "Insufficient balance");
+    return balance;
+  }
+
+  export circuit transfer(to: Bytes<32>, amount: Field): [] {
+    const balance = validateSufficientBalance(sender, amount);
+    balances.insert(sender, balance - amount);
+    const toBalance = balances.member(to) ? balances.lookup(to) : 0;
+    balances.insert(to, toBalance + amount);
+  }
+
+  export circuit withdraw(amount: Field): [] {
+    const balance = validateSufficientBalance(sender, amount);
+    balances.insert(sender, balance - amount);
+  }
+  ```
+
+- [ ] **Similar struct or hash construction repeated: extract to a constructor circuit.** If the same struct literal or hash computation with the same domain string appears in multiple places, extract it into a dedicated circuit. This ensures consistency and prevents domain-string typos across copies.
+
+  ```compact
+  // BAD — same hash construction repeated with risk of domain-string typo
+  export circuit register(sk: Bytes<32>): [] {
+    const pk = persistentHash<Vector<2, Bytes<32>>>([
+      pad(32, "myapp:pk:"), sk
+    ]);
+    authority = disclose(pk);
+  }
+
+  export circuit verify(sk: Bytes<32>): [] {
+    const pk = persistentHash<Vector<2, Bytes<32>>>([
+      pad(32, "myapp:pk:"), sk  // Must match exactly — easy to mistype
+    ]);
+    assert(authority == disclose(pk), "Not authorized");
+  }
+
+  // GOOD — hash construction extracted to a dedicated circuit
+  pure circuit derivePublicKey(sk: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<2, Bytes<32>>>([
+      pad(32, "myapp:pk:"), sk
+    ]);
+  }
+
+  export circuit register(sk: Bytes<32>): [] {
+    authority = disclose(derivePublicKey(sk));
+  }
+
+  export circuit verify(sk: Bytes<32>): [] {
+    assert(authority == disclose(derivePublicKey(sk)), "Not authorized");
+  }
+  ```
+
+- [ ] **Duplicated nullifier construction across circuits.** Nullifier derivation must be identical wherever it is computed (same domain string, same inputs, same hash function). If the derivation is duplicated rather than extracted, a typo in one copy creates a subtle bug where nullifiers do not match across circuits.
+
+  ```compact
+  // BAD — nullifier constructed inline in two circuits; typo risk
+  export circuit commit(sk: Bytes<32>): [] {
+    const nul = persistentHash<Vector<3, Bytes<32>>>(
+      [pad(32, "app:vote-nul:"), round as Field as Bytes<32>, sk]
+    );
+    assert(!usedNullifiers.member(disclose(nul)), "Already committed");
+    usedNullifiers.insert(disclose(nul));
+  }
+
+  export circuit reveal(sk: Bytes<32>, value: Field): [] {
+    const nul = persistentHash<Vector<3, Bytes<32>>>(
+      [pad(32, "app:vote-nul:"), round as Field as Bytes<32>, sk]
+    );
+    assert(usedNullifiers.member(disclose(nul)), "Must commit first");
+    // ... reveal logic
+  }
+
+  // GOOD — nullifier construction extracted to a single source of truth
+  pure circuit voteNullifier(roundVal: Field, sk: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<3, Bytes<32>>>(
+      [pad(32, "app:vote-nul:"), roundVal as Bytes<32>, sk]
+    );
+  }
+
+  export circuit commit(sk: Bytes<32>): [] {
+    const nul = voteNullifier(round as Field, sk);
+    assert(!usedNullifiers.member(disclose(nul)), "Already committed");
+    usedNullifiers.insert(disclose(nul));
+  }
+
+  export circuit reveal(sk: Bytes<32>, value: Field): [] {
+    const nul = voteNullifier(round as Field, sk);
+    assert(usedNullifiers.member(disclose(nul)), "Must commit first");
+    // ... reveal logic
+  }
+  ```
+
+## Anti-Patterns Table
+
+Quick reference of common code quality anti-patterns in Compact contracts.
+
+| Anti-Pattern | Why It's Wrong | Correct Approach |
+|---|---|---|
+| Mixed naming conventions (camelCase + snake_case) in one contract | Inconsistency makes the code harder to read and review; signals careless authorship | Pick one convention and apply it consistently throughout the contract |
+| Circuit doing authorization + business logic + auxiliary updates | Violates single responsibility; harder to audit, test, and reuse individual pieces | Decompose into focused helper circuits; compose in the exported circuit |
+| Circuit > 50 lines | Difficult to review line-by-line; high chance of subtle bugs hiding in the length | Extract logical blocks into helper or pure circuits |
+| Deeply nested if/for (> 3 levels) | Hard to reason about all code paths; increases audit complexity | Flatten with guard assertions; extract inner logic to helper circuits |
+| Unused ledger variable declared but never referenced | Adds to state footprint and audit surface without contributing to behavior | Remove the variable or implement the missing feature that should use it |
+| `hash()`, `verify()`, `encrypt()`, `random()` function calls | These functions do not exist in Compact; code will not compile | Use `persistentHash<T>`/`transientHash<T>`, `assert()`, commitments, and witness functions respectively |
+| `counter.value()`, `map.get()`, `map.has()` | Wrong method names; code will not compile | Use `counter.read()`, `map.lookup()`, `map.member()` |
+| Magic numbers instead of enum variants | Fragile; breaks if enum ordering changes; obscures intent | Use `State.Active` instead of `1`; define named constants |
+| State modified before assertions | If a later assertion fails, state may be partially modified; harder to reason about correctness | Assert all preconditions first (guard), then modify state (act) |
+| Same logic copy-pasted across circuits | Bug fixes must be applied to every copy; easy to miss one; inconsistency risk | Extract shared logic to a helper or pure circuit |
+| Inline domain strings duplicated across circuits | Typo in one copy creates mismatched hashes; subtle and hard to debug | Extract hash/nullifier construction to a single pure circuit |
+| Commented-out code blocks in production | Clutters the contract; confuses reviewers; may mask incomplete refactoring | Remove commented code; rely on version control for history |

--- a/plugins/compact-core/skills/compact-review/references/code-quality-review.md
+++ b/plugins/compact-core/skills/compact-review/references/code-quality-review.md
@@ -2,6 +2,19 @@
 
 Review checklist for the **Code Quality & Best Practices** category. This covers naming conventions, circuit complexity, dead code detection, standard library usage verification, Compact idioms, and code duplication. These items catch maintainability and correctness issues that do not fall under security or performance but still affect long-term contract health. Apply every item below to the contract under review.
 
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Catches hallucinated functions and type errors |
+| `midnight-extract-contract-structure` | `[shared]` | Identifies dead code, unused declarations, structural patterns |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of code patterns |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for valid stdlib functions and types |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
 ## Naming Conventions Checklist
 
 Check every identifier in the contract for consistent and idiomatic naming. Compact follows specific conventions that differ from Solidity, Rust, and TypeScript. Inconsistent naming reduces readability and makes review harder.
@@ -63,17 +76,20 @@ Check every identifier in the contract for consistent and idiomatic naming. Comp
   }
   ```
 
-- [ ] **Enum variants should use PascalCase (or UPPER_SNAKE_CASE if the project is consistent).** Enum variants follow PascalCase by default, matching the convention in official examples. UPPER_SNAKE_CASE is acceptable if the project uses it consistently throughout.
+- [ ] **Enum variants should use a consistent naming style.** Official Compact examples use varying conventions — lowercase (`apple, pear, plum` in the language reference), UPPER_SNAKE_CASE (`UNSET, SET` in lock.compact, `VACANT, OCCUPIED` in bboard.compact), and PascalCase. The key requirement is consistency within a single contract. Mixed variant styles in the same enum is a code quality issue.
 
   ```compact
-  // BAD — mixed variant naming styles
+  // BAD — mixed variant naming styles in one enum
   enum State { setup, IN_PROGRESS, Completed }
 
   // GOOD — consistent PascalCase variants
   enum State { Setup, InProgress, Completed }
 
-  // ALSO GOOD — consistent UPPER_SNAKE_CASE variants (if project convention)
+  // ALSO GOOD — consistent UPPER_SNAKE_CASE variants (common in official examples)
   enum State { SETUP, IN_PROGRESS, COMPLETED }
+
+  // ALSO GOOD — consistent lowercase variants (matches language reference style)
+  enum State { setup, in_progress, completed }
   ```
 
 - [ ] **Witness function names should use camelCase and be descriptive of their purpose.** Witnesses are the bridge between off-chain TypeScript and on-chain Compact. Their names should clearly communicate what data they provide. Common prefixes include `local` for secret state, `get` for retrieval, and `context` for environmental data.
@@ -199,6 +215,8 @@ Check every circuit for excessive complexity. Long circuits with deep nesting ar
   }
   ```
 
+  > **Tool:** `midnight-extract-contract-structure` identifies all circuits and whether they access ledger state. Flag any non-pure circuit that could be marked `pure`. `midnight-list-examples` shows idiomatic use of `pure circuit` in reference contracts.
+
 ## Dead Code Detection Checklist
 
 Check the contract for code that serves no purpose. Dead code increases audit surface, confuses reviewers, and may mask missing functionality.
@@ -219,6 +237,8 @@ Check the contract for code that serves no purpose. Dead code increases audit su
   ```
 
   Review action: search every circuit body for references to each ledger variable. Any ledger variable with zero references should be flagged for removal or investigation.
+
+  > **Tool:** `midnight-extract-contract-structure` identifies all ledger declarations. Cross-reference each against usage in circuit bodies.
 
 - [ ] **Unused circuits (defined but never called).** An internal or pure circuit that is defined but never called from any other circuit is dead code. It increases audit surface without contributing to contract behavior. Note: `export circuit` declarations are always callable externally, so they are not dead code even if not called internally.
 
@@ -280,7 +300,9 @@ Check the contract for code that serves no purpose. Dead code increases audit su
 
 Verify that every standard library call in the contract actually exists in `CompactStandardLibrary`. LLM-generated Compact code frequently invents plausible-sounding functions that do not exist. Each item below lists a common hallucination and its correct replacement.
 
-- [ ] **Verify every stdlib function call exists.** For each function call in the contract, confirm it is a real `CompactStandardLibrary` function. The complete set of stdlib functions includes: `persistentHash<T>()`, `transientHash<T>()`, `persistentCommit<T>()`, `transientCommit<T>()`, `disclose()`, `assert()`, `pad()`, `default<T>()`, `some<T>()`, `none<T>()`, `left<A, B>()`, `right<A, B>()`, `publicKey()`, `slice<N>()`, `merkleTreePathRoot<N, T>()`, and ADT methods on `Counter`, `Map`, `Set`, `List`, `MerkleTree`, and `HistoricMerkleTree`.
+- [ ] **Verify every stdlib function call exists.** For each function call in the contract, confirm it is a real `CompactStandardLibrary` function. Key stdlib functions include: `persistentHash<T>()`, `transientHash<T>()`, `persistentCommit<T>()`, `transientCommit<T>()`, `disclose()`, `assert()`, `pad()`, `default<T>()`, `some<T>()`, `none<T>()`, `left<A, B>()`, `right<A, B>()`, `slice<N>()`, `merkleTreePathRoot<N, T>()`, `merkleTreePathRootNoLeafHash<N, T>()`, `ownPublicKey()`, `evolveNonce()`, `mergeCoin()`, `ecAdd()`, `ecMul()`, `ecMulGenerator()`, `hashToCurve()`, `degradeToTransient()`, `upgradeFromTransient()`, and ADT methods on `Counter`, `Map`, `Set`, `List`, `MerkleTree`, and `HistoricMerkleTree`, plus token operations like `mintShieldedToken()`, `sendShielded()`, `receiveShielded()`, `sendImmediateShielded()`, `mintUnshieldedToken()`, `sendUnshielded()`, `unshieldedBalance()`, `unshieldedBalanceGt()`, `unshieldedBalanceLt()`, `unshieldedBalanceGte()`, `unshieldedBalanceLte()`. Note: `publicKey()` is NOT a stdlib function — it is commonly defined as a user-created helper circuit using `persistentHash` with domain separation.
+
+  > **Tool:** `midnight-compile-contract` output will show `unknown function` or `operation undefined` errors for any hallucinated API calls. `midnight-get-latest-syntax` is the authoritative list of valid stdlib functions. Cross-reference every function call in the contract against these two sources.
 
 - [ ] **`hash()` does not exist.** Use `persistentHash<T>()` for deterministic hashing or `transientHash<T>()` for circuit-efficient one-time hashing. Both require an explicit type parameter.
 
@@ -291,6 +313,8 @@ Verify that every standard library call in the contract actually exists in `Comp
   // GOOD — use the specific hash function with type parameter
   const h = persistentHash<Bytes<32>>(input);
   ```
+
+  > **Tool:** `midnight-compile-contract` output will show `unknown function "hash"` if present.
 
 - [ ] **`verify()` does not exist.** There is no general verification function. Use `assert()` for condition checks and `checkRoot()` for Merkle tree root verification.
 
@@ -338,6 +362,8 @@ Verify that every standard library call in the contract actually exists in `Comp
   const current = counter.read();
   ```
 
+  > **Tool:** `midnight-compile-contract` output will show `operation "value" undefined for Counter`.
+
 - [ ] **`map.get()` does not exist.** The correct method is `map.lookup()`. LLMs hallucinate `.get()` from JavaScript's `Map`.
 
   ```compact
@@ -368,15 +394,18 @@ Verify that every standard library call in the contract actually exists in `Comp
   const coin: ShieldedCoinInfo = getCoinDetails();
   ```
 
-- [ ] **`CurvePoint` does not exist.** The correct type is `EllipticCurvePoint`.
+- [ ] **`CurvePoint` or `EllipticCurvePoint` do not exist.** The correct type name is `NativePoint`. Older documentation referenced `CurvePoint` or `EllipticCurvePoint`, but these have been superseded.
 
   ```compact
-  // BAD — CurvePoint is not a valid type
+  // BAD — CurvePoint and EllipticCurvePoint are not valid types
   const point: CurvePoint = getPoint();
-
-  // GOOD — use the correct type name
   const point: EllipticCurvePoint = getPoint();
+
+  // GOOD — use the current type name
+  const point: NativePoint = getPoint();
   ```
+
+  > **Tool:** `midnight-compile-contract` output will show an unknown type error. `midnight-get-latest-syntax` confirms `NativePoint` as the current type name.
 
 ## Compact Idioms Checklist
 
@@ -676,3 +705,14 @@ Quick reference of common code quality anti-patterns in Compact contracts.
 | Same logic copy-pasted across circuits | Bug fixes must be applied to every copy; easy to miss one; inconsistency risk | Extract shared logic to a helper or pure circuit |
 | Inline domain strings duplicated across circuits | Typo in one copy creates mismatched hashes; subtle and hard to debug | Extract hash/nullifier construction to a single pure circuit |
 | Commented-out code blocks in production | Clutters the contract; confuses reviewers; may mask incomplete refactoring | Remove commented code; rely on version control for history |
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Catches hallucinated functions, wrong method names, invalid types. |
+| `midnight-extract-contract-structure` | Deep structural analysis: dead code detection, unused declarations, circuit structure. |
+| `midnight-analyze-contract` | Static analysis of code patterns and quality. |
+| `midnight-get-latest-syntax` | Authoritative list of valid Compact stdlib functions, types, and methods. Ground truth for hallucination detection. |
+| `midnight-search-compact` | Semantic search across Compact code for idiomatic patterns and stdlib usage examples. |
+| `midnight-list-examples` | List available example contracts showing best practices and correct patterns. |

--- a/plugins/compact-core/skills/compact-review/references/compilation-review.md
+++ b/plugins/compact-core/skills/compact-review/references/compilation-review.md
@@ -1,0 +1,465 @@
+# Compilation & Type Safety Review Checklist
+
+Review checklist for the **Compilation & Type Safety** category. This covers deprecated syntax, incorrect return types, type casting errors, hallucinated API methods, and common compiler error patterns. LLM-generated Compact code is especially prone to these issues because training data contains outdated syntax and invented APIs. Apply every item below to the contract under review.
+
+## Syntax Error Checklist
+
+Check the contract for deprecated or invalid syntax that will cause compilation failures.
+
+- [ ] **`Void` return type instead of `[]`.** The `Void` return type has been removed from Compact. Functions (witnesses and circuits) that return no useful value must now use `[]`, signifying the empty tuple. LLMs frequently hallucinate `Void` because it appears in older documentation and is familiar from other languages.
+
+  ```compact
+  // BAD — Void is not a valid return type
+  export circuit reset(): Void {
+    counter.increment(1);
+  }
+
+  // GOOD — empty tuple [] is the correct "no return value" type
+  export circuit reset(): [] {
+    counter.increment(1);
+  }
+  ```
+
+- [ ] **Deprecated `ledger { ... }` block instead of individual `export ledger` declarations.** Older versions of Compact used a single `ledger { ... }` block to group all ledger declarations. Current Compact requires each ledger variable to be declared individually with `export ledger`.
+
+  ```compact
+  // BAD — ledger block syntax is deprecated
+  ledger {
+    counter: Counter;
+    balances: Map<Bytes<32>, Field>;
+    owner: Bytes<32>;
+  }
+
+  // GOOD — individual export ledger declarations
+  export ledger counter: Counter;
+  export ledger balances: Map<Bytes<32>, Field>;
+  export ledger owner: Bytes<32>;
+  ```
+
+- [ ] **`Choice::variant` (Rust-style) instead of `Choice.variant` (dot notation).** Compact uses dot notation for enum/choice variant access, not Rust-style double-colon path syntax. LLMs trained on Rust code frequently produce the wrong syntax.
+
+  ```compact
+  // BAD — Rust-style double-colon path
+  const status = State::Active;
+  assert(state == State::Committed, "Wrong state");
+
+  // GOOD — dot notation
+  const status = State.Active;
+  assert(state == State.Committed, "Wrong state");
+  ```
+
+- [ ] **`witness name() { ... }` with a function body instead of declaration-only syntax.** In Compact, witness functions are declared in the contract with a signature only (no body). The implementation lives in the TypeScript witness provider, not in the `.compact` file. A witness declaration that includes a body will not compile.
+
+  ```compact
+  // BAD — witness with a body (not valid in Compact)
+  witness local_secret_key() {
+    return generateSecretKey();
+  }
+
+  // GOOD — witness declaration only; body is in TypeScript
+  witness local_secret_key(): Bytes<32>;
+  ```
+
+- [ ] **`pure function` instead of `pure circuit`.** Compact does not have a `function` keyword. Reusable non-exported logic is declared as a `circuit` (or `pure circuit` for circuits that do not access ledger state). LLMs frequently hallucinate `function` because it is ubiquitous in other languages.
+
+  ```compact
+  // BAD — function keyword does not exist in Compact
+  pure function computeHash(input: Bytes<32>): Bytes<32> {
+    return persistentHash<Bytes<32>>(input);
+  }
+
+  // GOOD — pure circuit is the correct keyword
+  pure circuit computeHash(input: Bytes<32>): Bytes<32> {
+    return persistentHash<Bytes<32>>(input);
+  }
+  ```
+
+- [ ] **`Cell<T>` used as a type.** `Cell<T>` is not a valid Compact type. LLMs sometimes hallucinate it from Rust or other ZK language patterns. Use the type directly for ledger declarations.
+
+  ```compact
+  // BAD — Cell<T> is not a Compact type
+  export ledger owner: Cell<Bytes<32>>;
+  export ledger threshold: Cell<Field>;
+
+  // GOOD — use the type directly
+  export ledger owner: Bytes<32>;
+  export ledger threshold: Field;
+  ```
+
+- [ ] **`let` or `var` instead of `const`.** Compact only supports `const` for variable bindings. There is no `let` or `var` keyword. All bindings are immutable once assigned.
+
+  ```compact
+  // BAD — let and var are not valid keywords
+  let result = computeHash(input);
+  var total = counter.read();
+
+  // GOOD — const is the only variable binding keyword
+  const result = computeHash(input);
+  const total = counter.read();
+  ```
+
+- [ ] **`while` loop instead of bounded `for` loop.** Compact does not support `while` loops because circuits must have compile-time-bounded execution. Only `for` loops with compile-time-known bounds are allowed. An unbounded loop would make proof generation impossible.
+
+  ```compact
+  // BAD — while loops are not allowed (unbounded execution)
+  while (i < n) {
+    process(items[i]);
+    i = i + 1;
+  }
+
+  // GOOD — for loop with compile-time bound
+  for (const i = 0; i < 10; i++) {
+    process(items[i]);
+  }
+  ```
+
+- [ ] **Missing `import CompactStandardLibrary;` statement.** Compact contracts that use standard library types (`Counter`, `Map`, `Set`, `MerkleTree`, `HistoricMerkleTree`, `Vector`, etc.) must import the standard library. Without this import, all standard library types and functions are undefined.
+
+  ```compact
+  // BAD — missing import; Counter and Map are undefined
+  export ledger counter: Counter;
+  export ledger balances: Map<Bytes<32>, Field>;
+
+  // GOOD — import standard library first
+  import CompactStandardLibrary;
+
+  export ledger counter: Counter;
+  export ledger balances: Map<Bytes<32>, Field>;
+  ```
+
+- [ ] **`include "std"` (deprecated) instead of `import CompactStandardLibrary;`.** Older versions of Compact used `include "std"` or similar include directives. The current syntax is `import CompactStandardLibrary;`. LLMs trained on older documentation frequently produce the deprecated form.
+
+  ```compact
+  // BAD — deprecated include syntax
+  include "std";
+
+  // GOOD — current import syntax
+  import CompactStandardLibrary;
+  ```
+
+## Semantic Error Checklist
+
+Check the contract for code that is syntactically valid but semantically incorrect, causing compiler rejections or runtime failures.
+
+- [ ] **Implicit disclosure of witness value at a public boundary.** When a witness-derived value flows to a public context (ledger write, return from exported circuit, public assertion) without an explicit `disclose()` call, the compiler rejects the code. This is the most common semantic error in Compact. The fix is to add `disclose()` at the point where the value crosses the public boundary.
+
+  ```compact
+  // BAD — witness value written to ledger without disclose()
+  witness get_owner(): Bytes<32>;
+
+  export circuit initialize(): [] {
+    const owner_pk = get_owner();
+    authority = owner_pk;
+    // Compiler error: implicit disclosure of witness value
+  }
+
+  // GOOD — explicit disclose() at the public boundary
+  export circuit initialize(): [] {
+    const owner_pk = get_owner();
+    authority = disclose(owner_pk);
+  }
+  ```
+
+- [ ] **Recursive circuit calls.** Circuits in Compact cannot call themselves, either directly or through mutual recursion. The compiler rejects recursive circuit definitions because ZK circuits must have a fixed, finite structure that can be flattened into constraints. If you need iterative logic, use a bounded `for` loop instead.
+
+  ```compact
+  // BAD — recursive circuit call (not allowed)
+  circuit factorial(n: Uint<64>): Uint<64> {
+    if (n == 0) {
+      return 1;
+    }
+    return n * factorial(n - 1);
+    // Compiler error: recursive circuit call
+  }
+
+  // GOOD — use bounded iteration instead
+  circuit factorial(n: Uint<64>): Uint<64> {
+    const result = 1;
+    for (const i = 1; i <= 20; i++) {
+      // Bounded loop with compile-time limit
+      result = (i <= n) ? result * i : result;
+    }
+    return result;
+  }
+  ```
+
+- [ ] **Mutable reassignment of a `const` binding.** All variable bindings in Compact use `const` and are immutable. Attempting to reassign a previously bound variable is a compiler error. If you need to compute a new value from an existing one, bind it to a new `const` with a different name.
+
+  ```compact
+  // BAD — reassigning a const binding
+  const total = balances.lookup(account);
+  total = total + amount;
+  // Compiler error: cannot reassign const binding
+
+  // GOOD — bind to a new const
+  const current_total = balances.lookup(account);
+  const new_total = current_total + amount;
+  ```
+
+- [ ] **Non-exported circuit returning witness data that crosses a public boundary.** If a non-exported circuit receives witness-tainted data and returns it, the caller may unknowingly pass that tainted data to a public context. The compiler tracks taint through the call chain. Ensure that `disclose()` is applied at the appropriate point before the data reaches a ledger write or exported circuit return.
+
+  ```compact
+  // BAD — helper circuit returns tainted data; caller writes to ledger
+  circuit computeKey(): Bytes<32> {
+    const sk = local_secret_key();
+    return publicKey(sk);
+    // Return value is witness-tainted
+  }
+
+  export circuit register(): [] {
+    const pk = computeKey();
+    authority = pk;
+    // Compiler error: implicit disclosure of witness value
+  }
+
+  // GOOD — disclose at the public boundary in the caller
+  export circuit register(): [] {
+    const pk = computeKey();
+    authority = disclose(pk);
+  }
+  ```
+
+- [ ] **Constructor accessing witnesses.** Constructors in Compact cannot access witness functions. Witnesses are only available during circuit execution (transaction time), not during contract deployment. If the constructor needs initial values, they must be passed as constructor parameters or set to default values.
+
+  ```compact
+  // BAD — constructor calling a witness function
+  constructor() {
+    const sk = local_secret_key();
+    // Compiler error: cannot access witnesses in constructor
+    authority = publicKey(sk);
+  }
+
+  // GOOD — pass initial values as constructor parameters
+  constructor(initial_authority: Bytes<32>) {
+    authority = initial_authority;
+  }
+  ```
+
+## Type Error Checklist
+
+Check the contract for type mismatches, incorrect casts, and wrong method names that will cause compiler rejections.
+
+- [ ] **Direct cast from `Uint<N>` to `Bytes<M>`.** Compact does not support direct casting between `Uint` and `Bytes` types. The cast must go through `Field` as an intermediate step. This is a multi-step cast requirement that LLMs frequently miss.
+
+  ```compact
+  // BAD — direct cast not supported
+  const value: Uint<64> = 42;
+  const result = value as Bytes<32>;
+  // Compiler error: cannot cast from type Uint<64> to type Bytes<32>
+
+  // GOOD — cast through Field as intermediate
+  const value: Uint<64> = 42;
+  const result = value as Field as Bytes<32>;
+  ```
+
+- [ ] **Direct cast from `Boolean` to `Field`.** `Boolean` cannot be cast directly to `Field`. The cast must go through `Uint<8>` (or another unsigned integer type) first.
+
+  ```compact
+  // BAD — direct Boolean to Field cast
+  const flag: Boolean = true;
+  const field_value = flag as Field;
+  // Compiler error: cannot cast from type Boolean to type Field
+
+  // GOOD — cast through Uint<8> as intermediate
+  const flag: Boolean = true;
+  const field_value = flag as Uint<8> as Field;
+  ```
+
+- [ ] **Relational operators (`<`, `>`, `<=`, `>=`) used on `Field` type.** The `Field` type does not support relational (ordering) operators because field elements do not have a natural total ordering. If you need to compare field values, cast them to `Uint<N>` first where ordering is defined.
+
+  ```compact
+  // BAD — relational operators not supported on Field
+  const a: Field = 10;
+  const b: Field = 20;
+  assert(a < b, "a must be less than b");
+  // Compiler error: operation "<" undefined for Field
+
+  // GOOD — cast to Uint for comparison
+  const a: Field = 10;
+  const b: Field = 20;
+  assert(a as Uint<64> < b as Uint<64>, "a must be less than b");
+  ```
+
+- [ ] **Mixing `Field` and `Uint<N>` in arithmetic expressions.** Compact does not implicitly convert between `Field` and `Uint<N>`. Arithmetic operations require both operands to be the same type. Cast one operand to match the other before performing the operation.
+
+  ```compact
+  // BAD — mixing Field and Uint in arithmetic
+  const field_val: Field = 100;
+  const uint_val: Uint<64> = 5;
+  const result = field_val + uint_val;
+  // Compiler error: type mismatch in arithmetic
+
+  // GOOD — cast one operand to match
+  const field_val: Field = 100;
+  const uint_val: Uint<64> = 5;
+  const result = field_val + (uint_val as Field);
+  ```
+
+- [ ] **Arithmetic result type widening: `Uint<8> + Uint<8>` produces `Uint<16>`.** When two `Uint<N>` values are added, the result type widens to `Uint<2N>` to prevent overflow. This means the result may not fit back into the original type without an explicit cast. Assignments to narrower types will fail without a cast.
+
+  ```compact
+  // BAD — result is Uint<16>, cannot assign to Uint<8> without cast
+  const a: Uint<8> = 100;
+  const b: Uint<8> = 50;
+  const c: Uint<8> = a + b;
+  // Compiler error: cannot assign Uint<16> to Uint<8>
+
+  // GOOD — explicit cast back to narrower type
+  const a: Uint<8> = 100;
+  const b: Uint<8> = 50;
+  const c: Uint<8> = (a + b) as Uint<8>;
+  ```
+
+- [ ] **Missing generic parameters on data structure types.** Some Compact data structures require multiple generic parameters. A common mistake is omitting the depth parameter on `MerkleTree` or `HistoricMerkleTree`, which require both a depth and a leaf type.
+
+  ```compact
+  // BAD — missing depth parameter
+  export ledger members: MerkleTree<Bytes<32>>;
+  // Compiler error: MerkleTree requires 2 type parameters
+
+  // GOOD — include depth and leaf type
+  export ledger members: MerkleTree<16, Bytes<32>>;
+  ```
+
+- [ ] **`Counter.value()` instead of `Counter.read()`.** The `Counter` type does not have a `.value()` method. The correct method to read the current counter value is `.read()`. LLMs frequently hallucinate `.value()` from other language patterns.
+
+  ```compact
+  // BAD — .value() does not exist on Counter
+  const current = counter.value();
+  // Compiler error: operation "value" undefined for Counter
+
+  // GOOD — use .read()
+  const current = counter.read();
+  ```
+
+- [ ] **`Map.get(key)` instead of `Map.lookup(key)`.** The `Map` type does not have a `.get()` method. The correct method to retrieve a value by key is `.lookup(key)`. LLMs hallucinate `.get()` from JavaScript `Map` or other language standard libraries.
+
+  ```compact
+  // BAD — .get() does not exist on Map
+  const balance = balances.get(account);
+  // Compiler error: operation "get" undefined for Map
+
+  // GOOD — use .lookup()
+  const balance = balances.lookup(account);
+  ```
+
+- [ ] **`Map.has(key)` instead of `Map.member(key)`.** The `Map` type does not have a `.has()` method. The correct method to check whether a key exists is `.member(key)`. LLMs hallucinate `.has()` from JavaScript `Map` or similar APIs.
+
+  ```compact
+  // BAD — .has() does not exist on Map
+  if (balances.has(account)) {
+    // ...
+  }
+  // Compiler error: operation "has" undefined for Map
+
+  // GOOD — use .member()
+  if (balances.member(account)) {
+    // ...
+  }
+  ```
+
+## Common Hallucination Traps
+
+Check the contract for functions and types that LLMs commonly invent but do not exist in Compact. These are the most frequent hallucinations found in LLM-generated Compact code.
+
+- [ ] **`hash()` instead of `persistentHash<T>()` or `transientHash<T>()`.** There is no generic `hash()` function in Compact. The correct functions are `persistentHash<T>()` (deterministic, for values that must be reproducible) or `transientHash<T>()` (non-deterministic, for one-time use). Both require an explicit type parameter.
+
+  ```compact
+  // BAD — hash() does not exist
+  const h = hash(input);
+
+  // GOOD — use the specific hash function with type parameter
+  const h = persistentHash<Bytes<32>>(input);
+  // or
+  const h = transientHash<Bytes<32>>(input);
+  ```
+
+- [ ] **`verify()` as a general verification function.** There is no general `verify()` function in Compact. Verification is done through `assert()` for condition checks, `checkRoot()` for Merkle tree root verification, or specific cryptographic operations. LLMs invent `verify()` because it sounds natural.
+
+  ```compact
+  // BAD — verify() does not exist
+  verify(proof, publicInput);
+  verify(signature, message, publicKey);
+
+  // GOOD — use assert() for condition checks
+  assert(condition, "Verification failed");
+  // GOOD — use checkRoot() for Merkle verification
+  assert(tree.checkRoot(disclose(root)), "Invalid root");
+  ```
+
+- [ ] **`encrypt()` / `decrypt()` functions.** Compact does not provide encryption or decryption operations. Privacy in Midnight is achieved through the zero-knowledge proof system and the `disclose()` mechanism, not through encryption. If data must be hidden, use commitments (`persistentCommit`) or keep it off-chain in witness state.
+
+  ```compact
+  // BAD — encrypt/decrypt do not exist in Compact
+  const ciphertext = encrypt(plaintext, key);
+  const decrypted = decrypt(ciphertext, key);
+
+  // GOOD — use commitments for hiding data
+  const salt = get_randomness();
+  const hidden = persistentCommit<Field>(value, salt);
+  ```
+
+- [ ] **`random()` function.** There is no `random()` function available in Compact circuits. Circuits are deterministic by nature. Randomness must be sourced from a witness function (e.g., `get_randomness()`) which runs outside the circuit in the TypeScript witness provider.
+
+  ```compact
+  // BAD — random() does not exist in circuits
+  const nonce = random();
+
+  // GOOD — source randomness from a witness function
+  witness get_randomness(): Bytes<32>;
+  // Then in a circuit:
+  const nonce = get_randomness();
+  ```
+
+- [ ] **`public_key()` instead of `publicKey()`.** The correct function name uses camelCase, not snake_case. The function signature is `publicKey(secretKey, domain)` or derived from a domain-separated hash. LLMs sometimes generate `public_key()` due to snake_case conventions in other languages.
+
+  ```compact
+  // BAD — wrong function name (snake_case)
+  const pk = public_key(sk);
+
+  // GOOD — correct camelCase function name
+  const pk = publicKey(sk);
+  ```
+
+- [ ] **`CurvePoint` instead of `EllipticCurvePoint`.** The correct type name for elliptic curve points in Compact is `EllipticCurvePoint`, not `CurvePoint`. LLMs abbreviate the type name because `CurvePoint` is shorter and feels natural.
+
+  ```compact
+  // BAD — CurvePoint is not a valid type
+  const point: CurvePoint = computePoint(scalar);
+
+  // GOOD — use the full type name
+  const point: EllipticCurvePoint = computePoint(scalar);
+  ```
+
+- [ ] **`CoinInfo` instead of `ShieldedCoinInfo` or `QualifiedShieldedCoinInfo`.** The correct type names for coin information in Compact are `ShieldedCoinInfo` or `QualifiedShieldedCoinInfo`, not `CoinInfo`. LLMs simplify the type name because `CoinInfo` is shorter.
+
+  ```compact
+  // BAD — CoinInfo is not a valid type
+  const coin: CoinInfo = getCoinDetails();
+
+  // GOOD — use the correct type name
+  const coin: ShieldedCoinInfo = getCoinDetails();
+  // or
+  const coin: QualifiedShieldedCoinInfo = getQualifiedCoinDetails();
+  ```
+
+## Compiler Error Quick Reference
+
+Quick reference of common compiler error patterns, their likely causes, and fixes.
+
+| Error Pattern | Likely Cause | Fix |
+|---|---|---|
+| `implicit disclosure of witness value` | Witness-derived value flows to a public context (ledger write, return from exported circuit) without `disclose()` | Add `disclose()` at the point where the value crosses the public boundary |
+| `found "{" looking for ";"` | Void return type used (e.g., `circuit foo(): Void {`) or deprecated ledger block syntax (`ledger { ... }`) | Use `[]` as the return type for circuits that return nothing; use individual `export ledger` declarations |
+| `cannot cast from type X to type Y` | Direct cast between incompatible types (e.g., `Uint<64>` to `Bytes<32>`, or `Boolean` to `Field`) | Use multi-step cast via `Field` as intermediate: `x as Field as Bytes<32>` |
+| `operation "value" undefined for Counter` | Using `.value()` instead of `.read()` on a `Counter` | Replace `.value()` with `.read()` |
+| `operation "get" undefined for Map` | Using `.get(key)` instead of `.lookup(key)` on a `Map` | Replace `.get()` with `.lookup()` |
+| `operation "has" undefined for Map` | Using `.has(key)` instead of `.member(key)` on a `Map` | Replace `.has()` with `.member()` |
+| `recursive circuit call` | A circuit calls itself directly or through mutual recursion | Refactor to use bounded `for` loops or restructure logic to avoid recursion |
+| `type X requires N type parameters` | Missing generic parameters on a data structure (e.g., `MerkleTree<Bytes<32>>` instead of `MerkleTree<16, Bytes<32>>`) | Add all required type parameters; check documentation for the type's full generic signature |
+| `type mismatch` in arithmetic | Mixing `Field` and `Uint<N>` in the same expression without casting | Cast one operand to match the other: `field_val + (uint_val as Field)` |
+| `cannot assign Uint<2N> to Uint<N>` | Arithmetic widening — `Uint<8> + Uint<8>` produces `Uint<16>` | Add explicit cast to narrow the result: `(a + b) as Uint<8>` |
+| `unknown type "Void"` | Using `Void` as a return type | Replace `Void` with `[]` (empty tuple) |
+| `unknown function "hash"` | Using `hash()` instead of `persistentHash<T>()` or `transientHash<T>()` | Use the correct hash function with explicit type parameter |
+| `witnesses not available in constructor` | Constructor body calls a witness function | Remove witness calls from constructor; pass initial values as constructor parameters |
+| `operation "<" undefined for Field` | Using relational operators on `Field` type | Cast to `Uint<N>` before comparison: `(a as Uint<64>) < (b as Uint<64>)` |

--- a/plugins/compact-core/skills/compact-review/references/compilation-review.md
+++ b/plugins/compact-core/skills/compact-review/references/compilation-review.md
@@ -2,6 +2,21 @@
 
 Review checklist for the **Compilation & Type Safety** category. This covers deprecated syntax, incorrect return types, type casting errors, hallucinated API methods, and common compiler error patterns. LLM-generated Compact code is especially prone to these issues because training data contains outdated syntax and invented APIs. Apply every item below to the contract under review.
 
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | **Primary evidence source.** Actual compilation output reveals all syntax and type errors. |
+| `midnight-extract-contract-structure` | `[shared]` | Detects deprecated syntax, hallucinated APIs, structural issues |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of contract patterns |
+| `midnight-get-latest-syntax` | `[shared]` | **Critical for this category.** Authoritative syntax reference — the ground truth for what is valid Compact. |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
+**Important:** For Compilation & Type Safety review, the `midnight-compile-contract` and `midnight-get-latest-syntax` outputs are your primary evidence. Cross-reference every checklist item against actual compilation results before reporting findings.
+
 ## Syntax Error Checklist
 
 Check the contract for deprecated or invalid syntax that will cause compilation failures.
@@ -20,7 +35,9 @@ Check the contract for deprecated or invalid syntax that will cause compilation 
   }
   ```
 
-- [ ] **Deprecated `ledger { ... }` block instead of individual `export ledger` declarations.** Older versions of Compact used a single `ledger { ... }` block to group all ledger declarations. Current Compact requires each ledger variable to be declared individually with `export ledger`.
+  > **Tool:** `midnight-compile-contract` output will show `unknown type "Void"` or `found "{" looking for ";"` if present. `midnight-extract-contract-structure` also flags deprecated syntax.
+
+- [ ] **Deprecated `ledger { ... }` block instead of individual ledger declarations.** Older versions of Compact used a single `ledger { ... }` block to group all ledger declarations. Current Compact requires each ledger variable to be declared individually. The `export` modifier is optional — use it when the DApp needs to query the variable directly.
 
   ```compact
   // BAD — ledger block syntax is deprecated
@@ -30,11 +47,13 @@ Check the contract for deprecated or invalid syntax that will cause compilation 
     owner: Bytes<32>;
   }
 
-  // GOOD — individual export ledger declarations
+  // GOOD — individual ledger declarations (export is optional)
   export ledger counter: Counter;
   export ledger balances: Map<Bytes<32>, Field>;
-  export ledger owner: Bytes<32>;
+  ledger owner: Bytes<32>;
   ```
+
+  > **Tool:** `midnight-compile-contract` output shows `found "{" looking for ";"` for deprecated ledger block syntax. `midnight-extract-contract-structure` flags this pattern.
 
 - [ ] **`Choice::variant` (Rust-style) instead of `Choice.variant` (dot notation).** Compact uses dot notation for enum/choice variant access, not Rust-style double-colon path syntax. LLMs trained on Rust code frequently produce the wrong syntax.
 
@@ -60,6 +79,8 @@ Check the contract for deprecated or invalid syntax that will cause compilation 
   witness local_secret_key(): Bytes<32>;
   ```
 
+  > **Tool:** `midnight-compile-contract` output will show a parsing error for witness bodies. `midnight-get-latest-syntax` confirms witness declaration-only syntax.
+
 - [ ] **`pure function` instead of `pure circuit`.** Compact does not have a `function` keyword. Reusable non-exported logic is declared as a `circuit` (or `pure circuit` for circuits that do not access ledger state). LLMs frequently hallucinate `function` because it is ubiquitous in other languages.
 
   ```compact
@@ -73,6 +94,8 @@ Check the contract for deprecated or invalid syntax that will cause compilation 
     return persistentHash<Bytes<32>>(input);
   }
   ```
+
+  > **Tool:** `midnight-compile-contract` output will show an error for the `function` keyword. `midnight-get-latest-syntax` confirms `circuit` and `pure circuit` as the only keywords.
 
 - [ ] **`Cell<T>` used as a type.** `Cell<T>` is not a valid Compact type. LLMs sometimes hallucinate it from Rust or other ZK language patterns. Use the type directly for ledger declarations.
 
@@ -107,8 +130,8 @@ Check the contract for deprecated or invalid syntax that will cause compilation 
     i = i + 1;
   }
 
-  // GOOD — for loop with compile-time bound
-  for (const i = 0; i < 10; i++) {
+  // GOOD — for loop with compile-time bound (range syntax)
+  for (const i of 0..9) {
     process(items[i]);
   }
   ```
@@ -127,7 +150,9 @@ Check the contract for deprecated or invalid syntax that will cause compilation 
   export ledger balances: Map<Bytes<32>, Field>;
   ```
 
-- [ ] **`include "std"` (deprecated) instead of `import CompactStandardLibrary;`.** Older versions of Compact used `include "std"` or similar include directives. The current syntax is `import CompactStandardLibrary;`. LLMs trained on older documentation frequently produce the deprecated form.
+  > **Tool:** `midnight-compile-contract` output will show undefined type errors for stdlib types if the import is missing. `midnight-extract-contract-structure` checks for the import presence.
+
+- [ ] **`include "std"` (outdated) instead of `import CompactStandardLibrary;`.** Older versions of Compact used `include "std"` to load the standard library. Since Compact 0.13.0, the standard library is a builtin module imported via `import CompactStandardLibrary;`. The `std.compact` file is still provided for backward compatibility, so `include "std"` may still compile, but the `import` form is the recommended approach. Note: the `include` keyword itself is still valid for including other `.compact` files — only its use for the standard library is outdated.
 
   ```compact
   // BAD — deprecated include syntax
@@ -175,7 +200,7 @@ Check the contract for code that is syntactically valid but semantically incorre
   // GOOD — use bounded iteration instead
   circuit factorial(n: Uint<64>): Uint<64> {
     const result = 1;
-    for (const i = 1; i <= 20; i++) {
+    for (const i of 1..20) {
       // Bounded loop with compile-time limit
       result = (i <= n) ? result * i : result;
     }
@@ -219,17 +244,16 @@ Check the contract for code that is syntactically valid but semantically incorre
   }
   ```
 
-- [ ] **Constructor accessing witnesses.** Constructors in Compact cannot access witness functions. Witnesses are only available during circuit execution (transaction time), not during contract deployment. If the constructor needs initial values, they must be passed as constructor parameters or set to default values.
+- [ ] **Constructor witness usage: valid but prefer parameters.** Constructors in Compact can access witness functions. However, the common pattern is to pass initialization values as constructor parameters for simplicity and testability. If a constructor calls witnesses, verify that the deployment workflow correctly provides the witness implementation at deploy time.
 
   ```compact
-  // BAD — constructor calling a witness function
+  // VALID but complex — constructor calling a witness function
   constructor() {
     const sk = local_secret_key();
-    // Compiler error: cannot access witnesses in constructor
-    authority = publicKey(sk);
+    authority = disclose(publicKey(sk));
   }
 
-  // GOOD — pass initial values as constructor parameters
+  // PREFERRED — pass initial values as constructor parameters (simpler deployment)
   constructor(initial_authority: Bytes<32>) {
     authority = initial_authority;
   }
@@ -252,15 +276,16 @@ Check the contract for type mismatches, incorrect casts, and wrong method names 
   const result = value as Field as Bytes<32>;
   ```
 
-- [ ] **Direct cast from `Boolean` to `Field`.** `Boolean` cannot be cast directly to `Field`. The cast must go through `Uint<8>` (or another unsigned integer type) first.
+  > **Tool:** `midnight-compile-contract` output will show `cannot cast from type X to type Y`. `midnight-get-latest-syntax` documents the valid cast paths.
+
+- [ ] **`Boolean` to `Field` cast is direct.** `Boolean` can be cast directly to `Field` without an intermediate step. This is a common source of unnecessary complexity — LLMs sometimes generate a multi-step cast through `Uint<8>` which works but is not required.
 
   ```compact
-  // BAD — direct Boolean to Field cast
+  // GOOD — direct Boolean to Field cast is supported
   const flag: Boolean = true;
   const field_value = flag as Field;
-  // Compiler error: cannot cast from type Boolean to type Field
 
-  // GOOD — cast through Uint<8> as intermediate
+  // ALSO WORKS but unnecessary — multi-step cast through Uint<8>
   const flag: Boolean = true;
   const field_value = flag as Uint<8> as Field;
   ```
@@ -295,14 +320,14 @@ Check the contract for type mismatches, incorrect casts, and wrong method names 
   const result = field_val + (uint_val as Field);
   ```
 
-- [ ] **Arithmetic result type widening: `Uint<8> + Uint<8>` produces `Uint<16>`.** When two `Uint<N>` values are added, the result type widens to `Uint<2N>` to prevent overflow. This means the result may not fit back into the original type without an explicit cast. Assignments to narrower types will fail without a cast.
+- [ ] **Arithmetic result type widening: `Uint<8> + Uint<8>` produces a wider type.** When two `Uint<N>` values are added, the result type widens to accommodate the full range of possible values (e.g., two `Uint<8>` values can sum to at most 510, so the result is a range type). This means the result may not fit back into the original type without an explicit cast. Assignments to narrower types will fail without a cast.
 
   ```compact
-  // BAD — result is Uint<16>, cannot assign to Uint<8> without cast
+  // BAD — result is wider than Uint<8>, cannot assign without cast
   const a: Uint<8> = 100;
   const b: Uint<8> = 50;
   const c: Uint<8> = a + b;
-  // Compiler error: cannot assign Uint<16> to Uint<8>
+  // Compiler error: cannot assign widened result to Uint<8>
 
   // GOOD — explicit cast back to narrower type
   const a: Uint<8> = 100;
@@ -332,6 +357,8 @@ Check the contract for type mismatches, incorrect casts, and wrong method names 
   const current = counter.read();
   ```
 
+  > **Tool:** `midnight-compile-contract` output will show `operation "value" undefined for Counter`. `midnight-get-latest-syntax` lists the correct Counter API methods.
+
 - [ ] **`Map.get(key)` instead of `Map.lookup(key)`.** The `Map` type does not have a `.get()` method. The correct method to retrieve a value by key is `.lookup(key)`. LLMs hallucinate `.get()` from JavaScript `Map` or other language standard libraries.
 
   ```compact
@@ -342,6 +369,8 @@ Check the contract for type mismatches, incorrect casts, and wrong method names 
   // GOOD — use .lookup()
   const balance = balances.lookup(account);
   ```
+
+  > **Tool:** `midnight-compile-contract` output will show `operation "get" undefined for Map`. `midnight-search-compact` can find correct Map usage patterns in reference code.
 
 - [ ] **`Map.has(key)` instead of `Map.member(key)`.** The `Map` type does not have a `.has()` method. The correct method to check whether a key exists is `.member(key)`. LLMs hallucinate `.has()` from JavaScript `Map` or similar APIs.
 
@@ -373,6 +402,8 @@ Check the contract for functions and types that LLMs commonly invent but do not 
   // or
   const h = transientHash<Bytes<32>>(input);
   ```
+
+  > **Tool:** `midnight-compile-contract` output will show `unknown function "hash"`. `midnight-get-latest-syntax` lists all valid hash functions.
 
 - [ ] **`verify()` as a general verification function.** There is no general `verify()` function in Compact. Verification is done through `assert()` for condition checks, `checkRoot()` for Merkle tree root verification, or specific cryptographic operations. LLMs invent `verify()` because it sounds natural.
 
@@ -421,15 +452,20 @@ Check the contract for functions and types that LLMs commonly invent but do not 
   const pk = publicKey(sk);
   ```
 
-- [ ] **`CurvePoint` instead of `EllipticCurvePoint`.** The correct type name for elliptic curve points in Compact is `EllipticCurvePoint`, not `CurvePoint`. LLMs abbreviate the type name because `CurvePoint` is shorter and feels natural.
+- [ ] **`CurvePoint` instead of `NativePoint`.** The correct type name for elliptic curve points in Compact is `NativePoint`, not `CurvePoint`. `CurvePoint` was the old type name (now rejected by the compiler) and persists only as the TypeScript runtime interface name. LLMs hallucinate `CurvePoint` or `EllipticCurvePoint` because they appear in older documentation or are invented from convention.
 
   ```compact
-  // BAD — CurvePoint is not a valid type
+  // BAD — CurvePoint is not a valid Compact type (old name, rejected by compiler)
   const point: CurvePoint = computePoint(scalar);
 
-  // GOOD — use the full type name
+  // BAD — EllipticCurvePoint does not exist in Compact
   const point: EllipticCurvePoint = computePoint(scalar);
+
+  // GOOD — NativePoint is the correct current type name
+  const point: NativePoint = computePoint(scalar);
   ```
+
+  > **Tool:** `midnight-compile-contract` output will show an unknown type error for `CurvePoint`. `midnight-get-latest-syntax` confirms `NativePoint` as the current type name.
 
 - [ ] **`CoinInfo` instead of `ShieldedCoinInfo` or `QualifiedShieldedCoinInfo`.** The correct type names for coin information in Compact are `ShieldedCoinInfo` or `QualifiedShieldedCoinInfo`, not `CoinInfo`. LLMs simplify the type name because `CoinInfo` is shorter.
 
@@ -451,15 +487,25 @@ Quick reference of common compiler error patterns, their likely causes, and fixe
 |---|---|---|
 | `implicit disclosure of witness value` | Witness-derived value flows to a public context (ledger write, return from exported circuit) without `disclose()` | Add `disclose()` at the point where the value crosses the public boundary |
 | `found "{" looking for ";"` | Void return type used (e.g., `circuit foo(): Void {`) or deprecated ledger block syntax (`ledger { ... }`) | Use `[]` as the return type for circuits that return nothing; use individual `export ledger` declarations |
-| `cannot cast from type X to type Y` | Direct cast between incompatible types (e.g., `Uint<64>` to `Bytes<32>`, or `Boolean` to `Field`) | Use multi-step cast via `Field` as intermediate: `x as Field as Bytes<32>` |
+| `cannot cast from type X to type Y` | Direct cast between incompatible types (e.g., `Uint<64>` to `Bytes<32>`) | Use multi-step cast via `Field` as intermediate: `x as Field as Bytes<32>`. Note: `Boolean` to `Field` IS a direct cast. |
 | `operation "value" undefined for Counter` | Using `.value()` instead of `.read()` on a `Counter` | Replace `.value()` with `.read()` |
 | `operation "get" undefined for Map` | Using `.get(key)` instead of `.lookup(key)` on a `Map` | Replace `.get()` with `.lookup()` |
 | `operation "has" undefined for Map` | Using `.has(key)` instead of `.member(key)` on a `Map` | Replace `.has()` with `.member()` |
 | `recursive circuit call` | A circuit calls itself directly or through mutual recursion | Refactor to use bounded `for` loops or restructure logic to avoid recursion |
 | `type X requires N type parameters` | Missing generic parameters on a data structure (e.g., `MerkleTree<Bytes<32>>` instead of `MerkleTree<16, Bytes<32>>`) | Add all required type parameters; check documentation for the type's full generic signature |
 | `type mismatch` in arithmetic | Mixing `Field` and `Uint<N>` in the same expression without casting | Cast one operand to match the other: `field_val + (uint_val as Field)` |
-| `cannot assign Uint<2N> to Uint<N>` | Arithmetic widening — `Uint<8> + Uint<8>` produces `Uint<16>` | Add explicit cast to narrow the result: `(a + b) as Uint<8>` |
+| `cannot assign widened result to Uint<N>` | Arithmetic widening — `Uint<8> + Uint<8>` produces a wider type that cannot be assigned back to `Uint<8>` | Add explicit cast to narrow the result: `(a + b) as Uint<8>` |
 | `unknown type "Void"` | Using `Void` as a return type | Replace `Void` with `[]` (empty tuple) |
 | `unknown function "hash"` | Using `hash()` instead of `persistentHash<T>()` or `transientHash<T>()` | Use the correct hash function with explicit type parameter |
-| `witnesses not available in constructor` | Constructor body calls a witness function | Remove witness calls from constructor; pass initial values as constructor parameters |
+| Witness-related deployment error in constructor | Constructor calls a witness but the deployment workflow does not provide the witness implementation | Ensure witness providers are available at deploy time, or prefer passing initial values as constructor parameters |
 | `operation "<" undefined for Field` | Using relational operators on `Field` type | Cast to `Uint<N>` before comparison: `(a as Uint<64>) < (b as Uint<64>)` |
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | **Primary tool for this category.** Compile contract with hosted compiler. Use `skipZk=true` for syntax/type validation. All compilation errors listed in the Compiler Error Quick Reference are directly caught by this tool. |
+| `midnight-extract-contract-structure` | Deep structural analysis: deprecated syntax, hallucinated APIs, missing imports. |
+| `midnight-analyze-contract` | Static analysis of contract structure and common patterns. |
+| `midnight-get-latest-syntax` | **Critical for this category.** Authoritative Compact syntax reference — use as ground truth for valid types, functions, and keywords. |
+| `midnight-search-compact` | Semantic search across Compact code for correct API usage patterns. |

--- a/plugins/compact-core/skills/compact-review/references/concurrency-review.md
+++ b/plugins/compact-core/skills/compact-review/references/concurrency-review.md
@@ -2,6 +2,19 @@
 
 Review checklist for the **Concurrency & Contention** category. Midnight processes transactions concurrently, and two transactions that read-then-write the same ledger state will conflict — only the first to land succeeds, and the rest fail. This review identifies contention-prone patterns and recommends conflict-free alternatives. Apply every item below to the contract under review.
 
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation output helps identify ledger operation patterns |
+| `midnight-extract-contract-structure` | `[shared]` | Identifies data structure declarations and usage patterns |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of contention-prone patterns |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for ADT operation semantics |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
 ## Read-Then-Write Contention Checklist
 
 Check every exported circuit for patterns where state is read and then written back with a value derived from the read. These are the primary source of transaction contention.
@@ -24,6 +37,8 @@ Check every exported circuit for patterns where state is read and then written b
     counter.increment(1);
   }
   ```
+
+  > **Tool:** `midnight-extract-contract-structure` shows all `Counter` operations. Look for `.read()` calls followed by manual writes to the same variable.
 
 - [ ] **Map read-modify-write pattern.** Reading a value from a `Map`, computing a new value from it, and writing it back to the same key creates contention when two transactions target the same key. Both transactions read the same value, compute derived values, and race to write — only one succeeds.
 
@@ -61,6 +76,8 @@ Check every exported circuit for patterns where state is read and then written b
     global_total.increment(amount);
   }
   ```
+
+  > **Tool:** `midnight-extract-contract-structure` lists all exported circuits and their ledger operations. Cross-reference reads and writes to the same variables within each circuit.
 
 ## ADT Contention Properties Checklist
 
@@ -126,7 +143,9 @@ Check each ledger data structure usage for its inherent contention characteristi
   export ledger members: HistoricMerkleTree<16, Bytes<32>>;
   ```
 
-- [ ] **`List.push(value)` — conflicts when concurrent pushes occur.** List ordering is significant. When two transactions push concurrently, they conflict because the resulting list depends on insertion order. If ordering is not important, consider whether a Set or Map would be more appropriate.
+  > **Tool:** `midnight-extract-contract-structure` identifies all MerkleTree declarations. Check whether `HistoricMerkleTree` is used where concurrent inserts are expected. `midnight-search-docs` has guidance on choosing between `MerkleTree` and `HistoricMerkleTree`.
+
+- [ ] **`List.pushFront(value)` — conflicts when concurrent pushes occur.** List ordering is significant. When two transactions push concurrently, they conflict because the resulting list depends on insertion order. If ordering is not important, consider whether a Set or Map would be more appropriate.
 
 ## Design Patterns for Low Contention Checklist
 
@@ -298,5 +317,15 @@ Quick reference of common concurrency anti-patterns in Compact contracts.
 | `highest_bid = amount` in auction circuit | Every bidder writes to the same field; under load, almost all bids fail | Store bids in a `Map` keyed by bidder identity; determine the winner in a separate finalize step |
 | `scores.insert(key, scores.lookup(key) + points)` on shared key | Read-modify-write on the same Map key; concurrent updates to the same key conflict | Use per-user keys so each user modifies only their own entry, or use `Counter` for additive accumulation |
 | `MerkleTree.insert()` under high concurrent load | Every insert changes the root; concurrent inserts invalidate each other's proofs | Use `HistoricMerkleTree` for membership verification (old roots stay valid); accept that concurrent inserts still contend |
-| `List.push()` from many concurrent users | Pushes conflict because list ordering depends on insertion sequence | Use `Map` or `Set` if ordering is not required; accept contention if strict ordering is necessary |
+| `List.pushFront()` from many concurrent users | Pushes conflict because list ordering depends on insertion sequence | Use `Map` or `Set` if ordering is not required; accept contention if strict ordering is necessary |
 | Single status flag (`state = State.ACTIVE`) set by every user | All concurrent transactions write to the same enum variable; only one succeeds | Redesign so the status is derived from per-user state, or limit state transitions to a single admin |
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Use `skipZk=true` for syntax validation. |
+| `midnight-extract-contract-structure` | Deep structural analysis: data structure declarations, ledger operation patterns. |
+| `midnight-analyze-contract` | Static analysis of contract structure and common patterns. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference including ADT operation semantics. |
+| `midnight-search-docs` | Full-text search across official Midnight documentation for concurrency guidance. |

--- a/plugins/compact-core/skills/compact-review/references/concurrency-review.md
+++ b/plugins/compact-core/skills/compact-review/references/concurrency-review.md
@@ -1,0 +1,302 @@
+# Concurrency & Contention Review Checklist
+
+Review checklist for the **Concurrency & Contention** category. Midnight processes transactions concurrently, and two transactions that read-then-write the same ledger state will conflict — only the first to land succeeds, and the rest fail. This review identifies contention-prone patterns and recommends conflict-free alternatives. Apply every item below to the contract under review.
+
+## Read-Then-Write Contention Checklist
+
+Check every exported circuit for patterns where state is read and then written back with a value derived from the read. These are the primary source of transaction contention.
+
+- [ ] **Counter read-then-set pattern.** Reading a `Counter` value and then manually setting it to `value + n` is the textbook contention pattern. If two transactions execute concurrently, both read the same value (e.g., `1`), and both attempt to write `2`. Only the first transaction succeeds; the second fails because the value it read is no longer current. Use `Counter.increment(n)` instead, which is a commutative operation that does not conflict.
+
+  > Consider a simple counter contract, where users increment a publicly stored counter. A naive implementation may a) read the current value, and b) set the new value to the read value + 1. This can be a problem if the steps are recorded separately in the transaction, say as `[read 1, write 2]`. If two of these transactions get submitted simultaneously, they will conflict, and only the first will succeed. For the others, the value read is no longer `1`, so the transaction will fail. If instead the transaction is structured to contain a single-step increment — for instance `[incr 1]` — then all transactions can succeed.
+
+  ```compact
+  // BAD — read-then-write causes contention
+  export circuit increment_counter(): [] {
+    const val = counter.read();
+    // Two concurrent transactions both read the same val
+    // Both try to write val + 1; only one can succeed
+    counter = val + 1;
+  }
+
+  // GOOD — atomic increment, conflict-free
+  export circuit increment_counter(): [] {
+    counter.increment(1);
+  }
+  ```
+
+- [ ] **Map read-modify-write pattern.** Reading a value from a `Map`, computing a new value from it, and writing it back to the same key creates contention when two transactions target the same key. Both transactions read the same value, compute derived values, and race to write — only one succeeds.
+
+  ```compact
+  // BAD — read-modify-write on same Map key; contention when concurrent
+  export circuit add_score(player: Bytes<32>, points: Field): [] {
+    assert(scores.member(player), "Player not found");
+    const current = scores.lookup(player);
+    scores.insert(player, current + points);
+  }
+
+  // GOOD — if the value is a counter-like accumulator, use a per-key Counter
+  // or restructure so concurrent users modify different keys
+  export circuit add_score(points: Field): [] {
+    const sk = local_secret_key();
+    const player = disclose(publicKey(sk));
+    // Each player modifies only their own key — no cross-user contention
+    const current = scores.member(player) ? scores.lookup(player) : 0;
+    scores.insert(player, current + points);
+  }
+  ```
+
+- [ ] **General read-then-write on any exported circuit.** Any `export circuit` that reads a ledger variable and then writes a value derived from the read to the same variable is contention-prone. The pattern is: (1) read state, (2) compute new value from the read, (3) write new value back. If two transactions do this concurrently, they conflict.
+
+  ```compact
+  // BAD — reads global_total, derives new value, writes it back
+  export circuit contribute(amount: Field): [] {
+    const current_total = global_total.read();
+    global_total = current_total + amount;
+  }
+
+  // GOOD — use Counter for commutative accumulation
+  // export ledger global_total: Counter;
+  export circuit contribute(amount: Field): [] {
+    global_total.increment(amount);
+  }
+  ```
+
+## ADT Contention Properties Checklist
+
+Check each ledger data structure usage for its inherent contention characteristics. Different ADTs have different conflict profiles.
+
+- [ ] **`Counter.increment(n)` — conflict-free.** `Counter.increment(n)` and `Counter.decrement(n)` are commutative operations. Multiple concurrent transactions can all increment or decrement the same counter without conflicting because the operations can be applied in any order and produce the same result. This is the preferred pattern for any accumulator.
+
+  ```compact
+  // Counter operations and their contention properties:
+  counter.increment(1);      // Conflict-free (commutative)
+  counter.decrement(1);      // Conflict-free (commutative)
+  counter.lessThan(1);       // Read-only comparison, no write contention
+  counter.read();            // Read-only, no write contention by itself
+  counter.resetToDefault();  // CAUSES CONTENTION — overwrites the value
+  ```
+
+- [ ] **`Counter.read()` followed by manual set — CAUSES CONTENTION.** When `counter.read()` is used to obtain the current value and then that value is used to compute a new state that is written back, the read creates a dependency on the current value. Concurrent transactions that both read the same value will conflict. Prefer `increment()` or `decrement()` which do not depend on the current value.
+
+  ```compact
+  // BAD — read creates dependency; concurrent transactions conflict
+  export circuit double_counter(): [] {
+    const val = counter.read();
+    counter = val * 2;
+    // Two transactions both read the same val and try to write val * 2
+  }
+
+  // If you need the current value for logic OTHER than writing back,
+  // reading is fine — the contention arises only when the read
+  // determines the write value.
+  ```
+
+- [ ] **`Map.insert(key, value)` — conflicts only when the same key is modified concurrently.** Map insertions conflict when two transactions insert to the same key simultaneously, because both are writing to the same storage slot. Insertions to different keys do not conflict. Design contracts so concurrent users modify different keys (e.g., per-user entries keyed by public key).
+
+  ```compact
+  // LOW CONTENTION — each user writes to their own key
+  export circuit update_profile(name: Field): [] {
+    const sk = local_secret_key();
+    const pk = disclose(publicKey(sk));
+    profiles.insert(pk, name);
+  }
+
+  // HIGH CONTENTION — all users write to the same key
+  export circuit update_global_config(value: Field): [] {
+    config.insert(pad(32, "global"), value);
+  }
+  ```
+
+- [ ] **`Set.insert(value)` — conflicts only when the same value is inserted concurrently.** Two transactions inserting different values into a Set do not conflict. However, two transactions inserting the same value will conflict. This is generally low contention for use cases like nullifier sets where each value is unique.
+
+- [ ] **`MerkleTree.insert(leaf)` — conflicts when concurrent inserts occur.** Every insertion into a MerkleTree changes the root hash. If two transactions insert leaves concurrently, the second transaction's proof was computed against the old root and is now invalid. Use `HistoricMerkleTree` to mitigate this for membership proofs (old roots remain valid), but concurrent inserts themselves still contend on the tree structure.
+
+  ```compact
+  // CONTENTION-PRONE — concurrent inserts change the root
+  export ledger members: MerkleTree<16, Bytes<32>>;
+
+  export circuit register(commitment: Bytes<32>): [] {
+    members.insert(disclose(commitment));
+    // If two users register concurrently, one transaction fails
+  }
+
+  // BETTER for membership verification — HistoricMerkleTree retains old roots
+  // so that verification paths obtained before concurrent inserts remain valid
+  export ledger members: HistoricMerkleTree<16, Bytes<32>>;
+  ```
+
+- [ ] **`List.push(value)` — conflicts when concurrent pushes occur.** List ordering is significant. When two transactions push concurrently, they conflict because the resulting list depends on insertion order. If ordering is not important, consider whether a Set or Map would be more appropriate.
+
+## Design Patterns for Low Contention Checklist
+
+Check the contract design for patterns that minimize transaction conflicts under concurrent load.
+
+- [ ] **Prefer `Counter.increment()` over read-then-set for counters.** Whenever a contract needs to accumulate a value (vote counts, deposit totals, participation counters), use `Counter` with `increment()` or `decrement()`. These are commutative operations that never conflict. Reading and manually setting is the most common contention anti-pattern.
+
+  ```compact
+  // BAD — contention on every concurrent vote
+  export circuit vote(): [] {
+    const current = vote_count.read();
+    vote_count = current + 1;
+  }
+
+  // GOOD — all concurrent votes succeed
+  // export ledger vote_count: Counter;
+  export circuit vote(): [] {
+    vote_count.increment(1);
+  }
+  ```
+
+- [ ] **Use per-user Map entries rather than a single global value.** When each user needs to store state, use a Map keyed by user identity (public key or derived identifier). This ensures concurrent transactions from different users write to different keys, eliminating cross-user contention.
+
+  ```compact
+  // BAD — single global value; every user transaction contends
+  export ledger last_action: Field;
+
+  export circuit perform_action(action: Field): [] {
+    last_action = disclose(action);
+  }
+
+  // GOOD — per-user entries; no cross-user contention
+  export ledger user_actions: Map<Bytes<32>, Field>;
+
+  export circuit perform_action(action: Field): [] {
+    const sk = local_secret_key();
+    const pk = disclose(publicKey(sk));
+    user_actions.insert(pk, disclose(action));
+  }
+  ```
+
+- [ ] **Design circuits so concurrent users modify different state entries.** Structure the contract so that each user's transaction touches only state that belongs to that user. Shared state (global counters, configuration) should use conflict-free operations. The ideal is that two concurrent transactions from different users have zero state overlap in their writes.
+
+  ```compact
+  // GOOD — each user's deposit modifies only their own balance entry
+  // and the shared counter uses conflict-free increment
+  export ledger balances: Map<Bytes<32>, Field>;
+  export ledger total_deposits: Counter;
+
+  export circuit deposit(amount: Field): [] {
+    const sk = local_secret_key();
+    const pk = disclose(publicKey(sk));
+    const current = balances.member(pk) ? balances.lookup(pk) : 0;
+    balances.insert(pk, current + disclose(amount));
+    total_deposits.increment(disclose(amount));
+  }
+  ```
+
+- [ ] **Use `MerkleTree` for membership proofs rather than `Set` when high throughput is needed.** While both `Set` and `MerkleTree` can represent membership, `MerkleTree` (especially `HistoricMerkleTree`) allows membership proofs to remain valid even after concurrent insertions change the root. With `Set`, a `member()` check depends on the current set state, and concurrent modifications can invalidate pending transactions.
+
+  ```compact
+  // LOWER THROUGHPUT — Set membership check depends on current state
+  export ledger allowlist: Set<Bytes<32>>;
+
+  export circuit check_member(id: Bytes<32>): [] {
+    assert(allowlist.member(disclose(id)), "Not in allowlist");
+  }
+
+  // HIGHER THROUGHPUT — HistoricMerkleTree allows older proofs to succeed
+  export ledger allowlist: HistoricMerkleTree<16, Bytes<32>>;
+
+  export circuit check_member(path: MerkleTreePath<16, Bytes<32>>): [] {
+    const root = merkleTreePathRoot<16, Bytes<32>>(path);
+    assert(allowlist.checkRoot(disclose(root)), "Not in allowlist");
+  }
+  ```
+
+## Red Flags Checklist
+
+Check the contract for high-contention anti-patterns that will cause transaction failures at scale.
+
+- [ ] **Any exported circuit that calls both `.read()` and modifies the same ledger variable.** This is the fundamental contention pattern. Search for `export circuit` bodies that contain a `.read()` call on a ledger variable followed by a write to the same variable. Every such circuit will fail under concurrent load.
+
+  ```compact
+  // RED FLAG — reads and writes same variable
+  export circuit process(): [] {
+    const val = state_var.read();    // Read
+    state_var = val + 1;             // Write derived from read
+    // Under concurrent load, most transactions fail
+  }
+  ```
+
+- [ ] **Global state (single variable) updated by every user transaction.** If a contract has a ledger variable that every user transaction writes to (e.g., a global counter stored as a `Field`, a single status flag, a "last updated by" field), every concurrent transaction will contend on that variable. Either remove the global state, move it to a per-user Map, or use a `Counter` if the update is additive.
+
+  ```compact
+  // RED FLAG — every user transaction writes to the same global variable
+  export ledger total_contributions: Field;
+
+  export circuit contribute(amount: Field): [] {
+    const current = total_contributions;
+    total_contributions = current + disclose(amount);
+    // Every concurrent contribute() call conflicts
+  }
+
+  // FIX — use Counter for the shared accumulator
+  export ledger total_contributions: Counter;
+
+  export circuit contribute(amount: Field): [] {
+    total_contributions.increment(disclose(amount));
+    // All concurrent contribute() calls succeed
+  }
+  ```
+
+- [ ] **Auction/voting patterns where all users write to the same field.** Auctions where every bid writes to a `highest_bid` field, or voting contracts where every vote writes to a shared `results` variable, are inherently contention-prone. Under load, most transactions will fail.
+
+  ```compact
+  // RED FLAG — every bid writes to the same highest_bid field
+  export ledger highest_bid: Field;
+  export ledger highest_bidder: Bytes<32>;
+
+  export circuit place_bid(amount: Field): [] {
+    assert(disclose(amount) > highest_bid, "Bid too low");
+    highest_bid = disclose(amount);
+    highest_bidder = disclose(publicKey(local_secret_key()));
+    // Only one bid can succeed per block; all others fail
+  }
+
+  // BETTER — store each bid separately, determine winner off-chain or in a finalize step
+  export ledger bids: Map<Bytes<32>, Field>;
+  export ledger bid_count: Counter;
+
+  export circuit place_bid(amount: Field): [] {
+    const sk = local_secret_key();
+    const pk = disclose(publicKey(sk));
+    assert(disclose(amount) > 0, "Bid must be positive");
+    bids.insert(pk, disclose(amount));
+    bid_count.increment(1);
+  }
+  ```
+
+- [ ] **Commit-reveal scheme where reveal phase reads global commitment state.** In a commit-reveal protocol, if the reveal phase reads a shared state variable that is also modified by other commits, concurrent reveals will contend. Structure the protocol so each user's commitment is stored independently (e.g., in a Map keyed by user identity) and the reveal reads only that user's entry.
+
+  ```compact
+  // RED FLAG — single shared commitment variable; only one user at a time
+  export ledger current_commitment: Bytes<32>;
+
+  export circuit commit(c: Bytes<32>): [] {
+    current_commitment = disclose(c);
+  }
+
+  // BETTER — per-user commitments; no cross-user contention
+  export ledger commitments: Map<Bytes<32>, Bytes<32>>;
+
+  export circuit commit(c: Bytes<32>): [] {
+    const sk = local_secret_key();
+    const pk = disclose(publicKey(sk));
+    commitments.insert(pk, disclose(c));
+  }
+  ```
+
+## Anti-Patterns Table
+
+Quick reference of common concurrency anti-patterns in Compact contracts.
+
+| Anti-Pattern | Why It Fails | Correct Approach |
+|---|---|---|
+| `const val = counter.read(); counter = val + 1` | Two concurrent transactions both read the same value and both try to write the same result; only one succeeds, the rest fail | `counter.increment(1)` — commutative operation that never conflicts regardless of concurrency |
+| Single global `Field` variable updated by every transaction | Every concurrent transaction writes to the same storage slot; only one can succeed per block | Use `Counter` for additive updates, or `Map` with per-user keys for individual state |
+| `highest_bid = amount` in auction circuit | Every bidder writes to the same field; under load, almost all bids fail | Store bids in a `Map` keyed by bidder identity; determine the winner in a separate finalize step |
+| `scores.insert(key, scores.lookup(key) + points)` on shared key | Read-modify-write on the same Map key; concurrent updates to the same key conflict | Use per-user keys so each user modifies only their own entry, or use `Counter` for additive accumulation |
+| `MerkleTree.insert()` under high concurrent load | Every insert changes the root; concurrent inserts invalidate each other's proofs | Use `HistoricMerkleTree` for membership verification (old roots stay valid); accept that concurrent inserts still contend |
+| `List.push()` from many concurrent users | Pushes conflict because list ordering depends on insertion sequence | Use `Map` or `Set` if ordering is not required; accept contention if strict ordering is necessary |
+| Single status flag (`state = State.ACTIVE`) set by every user | All concurrent transactions write to the same enum variable; only one succeeds | Redesign so the status is derived from per-user state, or limit state transitions to a single admin |

--- a/plugins/compact-core/skills/compact-review/references/documentation-review.md
+++ b/plugins/compact-core/skills/compact-review/references/documentation-review.md
@@ -1,0 +1,664 @@
+# Documentation Review Checklist
+
+Review checklist for the **Documentation** category. This covers contract-level documentation, circuit documentation, ledger state documentation, witness documentation, and privacy documentation. Well-documented contracts are easier to audit, maintain, and integrate with. Poor documentation hides intent, makes review harder, and increases the chance that bugs go unnoticed because reviewers cannot tell what the code is supposed to do. Apply every item below to the contract under review.
+
+## Contract-Level Documentation Checklist
+
+Check that the contract file includes top-level documentation explaining its purpose, design, deployment requirements, and dependencies.
+
+- [ ] **Contract purpose is clearly stated at the top of the file.** The first comment in the contract should explain what the contract does in one to three sentences. A reviewer opening the file for the first time should immediately understand the contract's role. Without this, the reviewer must reverse-engineer intent from the code, which is error-prone and time-consuming.
+
+  ```compact
+  // BAD — no top-level documentation; reviewer has no context
+  export ledger authority: Bytes<32>;
+  export ledger members: HistoricMerkleTree<16, Bytes<32>>;
+  export ledger usedNullifiers: Set<Bytes<32>>;
+
+  witness localSecretKey(): Bytes<32>;
+
+  export circuit register(commitment: Bytes<32>): [] {
+    // ...
+  }
+
+  // GOOD — purpose stated clearly at the top
+  // Anonymous voting contract for community governance proposals.
+  // Members register by inserting a commitment into a Merkle tree.
+  // Votes are cast anonymously using zero-knowledge membership proofs
+  // with nullifiers to prevent double-voting.
+
+  export ledger authority: Bytes<32>;
+  export ledger members: HistoricMerkleTree<16, Bytes<32>>;
+  export ledger usedNullifiers: Set<Bytes<32>>;
+
+  witness localSecretKey(): Bytes<32>;
+
+  export circuit register(commitment: Bytes<32>): [] {
+    // ...
+  }
+  ```
+
+- [ ] **Overall architecture and design are explained.** For contracts with multiple modules, state machines, or multi-phase protocols (e.g., commit-reveal, propose-vote-execute), a brief architectural overview should describe how the pieces fit together. This helps reviewers understand the intended flow before diving into individual circuits.
+
+  ```compact
+  // BAD — multi-phase protocol with no architectural explanation
+  enum State { Setup, Commit, Reveal, Finalized }
+  export ledger state: State;
+  export ledger commitments: Map<Bytes<32>, Bytes<32>>;
+  export ledger reveals: Map<Bytes<32>, Field>;
+
+  // GOOD — architecture documented before the code
+  // Commit-Reveal Auction Contract
+  //
+  // Architecture:
+  //   Phase 1 (Setup): Owner deploys and sets auction parameters.
+  //   Phase 2 (Commit): Bidders submit blinded commitments of their bids.
+  //   Phase 3 (Reveal): Bidders reveal their bids; contract verifies against commitments.
+  //   Phase 4 (Finalized): Highest bidder wins; funds are distributed.
+  //
+  // State transitions: Setup -> Commit -> Reveal -> Finalized
+  // Only the owner can advance phases via advancePhase().
+
+  enum State { Setup, Commit, Reveal, Finalized }
+  export ledger state: State;
+  export ledger commitments: Map<Bytes<32>, Bytes<32>>;
+  export ledger reveals: Map<Bytes<32>, Field>;
+  ```
+
+- [ ] **Deployment requirements are documented.** The constructor parameters, their expected values, and any deployment preconditions should be documented near the constructor. A deployer reading the contract should know exactly what values to provide and in what format.
+
+  ```compact
+  // BAD — constructor with no documentation; deployer must guess parameter meanings
+  constructor(key: Bytes<32>, depth: Field, threshold: Field) {
+    authority = key;
+    voteThreshold = threshold;
+  }
+
+  // GOOD — constructor parameters documented
+  // Constructor Parameters:
+  //   key: The public key of the contract administrator. Derived from
+  //        persistentHash<Vector<2, Bytes<32>>>([pad(32, "myapp:pk:"), secretKey]).
+  //   depth: Unused in current version; reserved for future MerkleTree sizing.
+  //   threshold: Minimum number of votes required to pass a proposal.
+  constructor(key: Bytes<32>, depth: Field, threshold: Field) {
+    authority = key;
+    voteThreshold = threshold;
+  }
+  ```
+
+- [ ] **Dependencies are documented.** If the contract imports modules, uses cross-contract calls, or depends on external contracts or off-chain services, these dependencies should be listed. A reviewer needs to know the trust boundaries.
+
+  ```compact
+  // BAD — imports with no explanation of what they provide
+  import TokenModule prefix $;
+  import GovernanceModule prefix #;
+
+  // GOOD — imports documented with their purpose
+  // Dependencies:
+  //   TokenModule: Provides token minting and transfer logic.
+  //     Imported with prefix $ (e.g., $mint, $transfer).
+  //   GovernanceModule: Provides proposal creation and voting logic.
+  //     Imported with prefix # (e.g., #propose, #vote).
+  import TokenModule prefix $;
+  import GovernanceModule prefix #;
+  ```
+
+## Circuit Documentation Checklist
+
+Check that every exported circuit and complex internal circuit has documentation explaining its purpose, parameters, return value, side effects, access control, and requirements.
+
+- [ ] **Every exported circuit has a comment explaining its purpose.** An `export circuit` is part of the contract's public API. Anyone interacting with the contract needs to understand what each circuit does. The comment should describe the high-level action, not repeat the code line-by-line.
+
+  ```compact
+  // BAD — no documentation on exported circuit
+  export circuit transfer(to: Bytes<32>, amount: Field): [] {
+    const sk = localSecretKey();
+    const pk = disclose(publicKey(sk));
+    assert(balances.member(pk), "Sender not found");
+    const senderBalance = balances.lookup(pk);
+    assert(senderBalance >= amount, "Insufficient balance");
+    balances.insert(pk, senderBalance - amount);
+    const toBalance = balances.member(to) ? balances.lookup(to) : 0;
+    balances.insert(to, toBalance + amount);
+  }
+
+  // GOOD — purpose, params, side effects, access control documented
+  // Transfers tokens from the caller's account to a recipient.
+  //
+  // Parameters:
+  //   to: Public key of the recipient account.
+  //   amount: Number of tokens to transfer. Must be > 0.
+  //
+  // Side effects:
+  //   - Decrements sender's balance in the balances map.
+  //   - Increments (or creates) recipient's balance in the balances map.
+  //
+  // Access control: Caller must possess the secret key corresponding
+  //   to a registered public key in the balances map.
+  //
+  // Requirements:
+  //   - Sender must exist in the balances map.
+  //   - Sender balance must be >= amount.
+  export circuit transfer(to: Bytes<32>, amount: Field): [] {
+    const sk = localSecretKey();
+    const pk = disclose(publicKey(sk));
+    assert(balances.member(pk), "Sender not found");
+    const senderBalance = balances.lookup(pk);
+    assert(senderBalance >= amount, "Insufficient balance");
+    balances.insert(pk, senderBalance - amount);
+    const toBalance = balances.member(to) ? balances.lookup(to) : 0;
+    balances.insert(to, toBalance + amount);
+  }
+  ```
+
+- [ ] **Circuit parameters are documented with their meaning and constraints.** Each parameter should have a brief description explaining what it represents, its expected format, and any constraints. This is especially important for `Bytes<32>` parameters where the semantic meaning (public key, commitment, nullifier, hash) is not obvious from the type alone.
+
+  ```compact
+  // BAD — parameter types convey no semantic meaning
+  export circuit act(
+    path: MerkleTreePath<16, Bytes<32>>,
+    data: Bytes<32>,
+    value: Field
+  ): [] {
+    // ...
+  }
+
+  // GOOD — parameters documented with semantic meaning
+  // Parameters:
+  //   path: Merkle proof of membership in the members tree.
+  //   data: The member's secret key, used to derive nullifier.
+  //   value: The vote choice (0 = no, 1 = yes).
+  export circuit act(
+    path: MerkleTreePath<16, Bytes<32>>,
+    data: Bytes<32>,
+    value: Field
+  ): [] {
+    // ...
+  }
+  ```
+
+- [ ] **Return value is documented with its meaning.** If an exported circuit returns a value, the documentation should explain what the return value represents and how callers should interpret it. This is critical for circuits that return computed results rather than simple confirmations.
+
+  ```compact
+  // BAD — return value undocumented; caller does not know what Field means
+  export circuit getVoteResult(proposalId: Field): Field {
+    // ...
+    return disclose(result);
+  }
+
+  // GOOD — return value explained
+  // Returns the total vote count for the given proposal.
+  // The returned Field represents the number of "yes" votes cast.
+  // Returns 0 if the proposal does not exist.
+  export circuit getVoteResult(proposalId: Field): Field {
+    // ...
+    return disclose(result);
+  }
+  ```
+
+- [ ] **Side effects are documented: which ledger state is modified.** Every ledger write (map insert, set insert, counter increment, MerkleTree insert, sealed or direct field assignment) should be mentioned in the circuit documentation. A reviewer should be able to determine the full state impact of a circuit without reading the implementation.
+
+  ```compact
+  // BAD — circuit modifies three ledger variables but docs do not mention it
+  export circuit register(commitment: Bytes<32>): [] {
+    members.insert(disclose(commitment));
+    memberCount.increment(1);
+    lastRegistration = disclose(commitment);
+  }
+
+  // GOOD — all ledger modifications listed
+  // Registers a new member by inserting their commitment.
+  //
+  // Side effects:
+  //   - Inserts commitment into the members MerkleTree.
+  //   - Increments memberCount by 1.
+  //   - Updates lastRegistration to the new commitment.
+  export circuit register(commitment: Bytes<32>): [] {
+    members.insert(disclose(commitment));
+    memberCount.increment(1);
+    lastRegistration = disclose(commitment);
+  }
+  ```
+
+- [ ] **Access control is documented: who can call this circuit.** If the circuit includes authorization checks (public key verification, role checks, state guards), the documentation should state who is allowed to call it. If there is no access control, that should also be explicitly stated so a reviewer can determine whether this is intentional.
+
+  ```compact
+  // BAD — circuit has access control but it is not documented
+  export circuit mint(amount: Field): [] {
+    const sk = localSecretKey();
+    const pk = disclose(publicKey(sk));
+    assert(authority == pk, "Not authorized");
+    token.mint(amount);
+  }
+
+  // GOOD — access control clearly stated
+  // Mints new tokens. Only the contract authority can call this circuit.
+  // Access control: Caller must possess the secret key for the authority public key.
+  export circuit mint(amount: Field): [] {
+    const sk = localSecretKey();
+    const pk = disclose(publicKey(sk));
+    assert(authority == pk, "Not authorized");
+    token.mint(amount);
+  }
+  ```
+
+- [ ] **Requirements and assertions are documented: what must hold for the circuit to succeed.** List the preconditions that must be true for the circuit to execute successfully. This includes state machine guards, balance requirements, membership checks, and any other assertions. A caller should know in advance what conditions will cause the transaction to fail.
+
+  ```compact
+  // BAD — multiple assertions with no summary of requirements
+  export circuit reveal(value: Field, salt: Bytes<32>): [] {
+    assert(state == State.Committed, "Wrong state");
+    assert(commitments.member(callerPk), "No commitment");
+    const expected = persistentCommit<Field>(value, salt);
+    assert(commitments.lookup(callerPk) == disclose(expected), "Mismatch");
+    state = State.Revealed;
+  }
+
+  // GOOD — requirements listed upfront
+  // Reveals a previously committed value.
+  //
+  // Requirements:
+  //   - Contract must be in State.Committed.
+  //   - Caller must have a stored commitment in the commitments map.
+  //   - The revealed value and salt must match the stored commitment.
+  export circuit reveal(value: Field, salt: Bytes<32>): [] {
+    assert(state == State.Committed, "Wrong state");
+    assert(commitments.member(callerPk), "No commitment");
+    const expected = persistentCommit<Field>(value, salt);
+    assert(commitments.lookup(callerPk) == disclose(expected), "Mismatch");
+    state = State.Revealed;
+  }
+  ```
+
+- [ ] **Complex internal circuits are also documented.** While exported circuits are the public API, complex internal (non-exported) circuits also benefit from documentation. If an internal circuit performs a non-trivial computation (nullifier derivation, Merkle path verification, multi-step validation), a brief comment explaining its purpose and expected inputs/outputs helps reviewers understand the code.
+
+  ```compact
+  // BAD — complex internal circuit with no documentation
+  circuit deriveNullifier(round: Field, sk: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<3, Bytes<32>>>(
+      [pad(32, "myapp:vote-nul:"), round as Field as Bytes<32>, sk]
+    );
+  }
+
+  // GOOD — internal circuit documented
+  // Derives a deterministic nullifier for a vote in a given round.
+  // The nullifier is unique per (round, secret key) pair and uses
+  // domain separation to prevent cross-protocol collisions.
+  // Used by both commit() and reveal() to ensure consistent nullifier derivation.
+  circuit deriveNullifier(round: Field, sk: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<3, Bytes<32>>>(
+      [pad(32, "myapp:vote-nul:"), round as Field as Bytes<32>, sk]
+    );
+  }
+  ```
+
+## Ledger State Documentation Checklist
+
+Check that every ledger variable has documentation explaining its purpose, visibility rationale, invariants, and relationships with other state.
+
+- [ ] **Every ledger variable has a comment explaining its purpose.** Ledger variables are the persistent state of the contract. Each one should have a brief comment explaining what it stores and why. Type alone does not convey purpose: a `Map<Bytes<32>, Field>` could be balances, vote counts, bid amounts, or timestamps. The comment disambiguates.
+
+  ```compact
+  // BAD — ledger variables with no documentation; purpose unclear
+  export ledger authority: Bytes<32>;
+  export ledger data: Map<Bytes<32>, Field>;
+  export ledger count: Counter;
+  export ledger tree: HistoricMerkleTree<16, Bytes<32>>;
+  export ledger flags: Set<Bytes<32>>;
+  export ledger state: Field;
+
+  // GOOD — every ledger variable documented
+  // Public key of the contract administrator; set at deployment, used for authorization.
+  export sealed ledger authority: Bytes<32>;
+
+  // Maps member public keys to their token balances.
+  export ledger data: Map<Bytes<32>, Field>;
+
+  // Total number of registered members; incremented on each registration.
+  export ledger count: Counter;
+
+  // Merkle tree of member commitments; supports anonymous membership proofs.
+  export ledger tree: HistoricMerkleTree<16, Bytes<32>>;
+
+  // Set of spent nullifiers; prevents double-voting.
+  export ledger flags: Set<Bytes<32>>;
+
+  // Current protocol phase (0 = setup, 1 = active, 2 = finalized).
+  export ledger state: Field;
+  ```
+
+- [ ] **Visibility rationale is explained: why `export` vs `sealed` vs internal.** Each ledger variable's visibility should be a conscious choice, not an accident. If a variable is `export`, the documentation should explain why external parties need to query it. If it is `sealed`, the documentation should explain why immutability is required. If it is internal (no modifier), the documentation should explain why it does not need external access.
+
+  ```compact
+  // BAD — visibility modifiers present but no rationale
+  export ledger voteCount: Counter;
+  sealed ledger maxVotes: Field;
+  ledger internalState: Field;
+
+  // GOOD — visibility rationale documented
+  // Total votes cast; exported so the DApp can display the current count.
+  export ledger voteCount: Counter;
+
+  // Maximum allowed votes per proposal; sealed because it is a deployment-time
+  // configuration that must never change after the contract is live.
+  export sealed ledger maxVotes: Field;
+
+  // Internal flag tracking whether the current round has been initialized.
+  // Not exported because it is only used for internal state machine logic
+  // and should not be part of the public API.
+  ledger internalState: Field;
+  ```
+
+- [ ] **State invariants are documented: what constraints must always hold.** If ledger variables have constraints that must always be maintained (e.g., a counter must equal the number of entries in a map, a balance must never go negative, a state variable must only increase), these invariants should be documented. Invariants help reviewers verify that every circuit maintains them.
+
+  ```compact
+  // BAD — implicit invariant that reviewers might miss
+  export ledger memberCount: Counter;
+  export ledger members: HistoricMerkleTree<16, Bytes<32>>;
+  export ledger usedNullifiers: Set<Bytes<32>>;
+
+  // GOOD — invariants explicitly stated
+  // Total registered members. Invariant: memberCount == number of leaves
+  // inserted into the members tree.
+  export ledger memberCount: Counter;
+
+  // Merkle tree of member commitments. Invariant: every leaf is a unique
+  // commitment derived from a distinct secret key.
+  export ledger members: HistoricMerkleTree<16, Bytes<32>>;
+
+  // Spent nullifiers. Invariant: each nullifier appears at most once;
+  // a nullifier in this set means the corresponding member has already
+  // acted in the current round.
+  export ledger usedNullifiers: Set<Bytes<32>>;
+  ```
+
+- [ ] **Relationships between ledger variables are documented.** When ledger variables are semantically related (e.g., a counter tracks the number of entries in a map, a state enum controls which circuits are callable, a sealed authority controls who can modify other variables), these relationships should be documented. Without this, a reviewer may not realize that modifying one variable requires updating another.
+
+  ```compact
+  // BAD — related variables with no documented relationship
+  export ledger proposals: Map<Field, Bytes<32>>;
+  export ledger proposalCount: Counter;
+  export ledger state: State;
+  export ledger currentRound: Field;
+
+  // GOOD — relationships between variables documented
+  // Active proposals keyed by proposal ID (0-indexed).
+  // Related: proposalCount tracks the next available proposal ID.
+  export ledger proposals: Map<Field, Bytes<32>>;
+
+  // Next proposal ID to assign. Invariant: proposalCount == number of
+  // entries in the proposals map.
+  export ledger proposalCount: Counter;
+
+  // Current protocol phase. Controls which circuits are callable:
+  //   State.Setup -> only initialize() is callable
+  //   State.Active -> propose(), vote() are callable
+  //   State.Finalized -> only getResult() is callable
+  export ledger state: State;
+
+  // Current voting round. Incremented when the state transitions from
+  // Active to Finalized. Used as input to nullifier derivation to ensure
+  // nullifiers are unique per round.
+  export ledger currentRound: Field;
+  ```
+
+- [ ] **Enum types used for ledger state have documented variant meanings.** If a ledger variable uses an enum type, the documentation should explain what each variant represents and when the contract enters that state. This is especially important for state machine contracts where the enum controls the protocol flow.
+
+  ```compact
+  // BAD — enum variants with no explanation
+  enum Phase { A, B, C, D }
+
+  // GOOD — enum variants documented
+  // Protocol phases for the commit-reveal auction.
+  //   Setup: Initial phase; owner configures auction parameters.
+  //   Commit: Bidders submit blinded bid commitments.
+  //   Reveal: Bidders reveal bids; contract verifies against commitments.
+  //   Finalized: Auction concluded; winner determined.
+  enum Phase { Setup, Commit, Reveal, Finalized }
+  ```
+
+## Witness Documentation Checklist
+
+Check that every witness declaration in the Compact contract has documentation explaining what data it provides, its expected behavior, return type semantics, private state requirements, and any preconditions or side effects.
+
+- [ ] **Every witness declaration has a comment explaining what data it provides.** A witness declaration in Compact is a function signature with no body. The implementation lives in TypeScript. Without documentation on the Compact side, a reviewer must switch to the TypeScript file to understand what the witness does. Each witness should have a brief comment explaining what data it supplies and from where.
+
+  ```compact
+  // BAD — witness declarations with no documentation
+  witness localSecretKey(): Bytes<32>;
+  witness getMerklePath(leaf: Bytes<32>): MerkleTreePath<16, Bytes<32>>;
+  witness getBalance(account: Bytes<32>): Uint<64>;
+
+  // GOOD — witness declarations documented
+  // Returns the caller's secret key from local private state.
+  // Used for authorization (deriving the public key for identity checks).
+  witness localSecretKey(): Bytes<32>;
+
+  // Returns a Merkle path proving that the given leaf (commitment) is a
+  // member of the members tree. The path is precomputed from the latest
+  // tree state stored in private state.
+  witness getMerklePath(leaf: Bytes<32>): MerkleTreePath<16, Bytes<32>>;
+
+  // Returns the private token balance for the given account from
+  // the caller's local state. Used for off-chain balance verification
+  // before on-chain assertions.
+  witness getBalance(account: Bytes<32>): Uint<64>;
+  ```
+
+- [ ] **Expected behavior and return type semantics are documented.** The return type of a witness (e.g., `Bytes<32>`, `Field`, `MerkleTreePath<16, Bytes<32>>`) does not convey what the value represents. The documentation should explain what a valid return value looks like and what happens if the witness cannot produce one (e.g., throws an error, returns a default).
+
+  ```compact
+  // BAD — return type alone does not explain what the Field means
+  witness getProposalVotes(proposalId: Field): Field;
+
+  // GOOD — return value semantics explained
+  // Returns the number of votes the caller has privately tracked for
+  // the given proposal. Returns 0 if the proposal is unknown.
+  // The TypeScript implementation should throw an error if the
+  // private state is corrupted rather than returning a garbage value.
+  witness getProposalVotes(proposalId: Field): Field;
+  ```
+
+- [ ] **Private state requirements are documented.** If a witness depends on specific private state being present (e.g., a secret key must have been generated, a Merkle path must have been precomputed, a balance record must exist), these requirements should be documented. This helps the DApp developer ensure the private state is properly initialized before invoking circuits that call the witness.
+
+  ```compact
+  // BAD — witness requires precomputed data but does not say so
+  witness getMerklePath(commitment: Bytes<32>): MerkleTreePath<16, Bytes<32>>;
+
+  // GOOD — private state prerequisites documented
+  // Returns a Merkle path for the given commitment.
+  //
+  // Private state requirement: The DApp must call prepareMerkleProofs()
+  // before invoking any circuit that uses this witness. The Merkle paths
+  // are precomputed from the current on-chain tree state and stored in
+  // privateState.merkleProofs. If no precomputed path exists for the
+  // given commitment, the TypeScript implementation throws an error.
+  witness getMerklePath(commitment: Bytes<32>): MerkleTreePath<16, Bytes<32>>;
+  ```
+
+- [ ] **Preconditions and side effects are documented.** Some witnesses have preconditions (e.g., must be called after another witness has populated state) or side effects (e.g., updates private state to track that a nonce has been used). These should be documented so reviewers and DApp developers understand the full behavior.
+
+  ```compact
+  // BAD — witness has a side effect (stores nonce) but does not document it
+  witness generateNonce(): Bytes<32>;
+
+  // GOOD — side effects documented
+  // Generates a random nonce for use in commitment schemes.
+  //
+  // Side effect: The generated nonce is stored in privateState.lastNonce
+  // so that it can be retrieved later during the reveal phase without
+  // re-generating (which would produce a different value).
+  //
+  // Precondition: None. Can be called at any time.
+  witness generateNonce(): Bytes<32>;
+  ```
+
+- [ ] **Witness parameters are documented with their meaning.** Just as circuit parameters need documentation, witness parameters should explain what the caller is passing. This is especially important because the circuit invokes the witness with specific arguments, and the TypeScript implementation must know what to expect.
+
+  ```compact
+  // BAD — witness parameter has no documented meaning
+  witness lookupRecord(key: Bytes<32>, flag: Boolean): Field;
+
+  // GOOD — witness parameters documented
+  // Looks up a record in the caller's private database.
+  //
+  // Parameters:
+  //   key: The record identifier (typically a hash of the record's public fields).
+  //   flag: If true, include expired records in the search. If false, only
+  //         return active records.
+  //
+  // Returns the record's value, or throws if not found.
+  witness lookupRecord(key: Bytes<32>, flag: Boolean): Field;
+  ```
+
+## Privacy Documentation Checklist
+
+Check that the contract includes documentation explaining its privacy model: what is private, what is disclosed, what guarantees are provided, and what limitations exist.
+
+- [ ] **Which data is private and why.** The contract should document which pieces of data remain private (never disclosed, never written to public ledger) and the reason for their privacy. This helps reviewers verify that the implementation matches the privacy intent.
+
+  ```compact
+  // BAD — no privacy documentation; reviewer must infer from code
+  witness localSecretKey(): Bytes<32>;
+  witness getVoteChoice(): Field;
+
+  export circuit vote(path: MerkleTreePath<16, Bytes<32>>): [] {
+    const sk = localSecretKey();
+    const choice = getVoteChoice();
+    // ...
+  }
+
+  // GOOD — privacy model documented
+  // Privacy Model:
+  //   Private data (never disclosed):
+  //     - Secret key (sk): The voter's identity. Kept private to ensure
+  //       anonymous voting. Only the derived nullifier is disclosed.
+  //     - Vote choice: The actual vote (yes/no) remains private.
+  //       Only a commitment to the vote is stored on-chain.
+  //
+  //   This ensures that:
+  //     1. No observer can determine which member cast a particular vote.
+  //     2. No observer can determine how any member voted.
+
+  witness localSecretKey(): Bytes<32>;
+  witness getVoteChoice(): Field;
+
+  export circuit vote(path: MerkleTreePath<16, Bytes<32>>): [] {
+    const sk = localSecretKey();
+    const choice = getVoteChoice();
+    // ...
+  }
+  ```
+
+- [ ] **Which data is disclosed and why.** Every `disclose()` call and every value written to a public ledger variable should have a documented rationale. The reviewer needs to understand why each piece of data is public so they can assess whether the disclosure is necessary or excessive.
+
+  ```compact
+  // BAD — disclosures present but no rationale
+  export circuit register(sk: Bytes<32>): [] {
+    const pk = disclose(publicKey(sk));
+    authority = pk;
+    memberCount.increment(1);
+  }
+
+  // GOOD — disclosure rationale documented
+  // register: Creates the contract authority.
+  //
+  // Disclosed data:
+  //   - pk (derived from sk): The authority's public key must be stored
+  //     on the public ledger so that future authorization checks can
+  //     compare against it. The secret key remains private; only the
+  //     derived public key is disclosed.
+  //   - memberCount increment: The count is inherently public (Counter
+  //     operations are always visible). This is acceptable because knowing
+  //     the total member count does not compromise individual privacy.
+  export circuit register(sk: Bytes<32>): [] {
+    const pk = disclose(publicKey(sk));
+    authority = pk;
+    memberCount.increment(1);
+  }
+  ```
+
+- [ ] **Privacy guarantees the contract provides are explicitly stated.** The contract should document the privacy properties it claims to provide. These are the promises to users. Common guarantees include: voter anonymity, transaction amount confidentiality, membership privacy, and unlinkability between actions.
+
+  ```compact
+  // BAD — no stated privacy guarantees; users cannot evaluate the contract's promises
+  // (no documentation)
+
+  // GOOD — privacy guarantees explicitly listed
+  // Privacy Guarantees:
+  //   1. Voter anonymity: An observer cannot determine which registered
+  //      member cast any particular vote. Votes use MerkleTree membership
+  //      proofs with nullifiers; the observer sees only a valid proof
+  //      and an opaque nullifier.
+  //   2. Vote confidentiality: Individual vote choices (yes/no) are never
+  //      disclosed. Only the aggregate tally is public after finalization.
+  //   3. Unlinkability: A voter's registration transaction cannot be linked
+  //      to their voting transaction because different domain-separated
+  //      values are used for registration commitments and vote nullifiers.
+  ```
+
+- [ ] **Privacy limitations or caveats are documented.** Every privacy system has limitations. The contract should honestly document what is NOT private, what can be inferred by an observer, and what trust assumptions exist. Common caveats include: transaction timing correlation, observable circuit names, visible state change patterns, and counter/set operation visibility.
+
+  ```compact
+  // BAD — no mention of privacy limitations; users may have false expectations
+
+  // GOOD — limitations honestly documented
+  // Privacy Limitations:
+  //   1. Transaction timing: An observer can correlate registration and
+  //      voting timing. If only one member registers and then votes
+  //      within a short window, anonymity is effectively broken.
+  //   2. Circuit name visibility: The name of the called circuit (e.g.,
+  //      "vote", "register") is always visible on-chain. An observer
+  //      knows WHAT action was taken, just not by whom.
+  //   3. Counter visibility: The memberCount and voteCount values are
+  //      public. An observer can track participation rates.
+  //   4. Set size: The usedNullifiers set size reveals how many unique
+  //      voters have participated, even though individual identities
+  //      are hidden.
+  //   5. Single-voter deanonymization: If the set of registered members
+  //      is small (e.g., 2-3 people), the anonymity set is too small
+  //      to provide meaningful privacy. This contract is designed for
+  //      groups of 10+ members.
+  ```
+
+- [ ] **Privacy documentation covers the full data lifecycle.** Privacy analysis should cover data at rest (ledger state), data in motion (circuit parameters, return values, disclosed values), and data derivation (what can be inferred from public state changes over time). A common oversight is documenting what is private within a single transaction but ignoring what can be inferred from observing multiple transactions over time.
+
+  ```compact
+  // BAD — privacy documented only for individual circuits, not lifecycle
+
+  // GOOD — lifecycle privacy documented
+  // Data Lifecycle Privacy Analysis:
+  //
+  // Registration (register circuit):
+  //   - Input: commitment (public) — derived from secret key + nonce
+  //   - On-chain: commitment inserted into MerkleTree (leaf value hidden)
+  //   - Observable: a new leaf was inserted (tree size increased by 1)
+  //
+  // Voting (vote circuit):
+  //   - Input: Merkle path (private), nullifier (disclosed)
+  //   - On-chain: nullifier inserted into usedNullifiers set
+  //   - Observable: a new nullifier appeared (one more voter participated)
+  //
+  // Cross-transaction inference:
+  //   - An observer tracking registration timestamps and subsequent vote
+  //     timestamps may narrow the anonymity set. Mitigation: users should
+  //     wait a random delay between registration and voting.
+  //   - If the total number of registrations equals the total number of
+  //     votes, all members voted, which is itself information.
+  ```
+
+## Anti-Patterns Table
+
+Quick reference of common documentation anti-patterns in Compact contracts.
+
+| Anti-Pattern | Why It's Wrong | Correct Approach |
+|---|---|---|
+| No top-level comment explaining contract purpose | Reviewer must reverse-engineer intent from code; increases review time and error rate | First comment in file should explain what the contract does in 1-3 sentences |
+| Exported circuit with no documentation | Part of the public API with no explanation; callers and reviewers cannot understand intent | Document purpose, parameters, return value, side effects, access control, and requirements |
+| Ledger variable with no comment | Type alone (e.g., `Map<Bytes<32>, Field>`) does not convey purpose; could mean balances, scores, timestamps, or anything else | Brief comment explaining what the variable stores and why |
+| Missing visibility rationale | Reviewer cannot tell if `export` vs `sealed` vs internal was a conscious choice or an accident | Document why each visibility modifier was chosen |
+| Undocumented state invariants | Invariants exist implicitly but reviewers do not know to check them; bugs slip through when a circuit breaks an unstated invariant | Explicitly document constraints like "counter == map size" or "balance >= 0" |
+| Witness declaration with no comment | Reviewer must find the TypeScript implementation to understand what the witness provides; slows down review | Document what data the witness provides, from where, and any prerequisites |
+| No privacy model documentation | Users cannot evaluate what privacy the contract provides; may have false expectations of confidentiality | Document what is private, what is disclosed, guarantees provided, and limitations |
+| Privacy guarantees stated without limitations | Gives users a false sense of security; every privacy system has caveats (timing, set size, observable metadata) | Honestly document both guarantees and limitations |
+| Documentation only covers happy path | No mention of what happens when assertions fail, when state is missing, or when preconditions are not met | Document failure modes, error conditions, and edge cases |
+| Stale documentation that contradicts the code | Worse than no documentation; misleads reviewers into believing incorrect behavior | Update documentation whenever code changes; review docs as part of code review |

--- a/plugins/compact-core/skills/compact-review/references/documentation-review.md
+++ b/plugins/compact-core/skills/compact-review/references/documentation-review.md
@@ -2,6 +2,19 @@
 
 Review checklist for the **Documentation** category. This covers contract-level documentation, circuit documentation, ledger state documentation, witness documentation, and privacy documentation. Well-documented contracts are easier to audit, maintain, and integrate with. Poor documentation hides intent, makes review harder, and increases the chance that bugs go unnoticed because reviewers cannot tell what the code is supposed to do. Apply every item below to the contract under review.
 
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation output reveals contract structure for documentation completeness analysis |
+| `midnight-extract-contract-structure` | `[shared]` | Lists all exported circuits, ledger variables, witnesses — the definitive inventory for documentation coverage |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of contract patterns and structure |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for verifying documentation accuracy |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
 ## Contract-Level Documentation Checklist
 
 Check that the contract file includes top-level documentation explaining its purpose, design, deployment requirements, and dependencies.
@@ -107,6 +120,8 @@ Check that the contract file includes top-level documentation explaining its pur
 Check that every exported circuit and complex internal circuit has documentation explaining its purpose, parameters, return value, side effects, access control, and requirements.
 
 - [ ] **Every exported circuit has a comment explaining its purpose.** An `export circuit` is part of the contract's public API. Anyone interacting with the contract needs to understand what each circuit does. The comment should describe the high-level action, not repeat the code line-by-line.
+
+  > **Tool:** `midnight-extract-contract-structure` lists all exported circuits. Use this as your definitive checklist — every exported circuit must have documentation.
 
   ```compact
   // BAD — no documentation on exported circuit
@@ -297,6 +312,8 @@ Check that every ledger variable has documentation explaining its purpose, visib
 
 - [ ] **Every ledger variable has a comment explaining its purpose.** Ledger variables are the persistent state of the contract. Each one should have a brief comment explaining what it stores and why. Type alone does not convey purpose: a `Map<Bytes<32>, Field>` could be balances, vote counts, bid amounts, or timestamps. The comment disambiguates.
 
+  > **Tool:** `midnight-extract-contract-structure` lists all ledger variable declarations with their types and visibility modifiers. Use this as your checklist for documentation coverage.
+
   ```compact
   // BAD — ledger variables with no documentation; purpose unclear
   export ledger authority: Bytes<32>;
@@ -421,6 +438,8 @@ Check that every ledger variable has documentation explaining its purpose, visib
 Check that every witness declaration in the Compact contract has documentation explaining what data it provides, its expected behavior, return type semantics, private state requirements, and any preconditions or side effects.
 
 - [ ] **Every witness declaration has a comment explaining what data it provides.** A witness declaration in Compact is a function signature with no body. The implementation lives in TypeScript. Without documentation on the Compact side, a reviewer must switch to the TypeScript file to understand what the witness does. Each witness should have a brief comment explaining what data it supplies and from where.
+
+  > **Tool:** `midnight-extract-contract-structure` lists all witness declarations. Use this to verify every witness has documentation. `midnight-search-docs` can provide context on standard witness patterns and WitnessContext documentation.
 
   ```compact
   // BAD — witness declarations with no documentation
@@ -622,6 +641,8 @@ Check that the contract includes documentation explaining its privacy model: wha
 
 - [ ] **Privacy documentation covers the full data lifecycle.** Privacy analysis should cover data at rest (ledger state), data in motion (circuit parameters, return values, disclosed values), and data derivation (what can be inferred from public state changes over time). A common oversight is documenting what is private within a single transaction but ignoring what can be inferred from observing multiple transactions over time.
 
+  > **Tool:** `midnight-extract-contract-structure` identifies all `disclose()` calls, ledger writes, and data flow patterns. Use this to verify the privacy documentation covers every disclosure point. `midnight-search-docs` has guidance on documenting privacy models.
+
   ```compact
   // BAD — privacy documented only for individual circuits, not lifecycle
 
@@ -662,3 +683,13 @@ Quick reference of common documentation anti-patterns in Compact contracts.
 | Privacy guarantees stated without limitations | Gives users a false sense of security; every privacy system has caveats (timing, set size, observable metadata) | Honestly document both guarantees and limitations |
 | Documentation only covers happy path | No mention of what happens when assertions fail, when state is missing, or when preconditions are not met | Document failure modes, error conditions, and edge cases |
 | Stale documentation that contradicts the code | Worse than no documentation; misleads reviewers into believing incorrect behavior | Update documentation whenever code changes; review docs as part of code review |
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Reveals complete contract structure. |
+| `midnight-extract-contract-structure` | Lists all exported circuits, ledger variables, witnesses, and data flow — the definitive inventory for documentation coverage analysis. |
+| `midnight-analyze-contract` | Static analysis of contract patterns for architectural documentation. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference for verifying technical accuracy of documentation. |
+| `midnight-search-docs` | Full-text search across official Midnight documentation for documentation standards and privacy model guidance. |

--- a/plugins/compact-core/skills/compact-review/references/performance-review.md
+++ b/plugins/compact-core/skills/compact-review/references/performance-review.md
@@ -1,0 +1,465 @@
+# Performance & Circuit Efficiency Review Checklist
+
+Review checklist for the **Performance & Circuit Efficiency** category. Every operation in a Compact circuit translates to constraints in the zero-knowledge proof. More constraints mean longer proof generation time and higher resource consumption for the prover. This review identifies unnecessary computational overhead, oversized data structures, and operations that could be moved off-chain. Apply every item below to the contract under review.
+
+## Proof Generation Cost Checklist
+
+Check every circuit for unnecessary arithmetic, redundant computations, and expressions that could be simplified. Every operation adds constraints to the ZK proof — fewer constraints mean faster proof generation.
+
+- [ ] **Unnecessary arithmetic operations that could be simplified.** Look for arithmetic expressions that perform extra steps when a simpler equivalent exists. Each arithmetic operation (addition, multiplication, comparison) adds constraints. Algebraic simplification directly reduces proof generation cost.
+
+  ```compact
+  // BAD — unnecessary multiplication and addition; 4 operations
+  export circuit compute(x: Field, y: Field): Field {
+    const a = x * 2;
+    const b = y * 2;
+    const c = a + b;
+    return disclose(c);
+  }
+
+  // GOOD — simplified to a single multiplication; 2 operations
+  export circuit compute(x: Field, y: Field): Field {
+    const result = (x + y) * 2;
+    return disclose(result);
+  }
+  ```
+
+- [ ] **Redundant computations that compute the same value multiple times.** If the same expression is evaluated more than once within a circuit, each evaluation generates its own set of constraints. Extract the result into a `const` and reuse it. This is especially important for expensive operations like hash computations.
+
+  ```compact
+  // BAD — same hash computed twice; double the constraints
+  export circuit verify_and_store(sk: Bytes<32>): [] {
+    const pk1 = persistentHash<Vector<2, Bytes<32>>>([pad(32, "app:pk:"), sk]);
+    assert(authority == disclose(pk1), "Not authorized");
+    const pk2 = persistentHash<Vector<2, Bytes<32>>>([pad(32, "app:pk:"), sk]);
+    records.insert(disclose(pk2), disclose(1 as Field));
+  }
+
+  // GOOD — compute once, reuse the result
+  export circuit verify_and_store(sk: Bytes<32>): [] {
+    const pk = persistentHash<Vector<2, Bytes<32>>>([pad(32, "app:pk:"), sk]);
+    assert(authority == disclose(pk), "Not authorized");
+    records.insert(disclose(pk), disclose(1 as Field));
+  }
+  ```
+
+- [ ] **Complex expressions that could be simplified algebraically.** Review mathematical expressions for algebraic identities that reduce operations. Common simplifications include factoring common subexpressions, reducing `x * 1` to `x`, replacing `x * 2` with `x + x` (if addition is cheaper in the constraint system), and simplifying boolean expressions.
+
+  ```compact
+  // BAD — redundant computation of (a * b) in both branches
+  export circuit calculate(a: Field, b: Field, c: Field): Field {
+    const term1 = a * b + c;
+    const term2 = a * b - c;
+    const result = term1 + term2;
+    return disclose(result);
+  }
+
+  // GOOD — algebraically simplified: (ab + c) + (ab - c) = 2ab
+  export circuit calculate(a: Field, b: Field, c: Field): Field {
+    const result = (a * b) + (a * b);
+    return disclose(result);
+  }
+  ```
+
+- [ ] **Unnecessary intermediate type conversions in arithmetic chains.** Each type cast in an arithmetic chain adds constraints. If a value flows through multiple casts before being used, check whether the initial declaration could match the target type directly, eliminating the casts entirely.
+
+  ```compact
+  // BAD — declares as Uint, casts to Field for arithmetic, casts back
+  const x: Uint<64> = 42;
+  const y: Uint<64> = 10;
+  const result = ((x as Field) + (y as Field)) as Uint<64>;
+
+  // GOOD — declare as Field if Field arithmetic is the primary use
+  const x: Field = 42;
+  const y: Field = 10;
+  const result = x + y;
+  ```
+
+## Ledger State Read Efficiency Checklist
+
+Check every circuit for redundant or unnecessary ledger reads. Each ledger read translates to constraints in the proof and increases the transaction's state footprint.
+
+- [ ] **Reading the same ledger variable multiple times in one circuit.** Each read of a ledger variable generates constraints. If the same ledger variable is read more than once within a single circuit, cache the value in a `const` and reuse it.
+
+  ```compact
+  // BAD — reads authority from ledger three times
+  export circuit check_and_act(sk: Bytes<32>): [] {
+    const pk = disclose(publicKey(sk));
+    assert(authority == pk, "Not authorized");
+    records.insert(pk, authority);
+    log_action(authority);
+  }
+
+  // GOOD — read once, cache in const, reuse
+  export circuit check_and_act(sk: Bytes<32>): [] {
+    const pk = disclose(publicKey(sk));
+    const auth = authority;
+    assert(auth == pk, "Not authorized");
+    records.insert(pk, auth);
+    log_action(auth);
+  }
+  ```
+
+- [ ] **`Map.member()` + `Map.lookup()` with the same key — necessary but note the double read.** The `member()` + `lookup()` pattern is required for safety (see Security checklist), because calling `lookup()` on a non-existent key causes a runtime failure. However, this does mean two ledger reads for the same key. This is an accepted cost for correctness, but flag it if the `member()` check is truly unnecessary (e.g., the key is guaranteed to exist from prior logic).
+
+  ```compact
+  // NECESSARY — member() check required before lookup()
+  export circuit get_balance(account: Bytes<32>): Field {
+    assert(balances.member(account), "Account not found");
+    return disclose(balances.lookup(account));
+  }
+
+  // UNNECESSARY DOUBLE READ — key is guaranteed to exist from insert above
+  export circuit initialize_and_read(account: Bytes<32>): Field {
+    balances.insert(account, disclose(100 as Field));
+    // account was just inserted; member() check is redundant here
+    assert(balances.member(account), "Account not found");
+    return disclose(balances.lookup(account));
+  }
+  ```
+
+- [ ] **Unnecessary ledger reads when the value is not needed.** A circuit that reads a ledger variable but never uses the result in any computation or assertion wastes constraints. Remove any ledger read whose result is not consumed.
+
+  ```compact
+  // BAD — reads counter value but never uses it
+  export circuit increment_only(): [] {
+    const unused = counter.read();
+    counter.increment(1);
+  }
+
+  // GOOD — only performs the needed operation
+  export circuit increment_only(): [] {
+    counter.increment(1);
+  }
+  ```
+
+## MerkleTree Depth Sizing Checklist
+
+Check every `MerkleTree` and `HistoricMerkleTree` declaration for appropriate depth. Merkle trees, exposed in Compact as the `MerkleTree<n, T>` and `HistoricMerkleTree<n, T>` types, are a very useful tool for shielding the values contained in a set. Their key feature is making it possible to assert publicly that some value is contained within the `MerkleTree`, without revealing which value this is. The depth parameter `n` determines the tree's capacity and directly impacts proof generation cost.
+
+- [ ] **Depth determines capacity: `2^depth` leaves.** Verify the depth is appropriate for the expected number of entries. Common depth values and their capacities:
+
+  | Depth | Capacity | Typical Use Case |
+  |-------|----------|-----------------|
+  | 8 | 256 | Small membership set, testing |
+  | 10 | 1,024 | Small to medium membership |
+  | 16 | 65,536 | Medium membership set |
+  | 20 | ~1M | Large membership set |
+  | 24 | ~16M | Very large membership set |
+  | 32 | ~4B | Global-scale set |
+
+- [ ] **Oversized depth wastes proof generation time.** Deeper Merkle trees generate more constraints per path verification because each level of the tree adds hash computations to the proof. A depth-32 tree generates roughly 4x the path verification constraints of a depth-8 tree. If the contract will never need more than a few thousand entries, a depth-32 tree wastes significant proof generation resources.
+
+  ```compact
+  // BAD — depth 32 for a voting contract with at most 1000 voters
+  // Proof verifies 32 hash levels when 10 would suffice
+  export ledger voters: HistoricMerkleTree<32, Bytes<32>>;
+
+  // GOOD — depth 10 covers 1024 entries; sufficient with margin
+  export ledger voters: HistoricMerkleTree<10, Bytes<32>>;
+  ```
+
+- [ ] **Undersized depth limits future capacity.** While oversizing wastes resources, undersizing risks running out of capacity. Once a MerkleTree is full, no new leaves can be inserted without deploying a new contract. This is not recoverable.
+
+  ```compact
+  // BAD — depth 4 only holds 16 entries; will fill up fast
+  export ledger members: MerkleTree<4, Bytes<32>>;
+
+  // GOOD — anticipate growth; use minimum depth with headroom
+  export ledger members: MerkleTree<16, Bytes<32>>;
+  ```
+
+- [ ] **Rule of thumb: use minimum depth that covers expected maximum entries with 10x margin.** If you expect 500 entries, 10x margin means planning for 5,000. `2^13 = 8192` covers this, so depth 13 is appropriate. Do not default to depth 32 "just in case" — the proof cost is real.
+
+  ```compact
+  // Expected: ~200 members
+  // 200 * 10 = 2000 → 2^11 = 2048 → depth 11
+
+  // BAD — default depth 32 for a 200-member DAO
+  export ledger members: HistoricMerkleTree<32, Bytes<32>>;
+
+  // GOOD — depth 11 covers 2048 entries (10x margin over 200)
+  export ledger members: HistoricMerkleTree<11, Bytes<32>>;
+  ```
+
+- [ ] **`MerkleTree<1, T>` — minimum depth is 2 (depth 1 is invalid).** A MerkleTree with depth 1 would have only 2 leaves and may not function correctly. The minimum usable depth is 2 (4 leaves). If you see depth 1, flag it as likely incorrect.
+
+  ```compact
+  // BAD — depth 1 is invalid; will not work correctly
+  export ledger items: MerkleTree<1, Bytes<32>>;
+
+  // GOOD — minimum usable depth is 2
+  export ledger items: MerkleTree<2, Bytes<32>>;
+  ```
+
+## Loop and Iteration Impact Checklist
+
+Check every `for` loop and `Vector<N, T>` iteration for circuit size impact. Compact loops are unrolled at compile time, so the loop body's constraints are multiplied by the iteration count.
+
+- [ ] **`for` loops in Compact are unrolled at compile time.** A `for` loop over 1000 elements generates 1000 copies of the loop body's constraints. This is not a runtime iteration — it is compile-time duplication. A loop body with 10 constraints iterated 1000 times produces 10,000 constraints. Review whether the iteration count is truly necessary.
+
+  ```compact
+  // BAD — 1000 iterations, each with hash computation
+  // Generates thousands of constraints from the unrolled loop
+  for (const i = 0; i < 1000; i++) {
+    const h = persistentHash<Bytes<32>>(data[i]);
+    assert(h != pad(32, ""), "Invalid data");
+  }
+
+  // BETTER — if only a subset needs validation, reduce the iteration count
+  // Or move the validation to witness code and verify the result in circuit
+  ```
+
+- [ ] **Large `Vector<N, T>` iterations: N directly multiplies circuit size.** When iterating over a `Vector<N, T>`, the loop body is duplicated N times. A `Vector<256, Field>` iteration with a body containing 5 constraints generates 1280 constraints. Consider whether the full vector needs to be processed in-circuit or whether a partial approach is possible.
+
+  ```compact
+  // BAD — iterates over 256-element vector in circuit
+  // Every element processed adds to proof generation time
+  circuit sumVector(v: Vector<256, Field>): Field {
+    const total: Field = 0;
+    for (const i = 0; i < 256; i++) {
+      total = total + v[i];
+    }
+    return total;
+  }
+
+  // BETTER — if the sum can be computed off-chain, do it in witness
+  // and verify the result in circuit (see Circuit vs Witness Boundary)
+  witness computeSum(v: Vector<256, Field>): Field;
+
+  circuit verifySumCorrect(v: Vector<256, Field>, claimed_sum: Field): Boolean {
+    // Verify a property of the sum rather than recomputing it
+    // (if verification is cheaper than computation)
+    return true;
+  }
+  ```
+
+- [ ] **Consider whether the operation can be done off-chain in witness code instead.** Any computation whose result can be efficiently verified is a candidate for moving to the witness. The circuit only needs to assert that the witness-provided result is correct. This trades circuit constraints for witness computation, which does not affect proof size.
+
+  ```compact
+  // BAD — searching for a value in a vector inside the circuit
+  // Unrolls to N comparisons regardless of where the value is found
+  circuit findIndex(v: Vector<64, Field>, target: Field): Uint<8> {
+    const index: Uint<8> = 0;
+    for (const i = 0; i < 64; i++) {
+      index = (v[i] == target) ? i as Uint<8> : index;
+    }
+    return index;
+  }
+
+  // GOOD — witness provides the index, circuit just verifies
+  witness findIndexOffchain(v: Vector<64, Field>, target: Field): Uint<8>;
+
+  circuit verifyIndex(v: Vector<64, Field>, target: Field, index: Uint<8>): [] {
+    assert(v[index] == target, "Witness provided incorrect index");
+  }
+  ```
+
+## Type Conversion Overhead Checklist
+
+Check for unnecessary or multi-step type casts that add proof constraints without serving a purpose.
+
+- [ ] **Unnecessary casts add proof constraints.** Every type conversion in a circuit generates additional constraints to prove the conversion is valid. If a value is declared as one type and then immediately cast to another, consider declaring it as the target type from the start.
+
+  ```compact
+  // BAD — declares as Uint<64>, immediately casts to Field
+  const x: Uint<64> = 42;
+  const y = x as Field;
+  // The cast adds constraints to prove the conversion is valid
+
+  // GOOD — declare as the type you actually need
+  const x: Field = 42;
+  ```
+
+- [ ] **Multi-step casts: each step adds constraints.** Patterns like `Uint<64> → Field → Bytes<32>` involve two separate cast operations, each generating its own constraints. While sometimes necessary (Compact requires the intermediate `Field` step for `Uint` to `Bytes` conversion), review whether the initial type choice could avoid the chain entirely.
+
+  ```compact
+  // BAD — triple cast chain; each step adds constraints
+  const value: Uint<64> = 42;
+  const asField = value as Field;
+  const asBytes = asField as Bytes<32>;
+  const result = persistentHash<Vector<2, Bytes<32>>>([pad(32, "app:"), asBytes]);
+
+  // GOOD — declare as Bytes<32> from the start if that is the final use
+  // Or accept the value as Bytes<32> from the witness
+  witness get_value_bytes(): Bytes<32>;
+
+  circuit computeHash(): Bytes<32> {
+    const value = get_value_bytes();
+    return persistentHash<Vector<2, Bytes<32>>>([pad(32, "app:"), value]);
+  }
+  ```
+
+- [ ] **Repeated casts of the same value.** If a value is cast to the same target type multiple times in a circuit, each cast generates separate constraints. Cache the cast result in a `const` and reuse it.
+
+  ```compact
+  // BAD — casts the same value to Field twice
+  const amount: Uint<64> = 100;
+  const hash_input = amount as Field as Bytes<32>;
+  const comparison = amount as Field;
+
+  // GOOD — cast once, reuse the result
+  const amount: Uint<64> = 100;
+  const amount_as_field = amount as Field;
+  const hash_input = amount_as_field as Bytes<32>;
+  const comparison = amount_as_field;
+  ```
+
+## Circuit vs Witness Boundary Checklist
+
+Check whether expensive computations are correctly placed at the circuit/witness boundary. Expensive computations that do not need to be proved should be in witness TypeScript code, not in the circuit. The circuit should only verify the result.
+
+- [ ] **Expensive computation in circuit that could be in witness.** If a computation is expensive (many constraints) but its result can be verified cheaply, move the computation to the witness and verify the result in the circuit. The proof only needs to demonstrate that the result is correct, not how it was computed.
+
+  ```compact
+  // BAD — sorting inside the circuit is extremely expensive
+  // A sort of N elements generates O(N^2) comparison constraints
+  circuit sortAndProcess(v: Vector<16, Field>): [] {
+    // Bubble sort in circuit — 16 * 15 / 2 = 120 comparison constraints
+    for (const i = 0; i < 16; i++) {
+      for (const j = 0; j < 15; j++) {
+        // swap logic generates many constraints per iteration
+      }
+    }
+    // ... process sorted result
+  }
+
+  // GOOD — sort in witness, verify sorted order in circuit
+  witness sortOffchain(v: Vector<16, Field>): Vector<16, Field>;
+
+  circuit processIfSorted(sorted: Vector<16, Field>): [] {
+    // Verify sorted order: O(N) comparisons instead of O(N^2)
+    for (const i = 0; i < 15; i++) {
+      assert(sorted[i] as Uint<64> <= sorted[i + 1] as Uint<64>,
+        "Not sorted");
+    }
+    // ... process verified sorted result
+  }
+  ```
+
+- [ ] **Only the verification (assert the result is correct) needs to be in the circuit.** The circuit's job is to constrain the witness output so that only correct results are accepted. The actual computation can happen anywhere — the witness, a server, the user's browser — as long as the circuit can verify the result. This is the fundamental optimization principle for ZK circuits.
+
+  ```compact
+  // BAD — computing square root in circuit (expensive iterative computation)
+  circuit squareRoot(n: Field): Field {
+    // Iterative approximation in circuit — many constraints
+    const guess: Field = n;
+    for (const i = 0; i < 20; i++) {
+      guess = (guess + n / guess) / 2;
+    }
+    return guess;
+  }
+
+  // GOOD — witness computes the root, circuit verifies root * root == n
+  witness computeSquareRoot(n: Field): Field;
+
+  circuit verifiedSquareRoot(n: Field): Field {
+    const root = computeSquareRoot(n);
+    assert(root * root == n, "Invalid square root");
+    return root;
+  }
+  ```
+
+- [ ] **Lookup tables or search operations inside circuit.** Searching through a data structure (finding a value in a list, looking up a key in an array) inside a circuit requires iterating over all elements. Move the search to the witness and have the circuit verify the result at the found index.
+
+  ```compact
+  // BAD — linear search in circuit; iterates over all 32 elements
+  circuit findOwner(
+    entries: Vector<32, Bytes<32>>,
+    target: Bytes<32>
+  ): Boolean {
+    const found: Boolean = false;
+    for (const i = 0; i < 32; i++) {
+      found = found || (entries[i] == target);
+    }
+    return found;
+  }
+
+  // GOOD — witness provides the index, circuit verifies
+  witness findOwnerIndex(
+    entries: Vector<32, Bytes<32>>,
+    target: Bytes<32>
+  ): Uint<8>;
+
+  circuit verifyOwner(
+    entries: Vector<32, Bytes<32>>,
+    target: Bytes<32>
+  ): Boolean {
+    const idx = findOwnerIndex(entries, target);
+    return entries[idx] == target;
+  }
+  ```
+
+## `pureCircuit` Optimization Checklist
+
+Check for opportunities to use `pure circuit` for reusable logic that does not access ledger state.
+
+- [ ] **Reusable logic that does not touch ledger state should be `pure circuit`.** A `pure circuit` cannot read or write ledger state. This restriction allows the compiler to apply optimizations that are not possible for stateful circuits. It also makes the circuit reusable from both other circuits and witness code. If a helper circuit does not access any ledger variables, mark it as `pure circuit`.
+
+  ```compact
+  // BAD — regular circuit that does not use ledger state
+  circuit computeCommitment(sk: Bytes<32>, value: Field): Bytes<32> {
+    return persistentHash<Vector<3, Bytes<32>>>(
+      [pad(32, "app:commit:"), sk, value as Field as Bytes<32>]
+    );
+  }
+
+  // GOOD — pure circuit; enables compiler optimizations and witness reuse
+  pure circuit computeCommitment(sk: Bytes<32>, value: Field): Bytes<32> {
+    return persistentHash<Vector<3, Bytes<32>>>(
+      [pad(32, "app:commit:"), sk, value as Field as Bytes<32>]
+    );
+  }
+  ```
+
+- [ ] **Pure circuits can be called from witnesses and may benefit from compiler optimizations.** Because `pure circuit` functions have no side effects (no ledger access), they can be safely called from witness TypeScript code as well as from other circuits. This enables sharing logic between the on-chain proof and the off-chain witness computation without duplication.
+
+  ```compact
+  // GOOD — pure circuit shared between circuit and witness contexts
+  pure circuit derivePublicKey(sk: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<2, Bytes<32>>>(
+      [pad(32, "app:pk:"), sk]
+    );
+  }
+
+  // Used in an export circuit for on-chain verification
+  export circuit register(): [] {
+    const sk = local_secret_key();
+    const pk = derivePublicKey(sk);
+    authority = disclose(pk);
+  }
+
+  // The same derivePublicKey can be called from witness TypeScript code
+  // to derive keys off-chain without duplicating the logic
+  ```
+
+- [ ] **Non-pure circuit used where a pure circuit would suffice.** If a circuit is declared without the `pure` modifier but does not access ledger state, it should be converted to `pure circuit`. A non-pure circuit may miss compiler optimizations and cannot be called from witness contexts.
+
+  ```compact
+  // BAD — circuit does not touch ledger but is not marked pure
+  circuit hashPair(a: Bytes<32>, b: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<2, Bytes<32>>>([a, b]);
+  }
+
+  // GOOD — marked as pure circuit; same logic, better optimizations
+  pure circuit hashPair(a: Bytes<32>, b: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<2, Bytes<32>>>([a, b]);
+  }
+  ```
+
+## Anti-Patterns Table
+
+Quick reference of common performance anti-patterns in Compact contracts.
+
+| Anti-Pattern | Why It's Costly | Correct Approach |
+|---|---|---|
+| Same hash computed twice in one circuit | Each hash computation generates its own full set of constraints; duplicating a hash doubles the constraint count | Compute once, store in `const`, reuse the result |
+| `MerkleTree<32, T>` for a 200-member set | Depth-32 path verification generates 32 levels of hash constraints; a depth-11 tree covers 2048 entries and generates 1/3 the constraints | Use minimum depth with 10x margin: `MerkleTree<11, T>` for ~200 expected entries |
+| `for` loop over 1000 elements in circuit | Loop is unrolled at compile time; 1000 iterations of a 10-constraint body produces 10,000 constraints | Move computation to witness; verify the result in circuit with a single assertion |
+| Sorting inside a circuit | O(N^2) comparisons all become constraints; sorting 16 elements generates ~120 comparison constraints | Sort in witness TypeScript code; verify sorted order in circuit with O(N) comparisons |
+| `Uint<64>` → `Field` → `Bytes<32>` chain when only `Bytes<32>` is needed | Each cast step adds constraints to prove the conversion is valid; multi-step chains multiply the cost | Declare or accept the value as the target type from the start |
+| Reading same ledger variable 3+ times | Each read generates constraints; 3 reads of the same variable triples the read cost | Read once into a `const`, reuse throughout the circuit |
+| Helper circuit without `pure` modifier that does not access ledger | Misses compiler optimizations available to pure circuits; cannot be called from witness code | Add `pure` modifier: `pure circuit helperName(...)` |
+| Linear search inside circuit over `Vector<N, T>` | Iterates all N elements regardless of position; N comparisons become N constraint groups | Witness provides the index; circuit verifies `v[index] == target` in a single comparison |
+| `MerkleTree<1, T>` declaration | Depth 1 is invalid and will not function correctly | Minimum usable depth is 2: `MerkleTree<2, T>` |
+| Unnecessary `counter.read()` when only `increment()` is needed | Read generates constraints for a value that is never used in computation | Remove the read; call `counter.increment(n)` directly |

--- a/plugins/compact-core/skills/compact-review/references/performance-review.md
+++ b/plugins/compact-core/skills/compact-review/references/performance-review.md
@@ -2,6 +2,21 @@
 
 Review checklist for the **Performance & Circuit Efficiency** category. Every operation in a Compact circuit translates to constraints in the zero-knowledge proof. More constraints mean longer proof generation time and higher resource consumption for the prover. This review identifies unnecessary computational overhead, oversized data structures, and operations that could be moved off-chain. Apply every item below to the contract under review.
 
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Syntax validation and basic compilation checks |
+| `midnight-extract-contract-structure` | `[shared]` | Identifies data structure declarations, loop patterns, type casts |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of circuit complexity patterns |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for pure circuit syntax and type cast rules |
+| `midnight-compile-contract` (fullCompile) | `[category-specific]` | **Run this yourself** with `fullCompile=true` to get full ZK compilation including circuit size metrics. This reveals proof generation cost. |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+Tools marked `[category-specific]` must be run by you during your review.
+
 ## Proof Generation Cost Checklist
 
 Check every circuit for unnecessary arithmetic, redundant computations, and expressions that could be simplified. Every operation adds constraints to the ZK proof — fewer constraints mean faster proof generation.
@@ -159,6 +174,8 @@ Check every `MerkleTree` and `HistoricMerkleTree` declaration for appropriate de
   export ledger voters: HistoricMerkleTree<10, Bytes<32>>;
   ```
 
+  > **Tool:** `midnight-extract-contract-structure` lists all MerkleTree declarations with their depth parameters. Cross-reference each depth against the expected capacity table above.
+
 - [ ] **Undersized depth limits future capacity.** While oversizing wastes resources, undersizing risks running out of capacity. Once a MerkleTree is full, no new leaves can be inserted without deploying a new contract. This is not recoverable.
 
   ```compact
@@ -182,13 +199,13 @@ Check every `MerkleTree` and `HistoricMerkleTree` declaration for appropriate de
   export ledger members: HistoricMerkleTree<11, Bytes<32>>;
   ```
 
-- [ ] **`MerkleTree<1, T>` — minimum depth is 2 (depth 1 is invalid).** A MerkleTree with depth 1 would have only 2 leaves and may not function correctly. The minimum usable depth is 2 (4 leaves). If you see depth 1, flag it as likely incorrect.
+- [ ] **`MerkleTree<1, T>` — minimum depth is 2 (depth 1 is a compile-time error).** A MerkleTree with depth 1 is invalid in Compact and will fail to compile. The minimum valid depth is 2 (4 leaves). If you see depth 1, flag it as a compilation error.
 
   ```compact
-  // BAD — depth 1 is invalid; will not work correctly
+  // BAD — depth 1 is invalid; causes a compile-time error
   export ledger items: MerkleTree<1, Bytes<32>>;
 
-  // GOOD — minimum usable depth is 2
+  // GOOD — minimum valid depth is 2
   export ledger items: MerkleTree<2, Bytes<32>>;
   ```
 
@@ -209,6 +226,8 @@ Check every `for` loop and `Vector<N, T>` iteration for circuit size impact. Com
   // BETTER — if only a subset needs validation, reduce the iteration count
   // Or move the validation to witness code and verify the result in circuit
   ```
+
+  > **Tool:** `midnight-compile-contract` with `fullCompile=true` reveals the actual constraint count. Compare against the expected count based on loop iterations and body complexity.
 
 - [ ] **Large `Vector<N, T>` iterations: N directly multiplies circuit size.** When iterating over a `Vector<N, T>`, the loop body is duplicated N times. A `Vector<256, Field>` iteration with a body containing 5 constraints generates 1280 constraints. Consider whether the full vector needs to be processed in-circuit or whether a partial approach is possible.
 
@@ -259,7 +278,7 @@ Check every `for` loop and `Vector<N, T>` iteration for circuit size impact. Com
 
 Check for unnecessary or multi-step type casts that add proof constraints without serving a purpose.
 
-- [ ] **Unnecessary casts add proof constraints.** Every type conversion in a circuit generates additional constraints to prove the conversion is valid. If a value is declared as one type and then immediately cast to another, consider declaring it as the target type from the start.
+- [ ] **Conversion casts add proof constraints; static casts are free.** Type casts that involve actual value conversion (e.g., `Uint<64> → Field`, `Field → Bytes<32>`) generate constraints to prove the conversion is valid. However, static casts that merely reinterpret bits without conversion are free. If a value is declared as one type and then immediately cast via a conversion cast, consider declaring it as the target type from the start.
 
   ```compact
   // BAD — declares as Uint<64>, immediately casts to Field
@@ -329,13 +348,15 @@ Check whether expensive computations are correctly placed at the circuit/witness
 
   circuit processIfSorted(sorted: Vector<16, Field>): [] {
     // Verify sorted order: O(N) comparisons instead of O(N^2)
-    for (const i = 0; i < 15; i++) {
+    for (const i of 0..14) {
       assert(sorted[i] as Uint<64> <= sorted[i + 1] as Uint<64>,
         "Not sorted");
     }
     // ... process verified sorted result
   }
   ```
+
+  > **Tool:** `midnight-explain-circuit` can explain what a circuit does in plain language, helping identify computations that could be moved to the witness. `midnight-search-docs` has guidance on the circuit vs witness boundary optimization.
 
 - [ ] **Only the verification (assert the result is correct) needs to be in the circuit.** The circuit's job is to constrain the witness output so that only correct results are accepted. The actual computation can happen anywhere — the witness, a server, the user's browser — as long as the circuit can verify the result. This is the fundamental optimization principle for ZK circuits.
 
@@ -394,7 +415,7 @@ Check whether expensive computations are correctly placed at the circuit/witness
 
 Check for opportunities to use `pure circuit` for reusable logic that does not access ledger state.
 
-- [ ] **Reusable logic that does not touch ledger state should be `pure circuit`.** A `pure circuit` cannot read or write ledger state. This restriction allows the compiler to apply optimizations that are not possible for stateful circuits. It also makes the circuit reusable from both other circuits and witness code. If a helper circuit does not access any ledger variables, mark it as `pure circuit`.
+- [ ] **Reusable logic that does not touch ledger state should be `pure circuit`.** A `pure circuit` cannot read or write ledger state. This restriction enforces purity at compile time and enables the circuit to be exported as a `pureCircuits` function callable from TypeScript witness code. If a helper circuit does not access any ledger variables, mark it as `pure circuit`.
 
   ```compact
   // BAD — regular circuit that does not use ledger state
@@ -412,7 +433,9 @@ Check for opportunities to use `pure circuit` for reusable logic that does not a
   }
   ```
 
-- [ ] **Pure circuits can be called from witnesses and may benefit from compiler optimizations.** Because `pure circuit` functions have no side effects (no ledger access), they can be safely called from witness TypeScript code as well as from other circuits. This enables sharing logic between the on-chain proof and the off-chain witness computation without duplication.
+  > **Tool:** `midnight-extract-contract-structure` identifies all circuits and whether they access ledger state. Flag any non-pure circuit that does not read or write ledger variables. `midnight-explain-circuit` can analyze specific circuits to confirm whether they access ledger state.
+
+- [ ] **Pure circuits can be called from TypeScript witness code.** Because `pure circuit` functions have no side effects (no ledger access), they are exported as `pureCircuits` and can be called from witness TypeScript code as well as from other circuits. This enables sharing logic between the on-chain proof and the off-chain witness computation without duplication. Note: the `pure` keyword primarily validates purity and enables TypeScript export — it does not trigger additional compiler optimizations beyond what the compiler already applies to all circuits.
 
   ```compact
   // GOOD — pure circuit shared between circuit and witness contexts
@@ -433,7 +456,7 @@ Check for opportunities to use `pure circuit` for reusable logic that does not a
   // to derive keys off-chain without duplicating the logic
   ```
 
-- [ ] **Non-pure circuit used where a pure circuit would suffice.** If a circuit is declared without the `pure` modifier but does not access ledger state, it should be converted to `pure circuit`. A non-pure circuit may miss compiler optimizations and cannot be called from witness contexts.
+- [ ] **Non-pure circuit used where a pure circuit would suffice.** If a circuit is declared without the `pure` modifier but does not access ledger state, it should be converted to `pure circuit`. A non-pure circuit cannot be called from witness TypeScript code, missing an opportunity for logic reuse.
 
   ```compact
   // BAD — circuit does not touch ledger but is not marked pure
@@ -459,7 +482,18 @@ Quick reference of common performance anti-patterns in Compact contracts.
 | Sorting inside a circuit | O(N^2) comparisons all become constraints; sorting 16 elements generates ~120 comparison constraints | Sort in witness TypeScript code; verify sorted order in circuit with O(N) comparisons |
 | `Uint<64>` → `Field` → `Bytes<32>` chain when only `Bytes<32>` is needed | Each cast step adds constraints to prove the conversion is valid; multi-step chains multiply the cost | Declare or accept the value as the target type from the start |
 | Reading same ledger variable 3+ times | Each read generates constraints; 3 reads of the same variable triples the read cost | Read once into a `const`, reuse throughout the circuit |
-| Helper circuit without `pure` modifier that does not access ledger | Misses compiler optimizations available to pure circuits; cannot be called from witness code | Add `pure` modifier: `pure circuit helperName(...)` |
+| Helper circuit without `pure` modifier that does not access ledger | Cannot be called from witness TypeScript code; misses the purity enforcement and `pureCircuits` export | Add `pure` modifier: `pure circuit helperName(...)` |
 | Linear search inside circuit over `Vector<N, T>` | Iterates all N elements regardless of position; N comparisons become N constraint groups | Witness provides the index; circuit verifies `v[index] == target` in a single comparison |
-| `MerkleTree<1, T>` declaration | Depth 1 is invalid and will not function correctly | Minimum usable depth is 2: `MerkleTree<2, T>` |
+| `MerkleTree<1, T>` declaration | Depth 1 is invalid and causes a compile-time error | Minimum valid depth is 2: `MerkleTree<2, T>` |
 | Unnecessary `counter.read()` when only `increment()` is needed | Read generates constraints for a value that is never used in computation | Remove the read; call `counter.increment(n)` directly |
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Use `skipZk=true` for syntax validation, `fullCompile=true` for circuit size metrics and proof generation cost analysis. |
+| `midnight-extract-contract-structure` | Deep structural analysis: data structure declarations, loop patterns, type cast chains, pure circuit candidates. |
+| `midnight-analyze-contract` | Static analysis of contract structure and common patterns. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference including `pure circuit` rules and type cast paths. |
+| `midnight-explain-circuit` | Explains what a circuit does in plain language, including ZK proof cost implications. |
+| `midnight-search-docs` | Full-text search across official Midnight documentation for performance guidance. |

--- a/plugins/compact-core/skills/compact-review/references/privacy-review.md
+++ b/plugins/compact-core/skills/compact-review/references/privacy-review.md
@@ -2,11 +2,26 @@
 
 Review checklist for the **Privacy & Disclosure** category. This is the highest-priority review category in Midnight's privacy-first design philosophy. Apply every item below to the contract under review.
 
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation errors from incorrect `disclose()` usage |
+| `midnight-extract-contract-structure` | `[shared]` | Detects missing `disclose()` calls, structural disclosure issues |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of privacy patterns |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for `disclose()` semantics |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
 ## Unnecessary Disclosure Checklist
 
 Check every `disclose()` call in the contract for necessity and placement.
 
 - [ ] **Every `disclose()` call: is it actually needed?** For each `disclose()`, ask whether the value could remain private. A value only needs disclosure if it flows to a public context (ledger write, return value, public assertion). If the value is only used in private computation, `disclose()` is unnecessary and reduces privacy.
+
+> **Tool:** `midnight-extract-contract-structure` lists all `disclose()` call sites. Cross-reference each one against necessity.
 
 - [ ] **`disclose()` placed at witness call site instead of near the public boundary.** Disclosing at the witness call site (e.g., `const x = disclose(getSecret())`) is bad practice because it marks the value as public immediately, and ALL downstream uses of that value lose privacy. Instead, place `disclose()` as close to the actual disclosure point as possible (e.g., the ledger write or return statement).
 
@@ -21,6 +36,8 @@ Check every `disclose()` call in the contract for necessity and placement.
   const derived = computeSomething(secret);
   ledgerField = disclose(derived);
   ```
+
+> **Tool:** `midnight-extract-contract-structure` flags early-disclosure patterns. Check its output for disclosure placement warnings.
 
 - [ ] **Bulk `disclose()` on structs when only one field needs disclosure.** If a struct has multiple fields but only one needs to be public, disclosing the entire struct leaks all fields. Extract and disclose only the specific field that must be public.
 
@@ -42,6 +59,8 @@ Check for private witness data escaping the zero-knowledge proof boundary.
 
 - [ ] **Witness-derived values written to public ledger without `disclose()`.** The compiler catches this as an error, but review the intent. If the developer added `disclose()` solely to silence the compiler without considering whether the value should actually be public, that is a privacy bug even though the code compiles.
 
+> **Tool:** `midnight-compile-contract` output shows `implicit disclosure of witness value` errors for these cases.
+
 - [ ] **Conditional branches revealing private information.** Patterns like `if (disclose(secret == expected))` leak the boolean result of a private comparison. An observer learns whether the secret matched the expected value. Consider whether the branch outcome itself is sensitive.
 
   ```compact
@@ -53,6 +72,8 @@ Check for private witness data escaping the zero-knowledge proof boundary.
   // BETTER — assert privately, only disclose the final action result
   assert(secret == expected, "Mismatch");
   ```
+
+> **Tool:** Consider calling `midnight-explain-circuit` on circuits that use `disclose()` inside conditionals to understand the full privacy implications.
 
 - [ ] **Assert conditions that leak private state.** Patterns like `assert(disclose(balance > 0), "...")` reveal private state through the assertion. The observer learns the boolean result of the condition. Consider whether the assertion condition itself is sensitive information.
 
@@ -91,6 +112,8 @@ Check ledger data structure choices for unintended information leakage.
   assert(members.checkRoot(disclose(digest)), "Not a member");
   ```
 
+> **Tool:** `midnight-extract-contract-structure` shows all data structure declarations. Look for `Set` types used in membership contexts.
+
 - [ ] **Using `Map<key, value>` where key reveals identity.** Map keys are always visible on insert and lookup. If the key is a user identifier (public key, address, name hash), every operation reveals which user is acting. Consider whether the key can be replaced with a commitment or whether the data model should use a different structure.
 
 - [ ] **Using `Counter` read-then-increment vs direct `increment()`.** Reading a `Counter` with `counter.read()` followed by `increment()` reveals the current counter value unnecessarily. If the current value is not needed for circuit logic, use `counter.increment(n)` directly. Note that all `Counter` operations are public regardless.
@@ -125,7 +148,9 @@ Check cryptographic operations for correctness and privacy guarantees.
   // 'hidden' is no longer tainted; value is cryptographically hidden
   ```
 
-- [ ] **Transient vs persistent confusion.** `transientHash` and `transientCommit` produce different values on each compilation or circuit execution. Their results must NEVER be stored in ledger state because a value committed with `transientCommit` cannot be reliably verified later. Use `persistentHash` or `persistentCommit` for any value that will be stored on-chain or compared across transactions.
+> **Tool:** `midnight-extract-contract-structure` flags `persistentHash` vs `persistentCommit` usage. Check for misuse patterns.
+
+- [ ] **Transient vs persistent confusion.** `transientHash` and `transientCommit` produce values that are deterministic within a single circuit execution but are NOT guaranteed to produce the same output across compiler upgrades or different contract versions. Their results must NEVER be stored in ledger state because a value committed with `transientCommit` cannot be reliably verified in a future transaction after a compiler upgrade. Use `persistentHash` or `persistentCommit` for any value that will be stored on-chain or compared across transactions.
 
   ```compact
   // BAD — transient result stored on ledger is meaningless
@@ -134,6 +159,8 @@ Check cryptographic operations for correctness and privacy guarantees.
   // GOOD — persistent result is stable across calls
   storedCommitment = disclose(persistentCommit<Field>(value, salt));
   ```
+
+> **Tool:** `midnight-search-docs` can clarify the transient vs persistent guarantees if there is any ambiguity in the contract's usage.
 
 - [ ] **Salt/nonce reuse in commitments.** Reusing the same salt across different commitments allows rainbow table attacks. If two commitments use the same salt and the same value, they produce identical outputs, breaking the hiding property. Always source fresh randomness from a witness function for each commitment.
 
@@ -188,6 +215,17 @@ Quick reference of common privacy anti-patterns in Compact contracts.
 | `disclose(getSecret())` at call site | Marks private data as public too early; all downstream uses of the value lose privacy, risking multiple unintended disclosure paths | `disclose(x)` at the point where `x` crosses a public boundary (ledger write, return, public assertion) |
 | `Set<Bytes<32>>` for private membership | Set operations (`member()`, `insert()`) reveal the exact element identity on-chain; any observer can see who acted | `MerkleTree` + nullifier for anonymous membership proof; observer sees only a root check and opaque nullifier |
 | `persistentHash(secret)` to "hide" data | Hash does not clear witness taint; the compiler still tracks the result as private; hash without blinding provides no hiding guarantee | `persistentCommit(secret, nonce)` which cryptographically hides the input and clears witness taint |
-| Storing `transientHash` result in ledger | Transient operations may produce different results across compilations or calls; the stored value is unreliable and cannot be verified later | Use `persistentHash` or `persistentCommit` for any value that must be stored on the ledger or compared across transactions |
+| Storing `transientHash` result in ledger | Transient operations are deterministic within a single execution but not guaranteed across compiler upgrades; the stored value cannot be reliably verified in future transactions | Use `persistentHash` or `persistentCommit` for any value that must be stored on the ledger or compared across transactions |
 | Same domain for commit + nullifier | Allows an observer to link a commitment to its corresponding nullifier, breaking unlinkability and deanonymizing the user | Different domain strings for each purpose: `"app:commit"` vs `"app:nullifier"` |
 | Raw secret in sealed field | Sealed fields are set publicly during contract deployment; the secret value is visible in the deployment transaction to all observers | Hash or commit the secret before storing it in a sealed field |
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Use `skipZk=true` for syntax validation, `fullCompile=true` for full ZK compilation. |
+| `midnight-extract-contract-structure` | Deep structural analysis: deprecated syntax, missing `disclose()`, potential overflows, data structure usage. |
+| `midnight-analyze-contract` | Static analysis of contract structure and common patterns. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference from the latest compiler version. |
+| `midnight-explain-circuit` | Explains what a circuit does in plain language, including ZK proof and privacy implications. |
+| `midnight-search-docs` | Full-text search across official Midnight documentation. |

--- a/plugins/compact-core/skills/compact-review/references/privacy-review.md
+++ b/plugins/compact-core/skills/compact-review/references/privacy-review.md
@@ -1,0 +1,193 @@
+# Privacy & Disclosure Review Checklist
+
+Review checklist for the **Privacy & Disclosure** category. This is the highest-priority review category in Midnight's privacy-first design philosophy. Apply every item below to the contract under review.
+
+## Unnecessary Disclosure Checklist
+
+Check every `disclose()` call in the contract for necessity and placement.
+
+- [ ] **Every `disclose()` call: is it actually needed?** For each `disclose()`, ask whether the value could remain private. A value only needs disclosure if it flows to a public context (ledger write, return value, public assertion). If the value is only used in private computation, `disclose()` is unnecessary and reduces privacy.
+
+- [ ] **`disclose()` placed at witness call site instead of near the public boundary.** Disclosing at the witness call site (e.g., `const x = disclose(getSecret())`) is bad practice because it marks the value as public immediately, and ALL downstream uses of that value lose privacy. Instead, place `disclose()` as close to the actual disclosure point as possible (e.g., the ledger write or return statement).
+
+  ```compact
+  // BAD — over-discloses at call site
+  const secret = disclose(getSecret());
+  const derived = computeSomething(secret);  // derived is now public too
+  ledgerField = derived;
+
+  // GOOD — disclose only at the public boundary
+  const secret = getSecret();
+  const derived = computeSomething(secret);
+  ledgerField = disclose(derived);
+  ```
+
+- [ ] **Bulk `disclose()` on structs when only one field needs disclosure.** If a struct has multiple fields but only one needs to be public, disclosing the entire struct leaks all fields. Extract and disclose only the specific field that must be public.
+
+  ```compact
+  // BAD — discloses all fields
+  const profile = disclose(getProfile());
+  ledgerName = profile.name;
+
+  // GOOD — disclose only the needed field
+  const profile = getProfile();
+  ledgerName = disclose(profile.name);
+  ```
+
+- [ ] **Return values from exported circuits: does everything returned need to be public?** Every value returned from an `export circuit` is visible to the caller and on-chain observers. Review whether all returned fields are necessary. If only a boolean confirmation is needed, do not return the underlying data.
+
+## Witness Data Leakage Checklist
+
+Check for private witness data escaping the zero-knowledge proof boundary.
+
+- [ ] **Witness-derived values written to public ledger without `disclose()`.** The compiler catches this as an error, but review the intent. If the developer added `disclose()` solely to silence the compiler without considering whether the value should actually be public, that is a privacy bug even though the code compiles.
+
+- [ ] **Conditional branches revealing private information.** Patterns like `if (disclose(secret == expected))` leak the boolean result of a private comparison. An observer learns whether the secret matched the expected value. Consider whether the branch outcome itself is sensitive.
+
+  ```compact
+  // BAD — leaks whether the secret matches
+  if (disclose(secret == expected)) {
+    // ...
+  }
+
+  // BETTER — assert privately, only disclose the final action result
+  assert(secret == expected, "Mismatch");
+  ```
+
+- [ ] **Assert conditions that leak private state.** Patterns like `assert(disclose(balance > 0), "...")` reveal private state through the assertion. The observer learns the boolean result of the condition. Consider whether the assertion condition itself is sensitive information.
+
+  ```compact
+  // BAD — leaks whether balance > 0
+  assert(disclose(balance > 0), "Insufficient balance");
+
+  // BETTER — keep the check private where possible
+  assert(balance > 0, "Insufficient balance");
+  // Only disclose the final derived value that must be public
+  ```
+
+- [ ] **Indirect leakage through control flow timing or state changes observable on-chain.** Even without explicit disclosure, an observer can infer private state from:
+  - Which exported circuit was called (circuit name is always visible)
+  - Whether a transaction succeeded or failed
+  - The number and pattern of ledger state changes
+  - Transaction timing and ordering
+
+- [ ] **Cross-contract calls passing witness data.** When witness-derived data crosses a contract boundary via a cross-contract call, it crosses a trust boundary. The receiving contract may disclose or store the data publicly. Verify that any data passed to another contract is safe to share.
+
+## Data Structure Privacy Checklist
+
+Check ledger data structure choices for unintended information leakage.
+
+- [ ] **Using `Set<Bytes<32>>` for membership that should be private.** `Set` operations (`member()`, `insert()`) reveal the exact element being checked or added. If membership should be anonymous, use `MerkleTree` (or `HistoricMerkleTree`) with a nullifier pattern instead. The observer sees only a root check and a nullifier insertion, not which member acted.
+
+  ```compact
+  // BAD — reveals who is a member
+  export ledger members: Set<Bytes<32>>;
+  assert(disclose(members.member(myPublicKey)), "Not a member");
+
+  // GOOD — anonymous membership proof
+  export ledger members: HistoricMerkleTree<16, Bytes<32>>;
+  export ledger usedNullifiers: Set<Bytes<32>>;
+  const digest = merkleTreePathRoot<16, Bytes<32>>(path);
+  assert(members.checkRoot(disclose(digest)), "Not a member");
+  ```
+
+- [ ] **Using `Map<key, value>` where key reveals identity.** Map keys are always visible on insert and lookup. If the key is a user identifier (public key, address, name hash), every operation reveals which user is acting. Consider whether the key can be replaced with a commitment or whether the data model should use a different structure.
+
+- [ ] **Using `Counter` read-then-increment vs direct `increment()`.** Reading a `Counter` with `counter.read()` followed by `increment()` reveals the current counter value unnecessarily. If the current value is not needed for circuit logic, use `counter.increment(n)` directly. Note that all `Counter` operations are public regardless.
+
+  ```compact
+  // BAD — reads and exposes current value when only increment is needed
+  const current = counter.read();  // observer sees current value
+  counter.increment(1);
+
+  // GOOD — increment without reading
+  counter.increment(1);
+  ```
+
+- [ ] **Using `List` which reveals insertion order and all values.** `List` operations make all stored values and their insertion order visible on-chain. If the data should be private, consider whether a `MerkleTree` or off-chain storage is more appropriate.
+
+- [ ] **`MerkleTree.insert()` properly used to hide leaf content.** `MerkleTree.insert()` is the only ledger operation that hides its data argument on-chain. Verify that contracts relying on data privacy are actually using MerkleTree insertion for the sensitive data, not Map/Set/List which expose their contents.
+
+## Cryptographic Privacy Checklist
+
+Check cryptographic operations for correctness and privacy guarantees.
+
+- [ ] **`persistentHash` used where `persistentCommit` is needed.** `persistentHash` does NOT clear witness taint. The compiler still tracks the result as witness-derived. If the goal is to hide a private value on-chain, `persistentCommit` with a blinding factor (nonce/salt) is required. `persistentHash` only provides binding, not hiding.
+
+  ```compact
+  // BAD — hash does not clear taint or hide the value
+  const hidden = persistentHash<Vector<2, Bytes<32>>>([pad(32, "app:"), secret]);
+  // Compiler still considers 'hidden' as witness-tainted
+
+  // GOOD — commit clears taint and provides hiding
+  const salt = get_randomness();
+  const hidden = persistentCommit<Vector<2, Bytes<32>>>([pad(32, "app:"), secret], salt);
+  // 'hidden' is no longer tainted; value is cryptographically hidden
+  ```
+
+- [ ] **Transient vs persistent confusion.** `transientHash` and `transientCommit` produce different values on each compilation or circuit execution. Their results must NEVER be stored in ledger state because a value committed with `transientCommit` cannot be reliably verified later. Use `persistentHash` or `persistentCommit` for any value that will be stored on-chain or compared across transactions.
+
+  ```compact
+  // BAD — transient result stored on ledger is meaningless
+  storedCommitment = disclose(transientCommit<Field>(value, salt));
+
+  // GOOD — persistent result is stable across calls
+  storedCommitment = disclose(persistentCommit<Field>(value, salt));
+  ```
+
+- [ ] **Salt/nonce reuse in commitments.** Reusing the same salt across different commitments allows rainbow table attacks. If two commitments use the same salt and the same value, they produce identical outputs, breaking the hiding property. Always source fresh randomness from a witness function for each commitment.
+
+- [ ] **Same domain string used for both commitment and nullifier.** If the commitment and nullifier for the same secret use the same domain separator, an observer can link them by comparing derivation outputs. Use distinct domain strings for each purpose.
+
+  ```compact
+  // BAD — same domain enables linking
+  const commitment = persistentHash<Vector<2, Bytes<32>>>([pad(32, "myapp:"), sk]);
+  const nullifier  = persistentHash<Vector<2, Bytes<32>>>([pad(32, "myapp:"), sk]);
+
+  // GOOD — different domains prevent correlation
+  const commitment = persistentHash<Vector<2, Bytes<32>>>([pad(32, "myapp:commit:"), sk]);
+  const nullifier  = persistentHash<Vector<2, Bytes<32>>>([pad(32, "myapp:nullifier:"), sk]);
+  ```
+
+- [ ] **Missing salt/randomness in commitment schemes.** A commitment without randomness is just a hash and does not provide hiding. If the input space is small (e.g., a boolean, a small integer), an observer can brute-force the hash to recover the committed value. Always include a random blinding factor.
+
+## Selective Disclosure Checklist
+
+Check that disclosed values reveal the minimum necessary information.
+
+- [ ] **Disclosing the actual value when only a boolean comparison result is needed.** If the contract only needs to prove that a value meets a condition (e.g., balance above a threshold), disclose the boolean result of the comparison, not the value itself.
+
+  ```compact
+  // BAD — reveals the actual balance
+  assert(disclose(balance) >= threshold, "Insufficient");
+
+  // GOOD — reveals only whether the condition holds
+  assert(disclose(balance >= threshold), "Insufficient");
+  ```
+
+- [ ] **Disclosing more fields than necessary from a struct.** When working with multi-field data, review whether each disclosed field is truly required by the public context. Disclose individual fields rather than entire structs.
+
+  ```compact
+  // BAD — discloses name, age, AND income
+  const profile = disclose(getProfile());
+  assert(profile.age >= 18, "Underage");
+
+  // GOOD — discloses only the age comparison result
+  const profile = getProfile();
+  assert(disclose(profile.age >= 18), "Underage");
+  ```
+
+- [ ] **Missing `disclose()` on derived values that should be public.** The compiler catches missing `disclose()` calls when a witness-tainted value flows to a public context. However, review for intent: if the developer had to add `disclose()` to make the code compile, verify that the value was actually intended to be public. A compiler-driven `disclose()` added without privacy consideration is a code smell.
+
+## Anti-Patterns Table
+
+Quick reference of common privacy anti-patterns in Compact contracts.
+
+| Anti-Pattern | Why It's Wrong | Correct Approach |
+|---|---|---|
+| `disclose(getSecret())` at call site | Marks private data as public too early; all downstream uses of the value lose privacy, risking multiple unintended disclosure paths | `disclose(x)` at the point where `x` crosses a public boundary (ledger write, return, public assertion) |
+| `Set<Bytes<32>>` for private membership | Set operations (`member()`, `insert()`) reveal the exact element identity on-chain; any observer can see who acted | `MerkleTree` + nullifier for anonymous membership proof; observer sees only a root check and opaque nullifier |
+| `persistentHash(secret)` to "hide" data | Hash does not clear witness taint; the compiler still tracks the result as private; hash without blinding provides no hiding guarantee | `persistentCommit(secret, nonce)` which cryptographically hides the input and clears witness taint |
+| Storing `transientHash` result in ledger | Transient operations may produce different results across compilations or calls; the stored value is unreliable and cannot be verified later | Use `persistentHash` or `persistentCommit` for any value that must be stored on the ledger or compared across transactions |
+| Same domain for commit + nullifier | Allows an observer to link a commitment to its corresponding nullifier, breaking unlinkability and deanonymizing the user | Different domain strings for each purpose: `"app:commit"` vs `"app:nullifier"` |
+| Raw secret in sealed field | Sealed fields are set publicly during contract deployment; the secret value is visible in the deployment transaction to all observers | Hash or commit the secret before storing it in a sealed field |

--- a/plugins/compact-core/skills/compact-review/references/security-review.md
+++ b/plugins/compact-core/skills/compact-review/references/security-review.md
@@ -2,6 +2,19 @@
 
 Review checklist for the **Security & Cryptographic Correctness** category. This covers access control, cryptographic primitive usage, Merkle path verification, error handling, and input validation. Apply every item below to the contract under review.
 
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation errors from missing assertions, type mismatches |
+| `midnight-extract-contract-structure` | `[shared]` | Detects missing access control, structural security issues |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of security patterns |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for cryptographic primitives |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
 ## Access Control Checklist
 
 Check every exported circuit for proper authorization and state guards.
@@ -24,6 +37,8 @@ Check every exported circuit for proper authorization and state guards.
     counter.increment(1);
   }
   ```
+
+  > **Tool:** `midnight-extract-contract-structure` lists all exported circuits and their structure. Cross-reference each exported circuit that modifies state against the presence of authorization checks.
 
 - [ ] **Missing ownership verification before state-modifying operations.** For contracts with an owner or authority pattern, every state-modifying circuit must verify that the caller holds the correct secret key. Look for `publicKey(secretKey, domain)` or equivalent derivation followed by an `assert` comparing against a stored authority. If the comparison is missing, anyone can modify state.
 
@@ -111,8 +126,8 @@ Check hash and commitment usage for correctness, determinism, and domain separat
   |-----------|---------------|---------------|---------|
   | `persistentHash` | Yes — same input always produces same output | No | Public identifiers, nullifiers, domain-separated keys. Value must be reproducible across transactions. |
   | `persistentCommit` | Yes (with nonce) — same input + nonce produces same output | Yes | Commitments that must be verifiable later. The nonce provides hiding; taint clearing allows on-chain storage. |
-  | `transientHash` | No — different result each call | No | One-time computations within a single circuit execution. Never store the result on-chain. |
-  | `transientCommit` | No (with nonce) — different result each call | Yes | One-time commitments within a single circuit execution. Never store the result on-chain. |
+  | `transientHash` | Deterministic within a single execution, but not guaranteed across compiler upgrades | No | One-time computations within a single circuit execution. Never store the result on-chain. |
+  | `transientCommit` | Deterministic within a single execution (with nonce), but not guaranteed across compiler upgrades | Yes | One-time commitments within a single circuit execution. Never store the result on-chain. |
 
   ```compact
   // BAD — using transientHash for a nullifier (not reproducible)
@@ -134,6 +149,8 @@ Check hash and commitment usage for correctness, determinism, and domain separat
   const hidden = persistentCommit<Vector<2, Bytes<32>>>([pad(32, "app:"), secret], salt);
   // Clears taint, hides the value, can be stored on ledger
   ```
+
+  > **Tool:** `midnight-extract-contract-structure` identifies hash and commit usage. Verify each call uses the correct primitive per the table above. `midnight-search-compact` can find reference patterns for correct cryptographic primitive usage.
 
 - [ ] **Domain separation: every hash/commit call should include a unique domain string.** Without domain separation, identical inputs across different protocols or different purposes within the same contract produce the same hash output, enabling cross-protocol replay attacks or unintended hash collisions.
 
@@ -165,6 +182,8 @@ Check hash and commitment usage for correctness, determinism, and domain separat
     ));
   }
   ```
+
+  > **Tool:** `midnight-search-compact` can find official examples of domain separation patterns to compare against.
 
 - [ ] **Nullifier construction: must be deterministic, include secret key + unique identifier, and use domain separation.** A nullifier is a one-time-use token derived from a secret to prevent double-spending or double-voting. It must satisfy three properties:
   1. **Deterministic** (uses `persistentHash`, not `transientHash`) so the same secret always produces the same nullifier.
@@ -224,6 +243,8 @@ Check Merkle tree operations for correct root verification and data structure ch
   const digest = merkleTreePathRoot<16, Bytes<32>>(path);
   assert(members.checkRoot(disclose(digest)), "Merkle root mismatch");
   ```
+
+  > **Tool:** `midnight-extract-contract-structure` identifies MerkleTree operations. Verify every `merkleTreePathRoot` call is followed by a `checkRoot()` assertion.
 
 - [ ] **Path leaf matches expected value.** A valid Merkle path proves that *some* leaf is in the tree, but the reviewer must verify that the leaf at the base of the path is the expected value (e.g., the user's commitment, the voter's credential). If the contract does not check what leaf the path proves membership for, a user could supply a path for a different leaf.
 
@@ -298,10 +319,14 @@ Check assertions and error paths for information leakage and missing safety chec
   }
   ```
 
-- [ ] **Missing bounds checks before arithmetic operations.** Subtraction underflow, division by zero, and array out-of-bounds access must be guarded with assertions. In a zero-knowledge context, arithmetic underflow does not throw an error; it wraps around, producing an incorrect but valid-looking result.
+  > **Tool:** `midnight-compile-contract` output may reveal runtime failures from missing safety checks. `midnight-search-docs` has guidance on safe Map/Set access patterns.
+
+- [ ] **Missing bounds checks before arithmetic operations.** Subtraction underflow, division by zero, and array out-of-bounds access must be guarded with assertions. For `Field` types, arithmetic underflow wraps around silently (modular arithmetic), producing an incorrect but valid-looking result. For `Uint<N>` types, subtraction underflow causes a runtime error. In both cases, explicit bounds checks prevent unexpected behavior.
 
   ```compact
-  // BAD — subtraction without underflow check; wraps silently in ZK
+  // BAD — subtraction without underflow check
+  // For Field: wraps silently (modular arithmetic)
+  // For Uint<N>: causes a runtime error
   export circuit withdraw(amount: Field): [] {
     const current = balances.lookup(account);
     balances.insert(account, current - amount);
@@ -394,4 +419,15 @@ Quick reference of common security anti-patterns in Compact contracts.
 | Regular `MerkleTree` for concurrent membership | Root changes on every insert; paths obtained before a concurrent insert become invalid | Use `HistoricMerkleTree` which retains previous roots and validates older paths |
 | Assert message reveals expected value | Failed transaction error message leaks private state (balance, authority key, expected commitment) to observers | Keep assert messages generic: "Not authorized", "Insufficient balance", "Invalid proof" |
 | Missing state machine guard on phase transition | Calling `reveal` before `commit`, or `execute` before `vote`, breaks protocol invariants | Assert current state at the top of each phase-transition circuit: `assert(state == State.COMMITTED, ...)` |
-| No bounds check before arithmetic | Subtraction underflow wraps silently in ZK circuits, producing valid-looking but incorrect results | Assert `a >= b` before computing `a - b`; assert `amount > 0` for all token operations |
+| No bounds check before arithmetic | `Field` subtraction underflow wraps silently (modular arithmetic); `Uint<N>` subtraction underflow causes a runtime error. Both produce incorrect or failed results | Assert `a >= b` before computing `a - b`; assert `amount > 0` for all token operations |
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Use `skipZk=true` for syntax validation, `fullCompile=true` for full ZK compilation. |
+| `midnight-extract-contract-structure` | Deep structural analysis: deprecated syntax, missing access control, cryptographic primitive usage. |
+| `midnight-analyze-contract` | Static analysis of contract structure and common patterns. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference from the latest compiler version. |
+| `midnight-search-compact` | Semantic search across Compact smart contract code and patterns. |
+| `midnight-search-docs` | Full-text search across official Midnight documentation. |

--- a/plugins/compact-core/skills/compact-review/references/security-review.md
+++ b/plugins/compact-core/skills/compact-review/references/security-review.md
@@ -1,0 +1,397 @@
+# Security & Cryptographic Correctness Review Checklist
+
+Review checklist for the **Security & Cryptographic Correctness** category. This covers access control, cryptographic primitive usage, Merkle path verification, error handling, and input validation. Apply every item below to the contract under review.
+
+## Access Control Checklist
+
+Check every exported circuit for proper authorization and state guards.
+
+- [ ] **Exported circuit with no authorization check.** Any `export circuit` that modifies ledger state (writes to maps, sets, counters, sealed fields, or Merkle trees) must verify the caller's identity. An exported circuit without an authorization check allows anyone to invoke it, which is equivalent to leaving an admin endpoint open to the public.
+
+  ```compact
+  // BAD — anyone can call this and reset the contract
+  export circuit reset(): [] {
+    state = State.UNSET;
+    counter.increment(1);
+  }
+
+  // GOOD — only the authorized party can reset
+  export circuit reset(): [] {
+    const sk = local_secret_key();
+    const pk = disclose(publicKey(sk));
+    assert(authority == pk, "Not authorized to reset");
+    state = State.UNSET;
+    counter.increment(1);
+  }
+  ```
+
+- [ ] **Missing ownership verification before state-modifying operations.** For contracts with an owner or authority pattern, every state-modifying circuit must verify that the caller holds the correct secret key. Look for `publicKey(secretKey, domain)` or equivalent derivation followed by an `assert` comparing against a stored authority. If the comparison is missing, anyone can modify state.
+
+  ```compact
+  // BAD — modifies owner-controlled state without checking ownership
+  export circuit set_value(value: Field): [] {
+    assert(state == State.SET, "Not initialized");
+    stored_value = value;
+  }
+
+  // GOOD — verifies ownership before modification
+  export circuit set_value(value: Field): [] {
+    assert(state == State.SET, "Not initialized");
+    const sk = local_secret_key();
+    const pk = disclose(publicKey(sk));
+    assert(authority == pk, "Not authorized");
+    stored_value = value;
+  }
+  ```
+
+- [ ] **`publicKey()` derivation missing domain separation for different roles.** If a contract has multiple roles (e.g., admin vs user, minter vs burner), each role must use a distinct domain string in the `publicKey` derivation. Without domain separation, a key authorized for one role could be used for another.
+
+  ```compact
+  // BAD — same derivation for both roles; admin key = user key
+  circuit adminKey(sk: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<2, Bytes<32>>>([pad(32, "myapp:pk:"), sk]);
+  }
+  circuit userKey(sk: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<2, Bytes<32>>>([pad(32, "myapp:pk:"), sk]);
+  }
+
+  // GOOD — distinct domain strings for each role
+  circuit adminKey(sk: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<2, Bytes<32>>>([pad(32, "myapp:admin:"), sk]);
+  }
+  circuit userKey(sk: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<2, Bytes<32>>>([pad(32, "myapp:user:"), sk]);
+  }
+  ```
+
+- [ ] **Admin or authority function callable by anyone.** Look for circuits that perform privileged operations (minting tokens, updating configuration, pausing the contract, transferring ownership) without an `assert(caller == owner)` or equivalent check. This is a critical vulnerability.
+
+  ```compact
+  // BAD — minting without authorization
+  export circuit mint(amount: Field): [] {
+    token.mint(amount);
+  }
+
+  // GOOD — only authority can mint (pattern from lock.compact)
+  export circuit mint(amount: Field): [] {
+    const sk = secretKey();
+    const pk = publicKey(round, sk);
+    assert(authority == pk, "Attempted to mint without authorization");
+    token.mint(amount);
+  }
+  ```
+
+- [ ] **Missing state machine guards.** For contracts implementing a multi-phase protocol (e.g., commit-reveal, propose-vote-execute, lock-unlock), each phase transition must assert the current state before proceeding. Calling a later phase before an earlier one has completed can lead to protocol violations.
+
+  ```compact
+  // BAD — reveal can be called without a prior commit
+  export circuit reveal(value: Field, salt: Bytes<32>): [] {
+    const expected = persistentCommit<Field>(value, salt);
+    assert(stored_commitment == expected, "Invalid reveal");
+    revealed_value = disclose(value);
+  }
+
+  // GOOD — state guard ensures correct phase ordering
+  export circuit reveal(value: Field, salt: Bytes<32>): [] {
+    assert(state == State.COMMITTED, "Must be in COMMITTED state to reveal");
+    const expected = persistentCommit<Field>(value, salt);
+    assert(stored_commitment == expected, "Invalid reveal");
+    revealed_value = disclose(value);
+    state = State.REVEALED;
+  }
+  ```
+
+## Cryptographic Correctness Checklist
+
+Check hash and commitment usage for correctness, determinism, and domain separation.
+
+- [ ] **`persistentHash` vs `persistentCommit` vs `transientHash` vs `transientCommit` — correct usage.** Each primitive has distinct properties and a correct use case. Using the wrong one is a security bug.
+
+  | Primitive | Deterministic? | Clears Taint? | Use For |
+  |-----------|---------------|---------------|---------|
+  | `persistentHash` | Yes — same input always produces same output | No | Public identifiers, nullifiers, domain-separated keys. Value must be reproducible across transactions. |
+  | `persistentCommit` | Yes (with nonce) — same input + nonce produces same output | Yes | Commitments that must be verifiable later. The nonce provides hiding; taint clearing allows on-chain storage. |
+  | `transientHash` | No — different result each call | No | One-time computations within a single circuit execution. Never store the result on-chain. |
+  | `transientCommit` | No (with nonce) — different result each call | Yes | One-time commitments within a single circuit execution. Never store the result on-chain. |
+
+  ```compact
+  // BAD — using transientHash for a nullifier (not reproducible)
+  const nullifier = transientHash<Vector<2, Bytes<32>>>([pad(32, "app:nul:"), sk]);
+  // This produces a different value each time; cannot detect double-spend
+
+  // GOOD — using persistentHash for a nullifier (always reproducible)
+  const nullifier = persistentHash<Vector<2, Bytes<32>>>([pad(32, "app:nul:"), sk]);
+  // Same sk always produces the same nullifier
+  ```
+
+  ```compact
+  // BAD — using persistentHash to hide a private value on-chain
+  const hidden = persistentHash<Vector<2, Bytes<32>>>([pad(32, "app:"), secret]);
+  // Does NOT clear witness taint; compiler will reject writing to ledger
+
+  // GOOD — using persistentCommit to hide a private value
+  const salt = get_randomness();
+  const hidden = persistentCommit<Vector<2, Bytes<32>>>([pad(32, "app:"), secret], salt);
+  // Clears taint, hides the value, can be stored on ledger
+  ```
+
+- [ ] **Domain separation: every hash/commit call should include a unique domain string.** Without domain separation, identical inputs across different protocols or different purposes within the same contract produce the same hash output, enabling cross-protocol replay attacks or unintended hash collisions.
+
+  ```compact
+  // BAD — no domain separation; vulnerable to cross-protocol attacks
+  const h = persistentHash<Bytes<32>>(sk);
+
+  // GOOD — domain separation prevents cross-protocol collisions
+  // (pattern from midnames)
+  export circuit publicKey(sk: Bytes<32>): Bytes<32> {
+      return persistentHash<Vector<2, Bytes<32>>>(
+          [pad(32, "midnames:pk:"), sk]
+      );
+  }
+  ```
+
+  ```compact
+  // GOOD — distinct domain strings for different purposes within one contract
+  // (pattern from micro-dao)
+  circuit commitment_nullifier(sk: Bytes<32>): Bytes<32> {
+    return disclose(persistentHash<Vector<3, Bytes<32>>>(
+      [pad(32, "lares:udao:cm-nul:"), round as Field as Bytes<32>, sk]
+    ));
+  }
+
+  circuit reveal_nullifier(sk: Bytes<32>): Bytes<32> {
+    return disclose(persistentHash<Vector<3, Bytes<32>>>(
+      [pad(32, "lares:udao:rv-nul:"), round as Field as Bytes<32>, sk]
+    ));
+  }
+  ```
+
+- [ ] **Nullifier construction: must be deterministic, include secret key + unique identifier, and use domain separation.** A nullifier is a one-time-use token derived from a secret to prevent double-spending or double-voting. It must satisfy three properties:
+  1. **Deterministic** (uses `persistentHash`, not `transientHash`) so the same secret always produces the same nullifier.
+  2. **Includes a secret** so that an observer cannot pre-compute nullifiers for other users.
+  3. **Domain-separated** so the nullifier cannot collide with nullifiers from other protocols or other purposes in the same contract.
+
+  ```compact
+  // BAD — no secret key; anyone can predict the nullifier
+  const nullifier = persistentHash<Bytes<32>>(proposalId as Field as Bytes<32>);
+
+  // BAD — no domain separation; could collide with another contract
+  const nullifier = persistentHash<Vector<2, Bytes<32>>>([proposalId as Field as Bytes<32>, sk]);
+
+  // GOOD — includes secret, unique identifier, and domain separation
+  const nullifier = persistentHash<Vector<3, Bytes<32>>>(
+    [pad(32, "myapp:vote-nul:"), proposalId as Field as Bytes<32>, sk]
+  );
+  ```
+
+- [ ] **Commitment scheme: commitment must use nonce/salt; reveal phase must verify against stored commitment.** A commitment without a nonce is just a hash and can be brute-forced if the input space is small. The reveal phase must recompute the commitment from the revealed value and nonce, then compare against the stored commitment.
+
+  ```compact
+  // BAD — commitment without nonce; can be brute-forced
+  export circuit commit(value: Field): [] {
+    stored_commitment = disclose(persistentHash<Field>(value));
+    state = State.COMMITTED;
+  }
+
+  // GOOD — commitment with nonce; reveal verifies
+  export circuit commit(value: Field): [] {
+    const salt = get_randomness();
+    stored_commitment = disclose(persistentCommit<Field>(value, salt));
+    state = State.COMMITTED;
+  }
+
+  export circuit reveal(value: Field, salt: Bytes<32>): [] {
+    assert(state == State.COMMITTED, "Must commit first");
+    const recomputed = persistentCommit<Field>(value, salt);
+    assert(stored_commitment == disclose(recomputed), "Commitment mismatch");
+    revealed_value = disclose(value);
+    state = State.REVEALED;
+  }
+  ```
+
+## Merkle Path Verification Checklist
+
+Check Merkle tree operations for correct root verification and data structure choice.
+
+- [ ] **`checkRoot()` called to verify path against current tree root.** After computing a Merkle root from a witness-provided path, the result must be checked against the on-chain tree root using `checkRoot()`. Without this check, a prover can fabricate any path and claim membership.
+
+  ```compact
+  // BAD — computes root but never checks it against on-chain state
+  const digest = merkleTreePathRoot<16, Bytes<32>>(path);
+  // Proceeds as if membership is verified, but it is not
+
+  // GOOD — verifies computed root against on-chain tree root
+  const digest = merkleTreePathRoot<16, Bytes<32>>(path);
+  assert(members.checkRoot(disclose(digest)), "Merkle root mismatch");
+  ```
+
+- [ ] **Path leaf matches expected value.** A valid Merkle path proves that *some* leaf is in the tree, but the reviewer must verify that the leaf at the base of the path is the expected value (e.g., the user's commitment, the voter's credential). If the contract does not check what leaf the path proves membership for, a user could supply a path for a different leaf.
+
+  ```compact
+  // BAD — proves some leaf is in the tree, but not which one
+  const root = merkleTreePathRoot<16, Bytes<32>>(path);
+  assert(members.checkRoot(disclose(root)), "Not a member");
+
+  // GOOD — verifies the leaf is the expected commitment
+  const my_commitment = persistentHash<Vector<2, Bytes<32>>>(
+    [pad(32, "app:member:"), sk]
+  );
+  const root = merkleTreePathRoot<16, Bytes<32>>(path);
+  assert(path.leaf == my_commitment, "Path does not prove your membership");
+  assert(members.checkRoot(disclose(root)), "Not a member");
+  ```
+
+- [ ] **Using `HistoricMerkleTree` when membership must persist across state changes.** A regular `MerkleTree` changes its root every time a new leaf is inserted. If a user obtains a Merkle path and another user inserts a leaf before the first user's transaction lands, the first user's path becomes invalid (root mismatch). `HistoricMerkleTree` retains previous roots, so older paths remain valid.
+
+  ```compact
+  // BAD — regular MerkleTree; paths invalidated by concurrent inserts
+  export ledger members: MerkleTree<16, Bytes<32>>;
+
+  // GOOD — HistoricMerkleTree; old paths remain valid
+  export ledger members: HistoricMerkleTree<16, Bytes<32>>;
+  ```
+
+- [ ] **Root comparison done correctly: not just path validity but root matches on-chain state.** Verify that the code does not merely check that a Merkle path is internally consistent (valid hash chain) but also that the resulting root matches the actual on-chain tree root. The `checkRoot()` method on the ledger tree handles this. Manual root comparison must use the correct ledger value.
+
+  ```compact
+  // BAD — checks path structure but not against on-chain root
+  const root = merkleTreePathRoot<16, Bytes<32>>(path);
+  assert(root != pad(32, ""), "Invalid path");  // Only checks non-empty
+
+  // GOOD — checks path against the actual on-chain Merkle root
+  const root = merkleTreePathRoot<16, Bytes<32>>(path);
+  assert(members.checkRoot(disclose(root)), "Root does not match on-chain tree");
+  ```
+
+## Error Handling Security Checklist
+
+Check assertions and error paths for information leakage and missing safety checks.
+
+- [ ] **Assert messages that leak sensitive information.** Error messages in `assert()` statements are visible to anyone observing the transaction failure. If the message includes the expected value, a secret, or private state, it leaks information. Keep error messages generic.
+
+  ```compact
+  // BAD — error message reveals the expected authority public key
+  assert(caller_pk == authority,
+    "Expected authority: " + authority_hex);
+
+  // BAD — error message reveals current balance
+  assert(balance >= amount,
+    "Balance is only " + balance_str);
+
+  // GOOD — generic error message reveals nothing
+  assert(caller_pk == authority, "Not authorized");
+  assert(balance >= amount, "Insufficient balance");
+  ```
+
+- [ ] **Missing assertions before dangerous operations.** Operations like `map.lookup()` will fail at runtime if the key does not exist. Always check `map.member()` before `map.lookup()`, or use a pattern that handles the missing-key case. Similarly, check set membership before relying on set-derived values.
+
+  ```compact
+  // BAD — lookup without membership check; runtime failure if key absent
+  export circuit get_balance(account: Bytes<32>): Field {
+    return disclose(balances.lookup(account));
+  }
+
+  // GOOD — check membership first
+  export circuit get_balance(account: Bytes<32>): Field {
+    assert(balances.member(account), "Account not found");
+    return disclose(balances.lookup(account));
+  }
+  ```
+
+- [ ] **Missing bounds checks before arithmetic operations.** Subtraction underflow, division by zero, and array out-of-bounds access must be guarded with assertions. In a zero-knowledge context, arithmetic underflow does not throw an error; it wraps around, producing an incorrect but valid-looking result.
+
+  ```compact
+  // BAD — subtraction without underflow check; wraps silently in ZK
+  export circuit withdraw(amount: Field): [] {
+    const current = balances.lookup(account);
+    balances.insert(account, current - amount);
+  }
+
+  // GOOD — assert sufficient balance before subtraction
+  export circuit withdraw(amount: Field): [] {
+    assert(balances.member(account), "Account not found");
+    const current = balances.lookup(account);
+    assert(current >= amount, "Insufficient balance");
+    balances.insert(account, current - amount);
+  }
+  ```
+
+## Input Validation Checklist
+
+Check exported circuit parameters for proper validation.
+
+- [ ] **Exported circuit parameters: are all inputs validated with appropriate assertions?** Every parameter to an `export circuit` is caller-controlled. The contract must validate all inputs before using them. Without validation, a malicious caller can pass crafted values that bypass intended logic.
+
+  ```compact
+  // BAD — caller-controlled 'to' and 'amount' used without validation
+  export circuit transfer(to: Bytes<32>, amount: Field): [] {
+    const from_balance = balances.lookup(from_account);
+    balances.insert(from_account, from_balance - amount);
+    balances.insert(to, amount);
+  }
+
+  // GOOD — validate all caller-controlled inputs
+  export circuit transfer(to: Bytes<32>, amount: Field): [] {
+    assert(amount > 0, "Amount must be positive");
+    assert(balances.member(from_account), "Sender account not found");
+    const from_balance = balances.lookup(from_account);
+    assert(from_balance >= amount, "Insufficient balance");
+    balances.insert(from_account, from_balance - amount);
+    const to_balance = balances.member(to) ? balances.lookup(to) : 0;
+    balances.insert(to, to_balance + amount);
+  }
+  ```
+
+- [ ] **Zero-value checks where zero would cause issues.** Zero amounts in token transfers, zero-length inputs, and zero divisors can all cause unexpected behavior. Check for zero explicitly where it matters.
+
+  ```compact
+  // BAD — allows zero-amount transfer (no-op that wastes gas, or worse)
+  export circuit transfer(to: Bytes<32>, amount: Field): [] {
+    // amount could be 0, making this a meaningless transaction
+    balances.insert(from_account, from_balance - amount);
+    balances.insert(to, to_balance + amount);
+  }
+
+  // GOOD — reject zero amounts
+  export circuit transfer(to: Bytes<32>, amount: Field): [] {
+    assert(amount > 0, "Amount must be non-zero");
+    // ... rest of transfer logic
+  }
+  ```
+
+- [ ] **Boundary condition checks for maximum values and empty collections.** Verify that inputs do not exceed protocol-defined maximums (e.g., max token supply, max tree depth, max participants). Also verify behavior when collections (maps, sets, lists) are empty.
+
+  ```compact
+  // BAD — no maximum check; could overflow total supply
+  export circuit mint(amount: Field): [] {
+    assert(caller_pk == authority, "Not authorized");
+    token.mint(amount);
+  }
+
+  // GOOD — enforce supply cap
+  export circuit mint(amount: Field): [] {
+    assert(caller_pk == authority, "Not authorized");
+    assert(amount > 0, "Amount must be positive");
+    const current_supply = total_supply.read();
+    assert(current_supply + amount <= MAX_SUPPLY, "Exceeds maximum supply");
+    token.mint(amount);
+    total_supply.increment(amount);
+  }
+  ```
+
+## Anti-Patterns Table
+
+Quick reference of common security anti-patterns in Compact contracts.
+
+| Anti-Pattern | Why It's Wrong | Correct Approach |
+|---|---|---|
+| `export circuit` with no `assert(caller == owner)` on state change | Anyone can invoke the circuit and modify contract state, leading to unauthorized minting, draining, or resetting | Derive caller identity via `publicKey(secretKey())` and assert against stored authority before any state modification |
+| `transientHash` used for nullifier | Non-deterministic; same input produces different outputs each call; double-spend detection fails completely | `persistentHash` with domain separation and secret key inclusion; deterministic output enables reliable duplicate detection |
+| Hash/commit call without domain string | Identical inputs from different contracts or different purposes produce the same output; enables cross-protocol replay attacks | Include a unique domain prefix in every hash: `[pad(32, "appname:purpose:"), ...]` |
+| Nullifier without secret key | Anyone can pre-compute nullifiers for other users and front-run or block their actions | Include the user's secret key in the nullifier derivation so only the key holder can produce it |
+| `map.lookup()` without `map.member()` check | Runtime failure if key does not exist; transaction reverts with an uninformative error | Always check `map.member(key)` before `map.lookup(key)` |
+| Commitment without nonce/salt | Just a hash; if the input space is small (boolean, small integer), an observer can brute-force the value | Use `persistentCommit` with a random salt/nonce; hiding property requires the blinding factor |
+| Regular `MerkleTree` for concurrent membership | Root changes on every insert; paths obtained before a concurrent insert become invalid | Use `HistoricMerkleTree` which retains previous roots and validates older paths |
+| Assert message reveals expected value | Failed transaction error message leaks private state (balance, authority key, expected commitment) to observers | Keep assert messages generic: "Not authorized", "Insufficient balance", "Invalid proof" |
+| Missing state machine guard on phase transition | Calling `reveal` before `commit`, or `execute` before `vote`, breaks protocol invariants | Assert current state at the top of each phase-transition circuit: `assert(state == State.COMMITTED, ...)` |
+| No bounds check before arithmetic | Subtraction underflow wraps silently in ZK circuits, producing valid-looking but incorrect results | Assert `a >= b` before computing `a - b`; assert `amount > 0` for all token operations |

--- a/plugins/compact-core/skills/compact-review/references/testing-review.md
+++ b/plugins/compact-core/skills/compact-review/references/testing-review.md
@@ -1,0 +1,913 @@
+# Testing Adequacy Review Checklist
+
+Review checklist for the **Testing Adequacy** category. This covers test coverage for exported circuits, edge case and boundary testing, negative/failure-path testing, private state verification, witness mock correctness, and integration test patterns. Apply every item below to the test files accompanying the contract under review.
+
+## Test Coverage Checklist
+
+Check that the test suite provides baseline coverage for every exported circuit and constructor.
+
+- [ ] **Every exported circuit has at least one test.** Each `export circuit` in the Compact contract must have a corresponding test that invokes it and verifies its observable effects (ledger state changes, return values, emitted events). An untested circuit is an unverified circuit — it may compile but behave incorrectly at runtime. List every exported circuit and check each one off against the test file.
+
+  ```compact
+  // Contract declares three exported circuits
+  export circuit initialize(authority: Bytes<32>): [] { /* ... */ }
+  export circuit deposit(amount: Uint<64>): [] { /* ... */ }
+  export circuit withdraw(amount: Uint<64>): [] { /* ... */ }
+  ```
+
+  ```typescript
+  // BAD — only tests initialize; deposit and withdraw are untested
+  describe("Vault contract", () => {
+    it("should initialize with authority", async () => {
+      const tx = await contract.initialize(authorityKey);
+      expect(tx.public.state).toBeDefined();
+    });
+    // deposit — MISSING
+    // withdraw — MISSING
+  });
+
+  // GOOD — every exported circuit has at least one test
+  describe("Vault contract", () => {
+    it("should initialize with authority", async () => {
+      const tx = await contract.initialize(authorityKey);
+      expect(tx.public.state).toBeDefined();
+    });
+
+    it("should accept deposits", async () => {
+      await contract.initialize(authorityKey);
+      const tx = await contract.deposit(100n);
+      expect(tx.public.balance).toBe(100n);
+    });
+
+    it("should process withdrawals", async () => {
+      await contract.initialize(authorityKey);
+      await contract.deposit(500n);
+      const tx = await contract.withdraw(200n);
+      expect(tx.public.balance).toBe(300n);
+    });
+  });
+  ```
+
+- [ ] **Constructor tested with expected initial state.** The contract constructor (typically the `deploy` or `initialize` circuit) sets the initial ledger state. A test must verify that all ledger fields are initialized to their expected values after construction. Missing constructor tests allow incorrect initialization to go undetected, causing all subsequent circuit calls to operate on wrong state.
+
+  ```typescript
+  // BAD — calls constructor but does not verify initial state
+  describe("Token contract", () => {
+    it("should deploy", async () => {
+      const contract = await deployContract();
+      // No assertions on initial state
+    });
+  });
+
+  // GOOD — verifies all initial state fields
+  describe("Token contract", () => {
+    it("should initialize with correct state", async () => {
+      const contract = await deployContract({
+        initialAuthority: authorityPk,
+        tokenName: "TestToken",
+      });
+
+      const ledgerState = await contract.getLedgerState();
+      expect(ledgerState.authority).toEqual(authorityPk);
+      expect(ledgerState.totalSupply).toBe(0n);
+      expect(ledgerState.state).toBe(State.INITIALIZED);
+    });
+  });
+  ```
+
+- [ ] **Happy path tested for each circuit.** Beyond mere invocation, each exported circuit needs a test that walks the expected success path: valid inputs, correct authorization, proper state preconditions. The test must verify the expected outcome — ledger state changes, return values, and private state updates. A test that calls a circuit without asserting outcomes is not a test; it only verifies the call does not throw.
+
+  ```typescript
+  // BAD — invokes circuit but asserts nothing about the outcome
+  it("should transfer tokens", async () => {
+    await contract.transfer(recipientPk, 50n);
+    // No assertions — what did the transfer actually do?
+  });
+
+  // GOOD — verifies the full happy-path outcome
+  it("should transfer tokens and update balances", async () => {
+    await contract.mint(senderPk, 100n);
+
+    const tx = await contract.transfer(recipientPk, 50n);
+
+    const senderBalance = await contract.getBalance(senderPk);
+    const recipientBalance = await contract.getBalance(recipientPk);
+    expect(senderBalance).toBe(50n);
+    expect(recipientBalance).toBe(50n);
+    expect(tx.public.totalSupply).toBe(100n); // Supply unchanged
+  });
+  ```
+
+- [ ] **Error/revert cases tested (assert failures).** Every `assert()` in the Compact contract represents a condition that should cause transaction failure when violated. Each assertion must have a corresponding test that triggers the failure and verifies the transaction reverts. Without these tests, assertion guards may be wrong (e.g., inverted condition) or missing entirely.
+
+  ```compact
+  // Contract has these assertions
+  export circuit withdraw(amount: Uint<64>): [] {
+    assert(state == State.ACTIVE, "Contract not active");
+    assert(balance >= amount, "Insufficient balance");
+    assert(amount > 0, "Amount must be positive");
+    balance = balance - amount;
+  }
+  ```
+
+  ```typescript
+  // GOOD — tests each assertion independently
+  describe("withdraw assertions", () => {
+    it("should revert when contract is not active", async () => {
+      // Contract starts in INITIALIZED state, not ACTIVE
+      await expect(contract.withdraw(10n)).rejects.toThrow(
+        "Contract not active",
+      );
+    });
+
+    it("should revert when balance is insufficient", async () => {
+      await activateContract();
+      await contract.deposit(50n);
+      await expect(contract.withdraw(100n)).rejects.toThrow(
+        "Insufficient balance",
+      );
+    });
+
+    it("should revert on zero amount", async () => {
+      await activateContract();
+      await contract.deposit(50n);
+      await expect(contract.withdraw(0n)).rejects.toThrow(
+        "Amount must be positive",
+      );
+    });
+  });
+  ```
+
+## Edge Case Checklist
+
+Check that the test suite covers boundary values and degenerate inputs that often expose arithmetic or logic bugs.
+
+- [ ] **Zero values tested: amount=0, empty bytes, zero-valued fields.** Zero is the most common source of edge-case bugs in smart contracts. A transfer of zero tokens should either be rejected or handled as a no-op. An empty `Bytes<32>` (all zeros) used as an address or key may collide with uninitialized storage. Test zero for every numeric parameter and empty/zero for every bytes parameter.
+
+  ```typescript
+  // GOOD — explicit zero-value tests
+  describe("zero value edge cases", () => {
+    it("should reject zero-amount transfer", async () => {
+      await expect(contract.transfer(recipientPk, 0n)).rejects.toThrow(
+        "Amount must be positive",
+      );
+    });
+
+    it("should reject zero-address recipient", async () => {
+      const zeroAddress = new Uint8Array(32); // All zeros
+      await expect(contract.transfer(zeroAddress, 50n)).rejects.toThrow(
+        "Invalid recipient",
+      );
+    });
+
+    it("should handle zero balance query without error", async () => {
+      const balance = await contract.getBalance(newAccountPk);
+      expect(balance).toBe(0n);
+    });
+  });
+  ```
+
+- [ ] **Maximum values tested: max Uint<64>, max Uint<128>, field maximum.** Arithmetic overflow is silent in ZK circuits — it wraps around without error. Tests must verify behavior at the upper boundary of each numeric type. For `Uint<64>`, the maximum is `2^64 - 1` (`18446744073709551615n`). For `Uint<128>`, it is `2^128 - 1`. Minting or transferring the maximum value, and then attempting one more, should be tested.
+
+  ```typescript
+  const MAX_UINT64 = (1n << 64n) - 1n;   // 18446744073709551615n
+  const MAX_UINT128 = (1n << 128n) - 1n;
+
+  describe("maximum value edge cases", () => {
+    it("should handle minting up to max supply", async () => {
+      const tx = await contract.mint(recipientPk, MAX_UINT64);
+      expect(tx.public.totalSupply).toBe(MAX_UINT64);
+    });
+
+    it("should reject minting beyond max supply (overflow)", async () => {
+      await contract.mint(recipientPk, MAX_UINT64);
+      // Minting 1 more would overflow Uint<64>
+      await expect(contract.mint(recipientPk, 1n)).rejects.toThrow();
+    });
+
+    it("should handle transfer of max amount", async () => {
+      await contract.mint(senderPk, MAX_UINT64);
+      const tx = await contract.transfer(recipientPk, MAX_UINT64);
+      expect(await contract.getBalance(senderPk)).toBe(0n);
+      expect(await contract.getBalance(recipientPk)).toBe(MAX_UINT64);
+    });
+  });
+  ```
+
+- [ ] **Boundary values tested: exactly at limit, one above, one below.** For any contract-defined limit (max supply, max participants, minimum stake), test exactly at the limit, one unit below, and one unit above. The "off-by-one" error is the most common boundary bug.
+
+  ```typescript
+  const MAX_PARTICIPANTS = 100n; // Contract-defined limit
+
+  describe("boundary value tests", () => {
+    it("should accept participant at limit", async () => {
+      // Register 100 participants (exactly at limit)
+      for (let i = 0n; i < MAX_PARTICIPANTS; i++) {
+        await contract.register(generateKey(i));
+      }
+      const count = await contract.getParticipantCount();
+      expect(count).toBe(MAX_PARTICIPANTS);
+    });
+
+    it("should reject participant above limit", async () => {
+      // Register 100, then try 101st
+      for (let i = 0n; i < MAX_PARTICIPANTS; i++) {
+        await contract.register(generateKey(i));
+      }
+      await expect(
+        contract.register(generateKey(MAX_PARTICIPANTS)),
+      ).rejects.toThrow("Max participants reached");
+    });
+
+    it("should accept participant below limit", async () => {
+      // Register 99 (one below limit) — should succeed
+      for (let i = 0n; i < MAX_PARTICIPANTS - 1n; i++) {
+        await contract.register(generateKey(i));
+      }
+      const count = await contract.getParticipantCount();
+      expect(count).toBe(MAX_PARTICIPANTS - 1n);
+    });
+  });
+  ```
+
+- [ ] **Empty collections tested: empty Map lookup, empty List head, empty Set membership.** Ledger data structures may be empty before any data is inserted. Tests must verify that the contract handles empty-collection operations correctly — either by asserting membership before lookup or by handling the missing-key case gracefully.
+
+  ```typescript
+  describe("empty collection edge cases", () => {
+    it("should handle balance lookup on empty map", async () => {
+      // Contract just deployed — no balances exist
+      await expect(contract.getBalance(unknownPk)).rejects.toThrow(
+        "Account not found",
+      );
+    });
+
+    it("should report non-membership on empty set", async () => {
+      const isMember = await contract.checkMembership(unknownPk);
+      expect(isMember).toBe(false);
+    });
+
+    it("should handle proposal query when no proposals exist", async () => {
+      await expect(contract.getLatestProposal()).rejects.toThrow(
+        "No proposals",
+      );
+    });
+  });
+  ```
+
+- [ ] **Double operations tested: calling same circuit twice, double-spend attempt.** Idempotency and replay protection are critical in smart contracts. Test what happens when the same operation is performed twice in sequence. For circuits protected by nullifiers, the second call with the same nullifier must fail. For circuits without replay protection, verify whether double-call is intended behavior.
+
+  ```typescript
+  describe("double operation tests", () => {
+    it("should prevent double-voting with same nullifier", async () => {
+      await contract.vote(proposalId, voteValue, secretKey);
+      // Second vote with same secret key produces same nullifier
+      await expect(
+        contract.vote(proposalId, voteValue, secretKey),
+      ).rejects.toThrow("Nullifier already used");
+    });
+
+    it("should prevent double-spend of same commitment", async () => {
+      await contract.deposit(100n);
+      await contract.withdraw(100n);
+      // Second withdraw with same proof should fail
+      await expect(contract.withdraw(100n)).rejects.toThrow(
+        "Insufficient balance",
+      );
+    });
+
+    it("should allow double deposit (not idempotent)", async () => {
+      await contract.deposit(50n);
+      await contract.deposit(50n);
+      const balance = await contract.getBalance(senderPk);
+      expect(balance).toBe(100n); // Both deposits should apply
+    });
+
+    it("should prevent double initialization", async () => {
+      await contract.initialize(authorityKey);
+      await expect(contract.initialize(authorityKey)).rejects.toThrow(
+        "Already initialized",
+      );
+    });
+  });
+  ```
+
+## Negative Testing Checklist
+
+Check that the test suite verifies the contract correctly rejects invalid inputs, unauthorized callers, and illegal state transitions.
+
+- [ ] **Unauthorized access tested: calling admin circuits without authorization.** Every circuit that modifies privileged state (minting, pausing, ownership transfer, configuration changes) must be tested with an unauthorized caller. The test must verify that the transaction reverts with the expected error. Without this test, an access control bug is invisible.
+
+  ```typescript
+  describe("unauthorized access tests", () => {
+    it("should reject mint from non-authority", async () => {
+      // Deploy with authority = adminKey
+      await contract.initialize(adminKey);
+
+      // Switch to non-admin caller context
+      const nonAdminContext = createWitnessContext(nonAdminSecretKey);
+      await expect(
+        contract.mint(recipientPk, 1000n, { witnessContext: nonAdminContext }),
+      ).rejects.toThrow("Not authorized");
+    });
+
+    it("should reject pause from non-owner", async () => {
+      const nonOwnerContext = createWitnessContext(nonOwnerSecretKey);
+      await expect(
+        contract.pause({ witnessContext: nonOwnerContext }),
+      ).rejects.toThrow("Not authorized");
+    });
+
+    it("should reject config update from non-admin", async () => {
+      const userContext = createWitnessContext(userSecretKey);
+      await expect(
+        contract.updateConfig(newConfig, { witnessContext: userContext }),
+      ).rejects.toThrow("Not authorized");
+    });
+  });
+  ```
+
+- [ ] **Invalid state transitions tested: calling circuits out of sequence.** For contracts with state machines (commit-reveal, propose-vote-execute, lock-unlock), test what happens when phases are called out of order. Each invalid transition must revert with the appropriate state guard error.
+
+  ```typescript
+  describe("invalid state transition tests", () => {
+    it("should reject reveal before commit", async () => {
+      // Contract in INITIALIZED state, not COMMITTED
+      await expect(
+        contract.reveal(secretValue, salt),
+      ).rejects.toThrow("Must be in COMMITTED state");
+    });
+
+    it("should reject execute before vote concludes", async () => {
+      await contract.propose(proposalData);
+      // Skip voting phase entirely
+      await expect(contract.execute(proposalId)).rejects.toThrow(
+        "Voting not concluded",
+      );
+    });
+
+    it("should reject second commit without reveal", async () => {
+      await contract.commit(commitment1);
+      // Attempt another commit without revealing the first
+      await expect(contract.commit(commitment2)).rejects.toThrow(
+        "Already committed",
+      );
+    });
+
+    it("should reject unlock when not locked", async () => {
+      // Contract starts unlocked
+      await expect(contract.unlock()).rejects.toThrow("Not locked");
+    });
+  });
+  ```
+
+- [ ] **Insufficient balance tested: transfer more than available.** This is the most basic financial safety test. Every token-handling circuit must be tested with an amount exceeding the available balance. The test must verify that both the sender's and receiver's balances remain unchanged after a failed transfer (no partial execution).
+
+  ```typescript
+  describe("insufficient balance tests", () => {
+    it("should reject transfer exceeding balance", async () => {
+      await contract.mint(senderPk, 100n);
+      await expect(contract.transfer(recipientPk, 150n)).rejects.toThrow(
+        "Insufficient balance",
+      );
+
+      // Verify balances unchanged after failed transfer
+      expect(await contract.getBalance(senderPk)).toBe(100n);
+      expect(await contract.getBalance(recipientPk)).toBe(0n);
+    });
+
+    it("should reject withdrawal exceeding balance", async () => {
+      await contract.deposit(50n);
+      await expect(contract.withdraw(51n)).rejects.toThrow(
+        "Insufficient balance",
+      );
+
+      // Verify balance unchanged
+      expect(await contract.getBalance(senderPk)).toBe(50n);
+    });
+
+    it("should reject burn exceeding supply", async () => {
+      await contract.mint(holderPk, 100n);
+      await expect(contract.burn(holderPk, 101n)).rejects.toThrow(
+        "Insufficient balance",
+      );
+    });
+  });
+  ```
+
+- [ ] **Already-used nullifiers tested: replay attack attempt.** Nullifiers are the primary mechanism for preventing double-spending and double-voting in privacy-preserving contracts. A test must verify that submitting a transaction with an already-used nullifier is rejected. This tests both the nullifier computation determinism and the on-chain set membership check.
+
+  ```typescript
+  describe("nullifier replay tests", () => {
+    it("should reject replayed vote nullifier", async () => {
+      // First vote succeeds
+      await contract.vote(proposalId, 1n, voterSecretKey);
+
+      // Same voter tries to vote again — same secret key produces same nullifier
+      await expect(
+        contract.vote(proposalId, 0n, voterSecretKey),
+      ).rejects.toThrow("Nullifier already used");
+    });
+
+    it("should reject replayed withdrawal nullifier", async () => {
+      await contract.deposit(commitmentData, 100n);
+      await contract.withdraw(proof, nullifier, 100n);
+
+      // Attempt to reuse the same withdrawal proof
+      await expect(
+        contract.withdraw(proof, nullifier, 100n),
+      ).rejects.toThrow("Nullifier already used");
+    });
+
+    it("should allow different voters on same proposal", async () => {
+      // Different secret keys produce different nullifiers
+      await contract.vote(proposalId, 1n, voter1SecretKey);
+      await contract.vote(proposalId, 0n, voter2SecretKey);
+      // Both votes should succeed — distinct nullifiers
+      const tally = await contract.getTally(proposalId);
+      expect(tally.total).toBe(2n);
+    });
+  });
+  ```
+
+- [ ] **Wrong type/format inputs tested.** While the Compact type system enforces types within circuits, the TypeScript test layer can pass malformed data to witness functions. Tests should verify that the witness layer or proof generation rejects inputs with wrong sizes (e.g., 16-byte value for a `Bytes<32>` parameter), wrong types, or invalid encodings.
+
+  ```typescript
+  describe("wrong input format tests", () => {
+    it("should reject short byte array for Bytes<32> parameter", async () => {
+      const shortKey = new Uint8Array(16); // 16 bytes instead of 32
+      await expect(contract.register(shortKey)).rejects.toThrow();
+    });
+
+    it("should reject negative amount encoded as bigint", async () => {
+      // Compact Uint<64> is unsigned — negative values should be rejected
+      // at the witness or proof generation layer
+      await expect(contract.deposit(-1n)).rejects.toThrow();
+    });
+
+    it("should reject oversized byte array", async () => {
+      const longKey = new Uint8Array(64); // 64 bytes instead of 32
+      await expect(contract.register(longKey)).rejects.toThrow();
+    });
+  });
+  ```
+
+## Private State Testing Checklist
+
+Check that tests verify the correctness of private (witness-side) state across circuit invocations.
+
+- [ ] **Private state correctly initialized.** The initial private state passed to the witness context must be verified in tests. If the initial state is wrong (missing fields, wrong types, incorrect defaults), all subsequent witness calls operate on a broken foundation. Test that the private state initializer creates the expected structure.
+
+  ```typescript
+  describe("private state initialization", () => {
+    it("should initialize private state with all required fields", () => {
+      const initialState = createInitialPrivateState(secretKey);
+
+      expect(initialState.secretKey).toEqual(secretKey);
+      expect(initialState.nonce).toBe(0n);
+      expect(initialState.balances).toBeInstanceOf(Map);
+      expect(initialState.balances.size).toBe(0);
+      expect(initialState.commitments).toEqual([]);
+    });
+
+    it("should create distinct private state per secret key", () => {
+      const state1 = createInitialPrivateState(key1);
+      const state2 = createInitialPrivateState(key2);
+
+      expect(state1.secretKey).not.toEqual(state2.secretKey);
+    });
+  });
+  ```
+
+- [ ] **Private state correctly updated after each circuit call.** After a circuit invocation that modifies private state (through a witness returning updated state), the test must verify that the private state reflects the expected changes. This typically means inspecting the witness context after the transaction.
+
+  ```typescript
+  describe("private state updates", () => {
+    it("should update private balance after deposit", async () => {
+      const initialState = createInitialPrivateState(secretKey);
+      const witnessContext = createWitnessContext(initialState);
+
+      await contract.deposit(100n, { witnessContext });
+
+      // Verify private state was updated
+      const updatedState = witnessContext.getPrivateState();
+      expect(updatedState.balances.get(accountHex)).toBe(100n);
+    });
+
+    it("should increment nonce after each operation", async () => {
+      const initialState = createInitialPrivateState(secretKey);
+      const witnessContext = createWitnessContext(initialState);
+
+      await contract.deposit(50n, { witnessContext });
+      expect(witnessContext.getPrivateState().nonce).toBe(1n);
+
+      await contract.deposit(50n, { witnessContext });
+      expect(witnessContext.getPrivateState().nonce).toBe(2n);
+    });
+  });
+  ```
+
+- [ ] **Private state immutability verified: spread operator creates new object.** Tests should verify that witness functions do not mutate the input private state. The easiest approach is to capture the state before a circuit call and compare it after the call to confirm the original reference was not modified. This catches the common bug of mutating `privateState` in place instead of returning a new object via spread.
+
+  ```typescript
+  describe("private state immutability", () => {
+    it("should not mutate the original private state object", async () => {
+      const originalState = createInitialPrivateState(secretKey);
+      const originalBalances = new Map(originalState.balances);
+      const originalNonce = originalState.nonce;
+
+      // Capture a reference to the original object
+      const stateRef = originalState;
+
+      const witnessContext = createWitnessContext(originalState);
+      await contract.deposit(100n, { witnessContext });
+
+      // The original state reference should be unchanged
+      expect(stateRef.nonce).toBe(originalNonce);
+      expect(stateRef.balances).toEqual(originalBalances);
+
+      // The updated state should be a different object
+      const newState = witnessContext.getPrivateState();
+      expect(newState).not.toBe(stateRef);
+    });
+
+    it("should not share nested object references between old and new state", async () => {
+      const originalState = createInitialPrivateState(secretKey);
+      originalState.balances.set("account1", 50n);
+      const originalBalancesRef = originalState.balances;
+
+      const witnessContext = createWitnessContext(originalState);
+      await contract.deposit(100n, { witnessContext });
+
+      const newState = witnessContext.getPrivateState();
+      // Nested Map should be a new instance
+      expect(newState.balances).not.toBe(originalBalancesRef);
+      // Original Map should be unchanged
+      expect(originalBalancesRef.get("account1")).toBe(50n);
+    });
+  });
+  ```
+
+- [ ] **Private state persistence verified: state carries between circuit calls.** Private state is passed through a chain of witness calls. A test must verify that state changes from one circuit call are visible to the next. This confirms that the witness context properly threads state through sequential operations.
+
+  ```typescript
+  describe("private state persistence across calls", () => {
+    it("should carry deposit state into withdrawal", async () => {
+      const witnessContext = createWitnessContext(
+        createInitialPrivateState(secretKey),
+      );
+
+      // First operation: deposit
+      await contract.deposit(200n, { witnessContext });
+      expect(witnessContext.getPrivateState().balances.get(accountHex)).toBe(
+        200n,
+      );
+
+      // Second operation: withdraw — should see the deposited balance
+      await contract.withdraw(75n, { witnessContext });
+      expect(witnessContext.getPrivateState().balances.get(accountHex)).toBe(
+        125n,
+      );
+    });
+
+    it("should persist commitment list across multiple commits", async () => {
+      const witnessContext = createWitnessContext(
+        createInitialPrivateState(secretKey),
+      );
+
+      await contract.commit(value1, { witnessContext });
+      expect(
+        witnessContext.getPrivateState().commitments.length,
+      ).toBe(1);
+
+      await contract.commit(value2, { witnessContext });
+      expect(
+        witnessContext.getPrivateState().commitments.length,
+      ).toBe(2);
+
+      // Both commitments should be present
+      const commitments = witnessContext.getPrivateState().commitments;
+      expect(commitments[0]).toBeDefined();
+      expect(commitments[1]).toBeDefined();
+    });
+  });
+  ```
+
+## Witness Mock Correctness Checklist
+
+Check that witness mocks in tests accurately represent the runtime witness behavior and use correct types and return shapes.
+
+- [ ] **Witness mocks return `[PrivateState, ReturnValue]` tuple, not just the return value.** This is the most common witness mock bug. The runtime expects every witness to return a two-element tuple where the first element is the (potentially updated) private state and the second is the value. A mock that returns only the value will cause the test to pass but the actual runtime to fail, or vice versa.
+
+  ```typescript
+  // BAD — mock returns only the value (not a tuple)
+  const mockWitnesses = {
+    local_secret_key: (
+      { privateState }: WitnessContext<Ledger, MyState>,
+    ): Uint8Array => {
+      return privateState.secretKey; // WRONG: runtime expects [MyState, Uint8Array]
+    },
+  };
+
+  // GOOD — mock returns the correct tuple
+  const mockWitnesses = {
+    local_secret_key: (
+      { privateState }: WitnessContext<Ledger, MyState>,
+    ): [MyState, Uint8Array] => {
+      return [privateState, privateState.secretKey];
+    },
+  };
+  ```
+
+- [ ] **Witness mocks handle `WitnessContext` correctly.** Mock witness functions must accept `WitnessContext<Ledger, PrivateState>` as their first parameter, just like production witnesses. A mock that skips the context parameter or destructures it incorrectly will receive arguments in the wrong positions, causing silent data corruption in tests.
+
+  ```typescript
+  // BAD — mock skips WitnessContext; receives context object as 'amount'
+  const mockWitnesses = {
+    get_balance: (amount: bigint): [MyState, bigint] => {
+      // 'amount' is actually the WitnessContext object — silently wrong
+      return [defaultState, 0n];
+    },
+  };
+
+  // GOOD — mock correctly accepts WitnessContext as first parameter
+  const mockWitnesses = {
+    get_balance: (
+      { privateState }: WitnessContext<Ledger, MyState>,
+      account: Uint8Array,
+    ): [MyState, bigint] => {
+      const balance = privateState.balances.get(toHex(account)) ?? 0n;
+      return [privateState, balance];
+    },
+  };
+  ```
+
+- [ ] **Mock type mappings match the Compact-to-TypeScript type table.** Mock witness functions must use the same TypeScript types as the production witnesses. A mock that uses `number` instead of `bigint` for `Field`/`Uint<N>`, or `string` instead of `Uint8Array` for `Bytes<N>`, may pass tests but masks type errors that will fail at runtime.
+
+  | Compact Type | Correct Mock Type | Common Mock Mistake |
+  |---|---|---|
+  | `Field` | `bigint` | `number` (loses precision) |
+  | `Uint<N>` | `bigint` | `number` |
+  | `Bytes<N>` | `Uint8Array` | `string` or `Buffer` |
+  | `Boolean` | `boolean` | `number` (0/1) |
+  | `Maybe<T>` | `{ is_some: boolean; value: T }` | `T \| null` |
+  | `Either<L, R>` | `{ tag: "left"; value: L } \| { tag: "right"; value: R }` | `L \| R` |
+  | Enum | `bigint` (variant index) | `string` (variant name) |
+
+  ```typescript
+  // BAD — mock uses number and string instead of correct types
+  const mockWitnesses = {
+    get_record: (
+      { privateState }: WitnessContext<Ledger, MyState>,
+      id: string, // WRONG: should be Uint8Array for Bytes<32>
+    ): [MyState, number] => { // WRONG: should be bigint for Uint<64>
+      return [privateState, 42]; // number, not bigint
+    },
+  };
+
+  // GOOD — mock uses correct type mappings
+  const mockWitnesses = {
+    get_record: (
+      { privateState }: WitnessContext<Ledger, MyState>,
+      id: Uint8Array, // Correct: Bytes<32> → Uint8Array
+    ): [MyState, bigint] => { // Correct: Uint<64> → bigint
+      return [privateState, 42n]; // bigint
+    },
+  };
+  ```
+
+- [ ] **`Maybe<T>` mocked as `{ is_some: boolean; value: T }`, not `null` or `undefined`.** The Compact `Maybe<T>` type is represented in TypeScript as a tagged object with explicit `is_some` and `value` fields. Mocks that use JavaScript `null`/`undefined` for absent values will silently produce incorrect proof inputs. When `is_some` is `false`, the `value` field must still be present with a zero/default value of the correct type.
+
+  ```typescript
+  // BAD — using null for Maybe<Uint<64>> when value is absent
+  const mockWitnesses = {
+    find_balance: (
+      { privateState }: WitnessContext<Ledger, MyState>,
+      account: Uint8Array,
+    ): [MyState, bigint | null] => {
+      const balance = privateState.balances.get(toHex(account));
+      return [privateState, balance ?? null]; // WRONG: runtime expects tagged object
+    },
+  };
+
+  // GOOD — using tagged object for Maybe<Uint<64>>
+  const mockWitnesses = {
+    find_balance: (
+      { privateState }: WitnessContext<Ledger, MyState>,
+      account: Uint8Array,
+    ): [MyState, { is_some: boolean; value: bigint }] => {
+      const balance = privateState.balances.get(toHex(account));
+      if (balance !== undefined) {
+        return [privateState, { is_some: true, value: balance }];
+      }
+      return [privateState, { is_some: false, value: 0n }];
+    },
+  };
+  ```
+
+- [ ] **`Either<L, R>` mocked with tagged union, not bare union.** The Compact `Either<L, R>` type maps to a discriminated union using a `tag` field. Mocks that return `L | R` without the tag field produce incorrect proof inputs because the runtime cannot determine which variant is active.
+
+  ```typescript
+  // BAD — bare union with no tag
+  const mockWitnesses = {
+    classify: (
+      { privateState }: WitnessContext<Ledger, MyState>,
+      data: Uint8Array,
+    ): [MyState, bigint | boolean] => {
+      return [privateState, isNumeric(data) ? toBigInt(data) : false];
+    },
+  };
+
+  // GOOD — tagged discriminated union
+  const mockWitnesses = {
+    classify: (
+      { privateState }: WitnessContext<Ledger, MyState>,
+      data: Uint8Array,
+    ): [MyState, { tag: "left"; value: bigint } | { tag: "right"; value: boolean }] => {
+      if (isNumeric(data)) {
+        return [privateState, { tag: "left", value: toBigInt(data) }];
+      }
+      return [privateState, { tag: "right", value: false }];
+    },
+  };
+  ```
+
+## Integration Test Patterns Checklist
+
+Check that the test suite covers multi-step workflows, concurrent user scenarios, and state consistency across operations.
+
+- [ ] **Multi-step flows tested end-to-end.** Contracts with multi-phase protocols (commit-reveal, mint-transfer-burn, propose-vote-execute) must have integration tests that walk through the entire flow in sequence. Each step must verify both ledger state and private state at each transition point. Testing individual steps in isolation misses bugs that only appear when the full sequence runs.
+
+  ```typescript
+  describe("commit-reveal end-to-end flow", () => {
+    it("should complete full commit → reveal cycle", async () => {
+      const secretValue = 42n;
+      const salt = crypto.getRandomValues(new Uint8Array(32));
+      const witnessContext = createWitnessContext(
+        createInitialPrivateState(secretKey),
+      );
+
+      // Step 1: Commit
+      const commitTx = await contract.commit(secretValue, salt, {
+        witnessContext,
+      });
+      expect(commitTx.public.state).toBe(State.COMMITTED);
+      expect(commitTx.public.commitment).toBeDefined();
+      const storedCommitment = commitTx.public.commitment;
+
+      // Step 2: Reveal
+      const revealTx = await contract.reveal(secretValue, salt, {
+        witnessContext,
+      });
+      expect(revealTx.public.state).toBe(State.REVEALED);
+      expect(revealTx.public.revealedValue).toBe(secretValue);
+    });
+  });
+
+  describe("token lifecycle end-to-end flow", () => {
+    it("should complete full mint → transfer → burn cycle", async () => {
+      // Step 1: Mint
+      await contract.mint(alicePk, 1000n);
+      expect(await contract.getBalance(alicePk)).toBe(1000n);
+      expect(await contract.getTotalSupply()).toBe(1000n);
+
+      // Step 2: Transfer
+      await contract.transfer(alicePk, bobPk, 400n);
+      expect(await contract.getBalance(alicePk)).toBe(600n);
+      expect(await contract.getBalance(bobPk)).toBe(400n);
+      expect(await contract.getTotalSupply()).toBe(1000n); // Supply unchanged
+
+      // Step 3: Burn
+      await contract.burn(bobPk, 100n);
+      expect(await contract.getBalance(bobPk)).toBe(300n);
+      expect(await contract.getTotalSupply()).toBe(900n); // Supply decreased
+    });
+  });
+  ```
+
+- [ ] **Concurrent user scenarios tested.** When two or more users interact with the same contract, contention and ordering issues can emerge. Tests should simulate two users acting on shared state — both depositing, one transferring while another withdraws, or two users voting on the same proposal. These tests catch concurrency bugs that single-user tests miss.
+
+  ```typescript
+  describe("concurrent user scenarios", () => {
+    it("should handle two users depositing to same contract", async () => {
+      const aliceContext = createWitnessContext(
+        createInitialPrivateState(aliceSecretKey),
+      );
+      const bobContext = createWitnessContext(
+        createInitialPrivateState(bobSecretKey),
+      );
+
+      await contract.deposit(100n, { witnessContext: aliceContext });
+      await contract.deposit(200n, { witnessContext: bobContext });
+
+      // Both deposits reflected in contract state
+      expect(await contract.getTotalDeposited()).toBe(300n);
+    });
+
+    it("should handle concurrent voting on same proposal", async () => {
+      await contract.propose(proposalData);
+
+      const voter1Context = createWitnessContext(
+        createInitialPrivateState(voter1Key),
+      );
+      const voter2Context = createWitnessContext(
+        createInitialPrivateState(voter2Key),
+      );
+
+      // Both voters submit votes
+      await contract.vote(proposalId, 1n, { witnessContext: voter1Context });
+      await contract.vote(proposalId, 0n, { witnessContext: voter2Context });
+
+      const tally = await contract.getTally(proposalId);
+      expect(tally.yesVotes).toBe(1n);
+      expect(tally.noVotes).toBe(1n);
+      expect(tally.totalVotes).toBe(2n);
+    });
+
+    it("should handle transfer between two users", async () => {
+      await contract.mint(alicePk, 500n);
+
+      const aliceContext = createWitnessContext(
+        createInitialPrivateState(aliceSecretKey),
+      );
+
+      await contract.transfer(bobPk, 200n, { witnessContext: aliceContext });
+
+      expect(await contract.getBalance(alicePk)).toBe(300n);
+      expect(await contract.getBalance(bobPk)).toBe(200n);
+    });
+  });
+  ```
+
+- [ ] **State consistency verified after multiple operations.** After a sequence of operations, the test must verify that the contract's state is internally consistent. This means checking invariants such as: total supply equals sum of all balances, counter matches number of operations performed, all merkle tree insertions are reflected in the root. These invariant checks catch subtle state corruption bugs.
+
+  ```typescript
+  describe("state consistency after multiple operations", () => {
+    it("should maintain supply invariant after mixed operations", async () => {
+      // Perform a series of operations
+      await contract.mint(alicePk, 1000n);
+      await contract.mint(bobPk, 500n);
+      await contract.transfer(alicePk, bobPk, 200n);
+      await contract.burn(alicePk, 100n);
+      await contract.transfer(bobPk, alicePk, 50n);
+
+      // Verify invariant: total supply == sum of all balances
+      const totalSupply = await contract.getTotalSupply();
+      const aliceBalance = await contract.getBalance(alicePk);
+      const bobBalance = await contract.getBalance(bobPk);
+      expect(aliceBalance + bobBalance).toBe(totalSupply);
+      expect(totalSupply).toBe(1400n); // 1000 + 500 - 100 = 1400
+    });
+
+    it("should maintain correct vote count after multiple votes", async () => {
+      await contract.propose(proposalData);
+      const voterKeys = [voter1Key, voter2Key, voter3Key, voter4Key, voter5Key];
+
+      for (const key of voterKeys) {
+        const ctx = createWitnessContext(createInitialPrivateState(key));
+        await contract.vote(proposalId, 1n, { witnessContext: ctx });
+      }
+
+      const tally = await contract.getTally(proposalId);
+      expect(tally.totalVotes).toBe(BigInt(voterKeys.length));
+    });
+
+    it("should maintain merkle tree consistency after multiple inserts", async () => {
+      const leaves: Uint8Array[] = [];
+      for (let i = 0; i < 10; i++) {
+        const leaf = generateLeaf(i);
+        leaves.push(leaf);
+        await contract.addMember(leaf);
+      }
+
+      // Verify all inserted leaves are valid members
+      for (const leaf of leaves) {
+        const isMember = await contract.verifyMembership(leaf);
+        expect(isMember).toBe(true);
+      }
+
+      // Verify a non-inserted leaf is not a member
+      const nonMember = generateLeaf(999);
+      const isMember = await contract.verifyMembership(nonMember);
+      expect(isMember).toBe(false);
+    });
+  });
+  ```
+
+## Anti-Patterns Table
+
+Quick reference of common testing anti-patterns in Compact contract test suites.
+
+| Anti-Pattern | Why It's Wrong | Correct Approach |
+|---|---|---|
+| Exported circuit with no test | Untested code is unverified code; bugs only discovered in production when real funds are at risk | Write at least one happy-path test and one failure-path test per exported circuit |
+| Test calls circuit but asserts nothing | Only verifies the call does not throw; does not verify correctness of state changes, return values, or side effects | Assert all expected outcomes: ledger state, return values, private state changes |
+| No zero-value tests | Zero amounts can bypass arithmetic checks, cause no-op transactions, or collide with uninitialized storage | Explicitly test zero for every numeric parameter and empty/zero for every bytes parameter |
+| No maximum-value tests | Arithmetic overflow wraps silently in ZK circuits; untested max values hide overflow vulnerabilities | Test at `MAX_UINT64`, `MAX_UINT128`, and contract-defined limits |
+| No unauthorized-caller tests | Access control bugs are invisible without negative tests; the circuit may accept anyone | Test every privileged circuit with a non-authorized witness context |
+| No out-of-order state transition tests | State machine guards may be missing or incorrect; protocol can be subverted by calling phases out of sequence | Test every invalid phase transition (reveal before commit, execute before vote, etc.) |
+| Witness mock returns only the value | Production witnesses return `[PrivateState, Value]` tuples; a mock returning just the value silently passes tests but the real witness behaves differently | Every mock witness must return `[privateState, returnValue]` |
+| Mock uses `null` for `Maybe<T>` | Runtime expects `{ is_some: boolean; value: T }` tagged object; `null`/`undefined` causes proof generation failure | Mock with `{ is_some: false, value: defaultValue }` for absent values |
+| Mock uses `number` for `Field`/`Uint<N>` | `number` loses precision above 2^53; tests pass with small values but production values overflow | Always use `bigint` in mocks for `Field` and `Uint<N>` types |
+| No integration tests for multi-step flows | Individual circuit tests pass but full workflows fail due to state threading, ordering, or intermediate state corruption | Test complete flows end-to-end: commit-reveal, mint-transfer-burn, propose-vote-execute |
+| No concurrent user tests | Single-user tests miss contention, ordering, and shared-state bugs that emerge when multiple users interact simultaneously | Test two or more users acting on the same contract in sequence |
+| No state invariant checks | Subtle corruption (supply != sum of balances, counter drift) accumulates across operations and goes undetected | After multi-operation sequences, verify contract invariants hold |

--- a/plugins/compact-core/skills/compact-review/references/testing-review.md
+++ b/plugins/compact-core/skills/compact-review/references/testing-review.md
@@ -2,6 +2,19 @@
 
 Review checklist for the **Testing Adequacy** category. This covers test coverage for exported circuits, edge case and boundary testing, negative/failure-path testing, private state verification, witness mock correctness, and integration test patterns. Apply every item below to the test files accompanying the contract under review.
 
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation output reveals contract structure for coverage analysis |
+| `midnight-extract-contract-structure` | `[shared]` | Lists all exported circuits (required for coverage checklist) |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of contract patterns |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for type mappings (needed for mock correctness) |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
 ## Test Coverage Checklist
 
 Check that the test suite provides baseline coverage for every exported circuit and constructor.
@@ -47,6 +60,8 @@ Check that the test suite provides baseline coverage for every exported circuit 
     });
   });
   ```
+
+  > **Tool:** `midnight-extract-contract-structure` lists all exported circuits. Use this as your definitive checklist — every exported circuit name must appear in the test files.
 
 - [ ] **Constructor tested with expected initial state.** The contract constructor (typically the `deploy` or `initialize` circuit) sets the initial ledger state. A test must verify that all ledger fields are initialized to their expected values after construction. Missing constructor tests allow incorrect initialization to go undetected, causing all subsequent circuit calls to operate on wrong state.
 
@@ -167,7 +182,7 @@ Check that the test suite covers boundary values and degenerate inputs that ofte
   });
   ```
 
-- [ ] **Maximum values tested: max Uint<64>, max Uint<128>, field maximum.** Arithmetic overflow is silent in ZK circuits — it wraps around without error. Tests must verify behavior at the upper boundary of each numeric type. For `Uint<64>`, the maximum is `2^64 - 1` (`18446744073709551615n`). For `Uint<128>`, it is `2^128 - 1`. Minting or transferring the maximum value, and then attempting one more, should be tested.
+- [ ] **Maximum values tested: max Uint<64>, max Uint<128>, field maximum.** Arithmetic behavior differs by type: `Field` arithmetic wraps silently (modular arithmetic), while `Uint<N>` addition widens the result type at compile time. For `Uint<N>`, subtraction underflow causes a runtime error. Tests must verify behavior at the upper boundary of each numeric type. For `Uint<64>`, the maximum is `2^64 - 1` (`18446744073709551615n`). For `Uint<128>`, it is `2^128 - 1`. Minting or transferring the maximum value, and then attempting one more, should be tested.
 
   ```typescript
   const MAX_UINT64 = (1n << 64n) - 1n;   // 18446744073709551615n
@@ -650,8 +665,8 @@ Check that witness mocks in tests accurately represent the runtime witness behav
   | `Bytes<N>` | `Uint8Array` | `string` or `Buffer` |
   | `Boolean` | `boolean` | `number` (0/1) |
   | `Maybe<T>` | `{ is_some: boolean; value: T }` | `T \| null` |
-  | `Either<L, R>` | `{ tag: "left"; value: L } \| { tag: "right"; value: R }` | `L \| R` |
-  | Enum | `bigint` (variant index) | `string` (variant name) |
+  | `Either<L, R>` | `{ is_left: boolean; left: L; right: R }` | `{ tag: "left"; value: L } \| { tag: "right"; value: R }` or `L \| R` |
+  | Enum | `number` (variant index) | `bigint` or `string` (variant name) |
 
   ```typescript
   // BAD — mock uses number and string instead of correct types
@@ -674,6 +689,8 @@ Check that witness mocks in tests accurately represent the runtime witness behav
     },
   };
   ```
+
+  > **Tool:** `midnight-get-latest-syntax` provides the authoritative type mapping rules. `midnight-extract-contract-structure` shows the Compact types for each witness, which must match the mock types per the mapping table.
 
 - [ ] **`Maybe<T>` mocked as `{ is_some: boolean; value: T }`, not `null` or `undefined`.** The Compact `Maybe<T>` type is represented in TypeScript as a tagged object with explicit `is_some` and `value` fields. Mocks that use JavaScript `null`/`undefined` for absent values will silently produce incorrect proof inputs. When `is_some` is `false`, the `value` field must still be present with a zero/default value of the correct type.
 
@@ -704,10 +721,10 @@ Check that witness mocks in tests accurately represent the runtime witness behav
   };
   ```
 
-- [ ] **`Either<L, R>` mocked with tagged union, not bare union.** The Compact `Either<L, R>` type maps to a discriminated union using a `tag` field. Mocks that return `L | R` without the tag field produce incorrect proof inputs because the runtime cannot determine which variant is active.
+- [ ] **`Either<L, R>` mocked with correct structure, not bare union.** The Compact `Either<L, R>` type maps to an object with `is_left`, `left`, and `right` fields. All fields must be present regardless of which variant is active. Mocks that return `L | R` without the structure produce incorrect proof inputs.
 
   ```typescript
-  // BAD — bare union with no tag
+  // BAD — bare union with no structure
   const mockWitnesses = {
     classify: (
       { privateState }: WitnessContext<Ledger, MyState>,
@@ -717,16 +734,16 @@ Check that witness mocks in tests accurately represent the runtime witness behav
     },
   };
 
-  // GOOD — tagged discriminated union
+  // GOOD — Either<L, R> uses { is_left, left, right } structure
   const mockWitnesses = {
     classify: (
       { privateState }: WitnessContext<Ledger, MyState>,
       data: Uint8Array,
-    ): [MyState, { tag: "left"; value: bigint } | { tag: "right"; value: boolean }] => {
+    ): [MyState, { is_left: boolean; left: bigint; right: boolean }] => {
       if (isNumeric(data)) {
-        return [privateState, { tag: "left", value: toBigInt(data) }];
+        return [privateState, { is_left: true, left: toBigInt(data), right: false }];
       }
-      return [privateState, { tag: "right", value: false }];
+      return [privateState, { is_left: false, left: 0n, right: false }];
     },
   };
   ```
@@ -783,6 +800,8 @@ Check that the test suite covers multi-step workflows, concurrent user scenarios
     });
   });
   ```
+
+  > **Tool:** `midnight-extract-contract-structure` and `midnight-analyze-contract` reveal the contract's state machine and multi-phase patterns. Use these to identify which flows need end-to-end tests. `midnight-list-examples` shows test patterns from reference implementations.
 
 - [ ] **Concurrent user scenarios tested.** When two or more users interact with the same contract, contention and ordering issues can emerge. Tests should simulate two users acting on shared state — both depositing, one transferring while another withdraws, or two users voting on the same proposal. These tests catch concurrency bugs that single-user tests miss.
 
@@ -902,12 +921,25 @@ Quick reference of common testing anti-patterns in Compact contract test suites.
 | Exported circuit with no test | Untested code is unverified code; bugs only discovered in production when real funds are at risk | Write at least one happy-path test and one failure-path test per exported circuit |
 | Test calls circuit but asserts nothing | Only verifies the call does not throw; does not verify correctness of state changes, return values, or side effects | Assert all expected outcomes: ledger state, return values, private state changes |
 | No zero-value tests | Zero amounts can bypass arithmetic checks, cause no-op transactions, or collide with uninitialized storage | Explicitly test zero for every numeric parameter and empty/zero for every bytes parameter |
-| No maximum-value tests | Arithmetic overflow wraps silently in ZK circuits; untested max values hide overflow vulnerabilities | Test at `MAX_UINT64`, `MAX_UINT128`, and contract-defined limits |
+| No maximum-value tests | `Field` arithmetic wraps silently (modular arithmetic); `Uint<N>` widens at compile time but subtraction underflow causes runtime error; untested max values hide vulnerabilities | Test at `MAX_UINT64`, `MAX_UINT128`, and contract-defined limits |
 | No unauthorized-caller tests | Access control bugs are invisible without negative tests; the circuit may accept anyone | Test every privileged circuit with a non-authorized witness context |
 | No out-of-order state transition tests | State machine guards may be missing or incorrect; protocol can be subverted by calling phases out of sequence | Test every invalid phase transition (reveal before commit, execute before vote, etc.) |
 | Witness mock returns only the value | Production witnesses return `[PrivateState, Value]` tuples; a mock returning just the value silently passes tests but the real witness behaves differently | Every mock witness must return `[privateState, returnValue]` |
 | Mock uses `null` for `Maybe<T>` | Runtime expects `{ is_some: boolean; value: T }` tagged object; `null`/`undefined` causes proof generation failure | Mock with `{ is_some: false, value: defaultValue }` for absent values |
+| Mock uses tagged union for `Either<L, R>` | Runtime expects `{ is_left: boolean; left: L; right: R }` with all fields present; tagged union `{ tag: "left"; value: L }` is incorrect | Mock with `{ is_left: true/false, left: ..., right: ... }` with all fields |
 | Mock uses `number` for `Field`/`Uint<N>` | `number` loses precision above 2^53; tests pass with small values but production values overflow | Always use `bigint` in mocks for `Field` and `Uint<N>` types |
+| Mock uses `bigint` for Enum | Compiler-generated enum constants are `number`, not `bigint`; using `bigint` causes type mismatches | Use `number` for enum variant indices; import constants from generated code |
 | No integration tests for multi-step flows | Individual circuit tests pass but full workflows fail due to state threading, ordering, or intermediate state corruption | Test complete flows end-to-end: commit-reveal, mint-transfer-burn, propose-vote-execute |
 | No concurrent user tests | Single-user tests miss contention, ordering, and shared-state bugs that emerge when multiple users interact simultaneously | Test two or more users acting on the same contract in sequence |
 | No state invariant checks | Subtle corruption (supply != sum of balances, counter drift) accumulates across operations and goes undetected | After multi-operation sequences, verify contract invariants hold |
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Reveals contract structure for coverage analysis. |
+| `midnight-extract-contract-structure` | Lists all exported circuits, witness declarations, and state structure — the definitive list for coverage analysis. |
+| `midnight-analyze-contract` | Static analysis of contract patterns and state machines. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference including type mapping rules for mock correctness. |
+| `midnight-list-examples` | List available example contracts with test suites for reference patterns. |
+| `midnight-search-docs` | Full-text search across official Midnight documentation for testing guidance. |

--- a/plugins/compact-core/skills/compact-review/references/token-security-review.md
+++ b/plugins/compact-core/skills/compact-review/references/token-security-review.md
@@ -1,0 +1,483 @@
+# Token & Economic Security Review Checklist
+
+Review checklist for the **Token & Economic Security** category. This covers double-spend prevention, arithmetic overflow/underflow, authorization controls, shielded token operations, and unshielded balance safety. Apply every item below to the contract under review.
+
+## Double-Spend Prevention Checklist
+
+Check every token-spending circuit for proper nullifier handling and commitment verification.
+
+- [ ] **Nullifier checked before spending.** Before any coin is consumed, the contract must verify that its nullifier has not already been used. A missing membership check allows the same coin to be spent multiple times, draining value from the system.
+
+  ```compact
+  // BAD — spends the coin without checking if nullifier was already used
+  export circuit spend(coin: ShieldedCoinInfo, nul: Bytes<32>): [] {
+    nullifiers.insert(disclose(nul));
+    // ... process spend
+  }
+
+  // GOOD — checks nullifier is unused before proceeding
+  export circuit spend(coin: ShieldedCoinInfo, nul: Bytes<32>): [] {
+    assert(!nullifiers.member(disclose(nul)), "Coin already spent");
+    nullifiers.insert(disclose(nul));
+    // ... process spend
+  }
+  ```
+
+- [ ] **Nullifier inserted after validation.** The nullifier must be inserted into the used-nullifier set only after all validity checks pass (commitment path verified, amount validated, authorization confirmed). Inserting the nullifier before validation means a failed transaction could still mark the nullifier as used, permanently locking the coin.
+
+  ```compact
+  // BAD — inserts nullifier before validation; failure locks the coin
+  export circuit spend(nul: Bytes<32>, path: MerkleTreePath<16, Bytes<32>>, amount: Field): [] {
+    nullifiers.insert(disclose(nul));
+    const root = merkleTreePathRoot<16, Bytes<32>>(path);
+    assert(commitments.checkRoot(disclose(root)), "Invalid commitment");
+    assert(amount > 0, "Invalid amount");
+    // ... process spend
+  }
+
+  // GOOD — validates everything before inserting nullifier
+  export circuit spend(nul: Bytes<32>, path: MerkleTreePath<16, Bytes<32>>, amount: Field): [] {
+    assert(!nullifiers.member(disclose(nul)), "Coin already spent");
+    const root = merkleTreePathRoot<16, Bytes<32>>(path);
+    assert(commitments.checkRoot(disclose(root)), "Invalid commitment");
+    assert(amount > 0, "Invalid amount");
+    nullifiers.insert(disclose(nul));
+    // ... process spend
+  }
+  ```
+
+- [ ] **Nullifier deterministically derived from coin and secret, not random.** A nullifier must be a deterministic function of the coin commitment and the owner's secret key. If the nullifier is random or non-deterministic (e.g., using `transientHash`), the same coin can produce different nullifiers each time, completely defeating double-spend detection.
+
+  ```compact
+  // BAD — random nullifier; same coin can produce different nullifiers
+  circuit computeNullifier(coin: Bytes<32>): Bytes<32> {
+    return transientHash<Bytes<32>>(coin);
+  }
+
+  // GOOD — deterministic nullifier derived from coin + secret + domain
+  circuit computeNullifier(coin: Bytes<32>, sk: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<3, Bytes<32>>>(
+      [pad(32, "mytoken:nul:"), coin, sk]
+    );
+  }
+  ```
+
+- [ ] **Commitment path verified against tree root before spend.** When spending a coin, the prover supplies a Merkle path proving the coin's commitment exists in the commitment tree. The contract must verify this path against the on-chain root using `checkRoot()`. Without this check, a prover can fabricate a commitment for coins that were never minted.
+
+  ```compact
+  // BAD — no commitment path verification; prover can invent coins
+  export circuit spend(nul: Bytes<32>, amount: Field): [] {
+    assert(!nullifiers.member(disclose(nul)), "Already spent");
+    nullifiers.insert(disclose(nul));
+    // Spends amount without proving the coin exists in the tree
+  }
+
+  // GOOD — verifies commitment exists in the tree
+  export circuit spend(nul: Bytes<32>, path: MerkleTreePath<16, Bytes<32>>, amount: Field): [] {
+    assert(!nullifiers.member(disclose(nul)), "Already spent");
+    const root = merkleTreePathRoot<16, Bytes<32>>(path);
+    assert(commitments.checkRoot(disclose(root)), "Commitment not in tree");
+    nullifiers.insert(disclose(nul));
+    // ... process spend with verified amount
+  }
+  ```
+
+## Overflow/Underflow Checklist
+
+Check all arithmetic operations on token amounts for type sufficiency and bounds safety.
+
+- [ ] **Token amount type: `Uint<64>` vs `Uint<128>` — is the chosen type sufficient?** Compact supports both `Uint<64>` and `Uint<128>` for token amounts. Shielded (zswap) operations require `Uint<64>`, while unshielded operations use `Uint<128>`. Using the wrong type can cause truncation or compilation errors. Verify that the type matches the token operation context.
+
+  ```compact
+  // BAD — Uint<128> for a shielded mint (zswap requires Uint<64>)
+  export circuit mintShielded(amount: Uint<128>): ShieldedCoinInfo {
+    return mintShieldedToken(
+      disclose(domainSep), disclose(amount), // Type mismatch for zswap
+      evolveNonce(0 as Uint<128>, disclose(domainSep)),
+      left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey())
+    );
+  }
+
+  // GOOD — Uint<64> for shielded operations, matching zswap requirements
+  export circuit mintShielded(amount: Uint<64>): ShieldedCoinInfo {
+    return mintShieldedToken(
+      disclose(domainSep), disclose(amount),
+      evolveNonce(0 as Uint<128>, disclose(domainSep)),
+      left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey())
+    );
+  }
+  ```
+
+- [ ] **Addition overflow check: total does not exceed maximum value.** When adding to a balance or accumulating amounts, the result must not exceed the maximum representable value for the type. In ZK circuits, overflow wraps silently, producing a small value instead of a large one. Always assert that the addition will not overflow before performing it.
+
+  ```compact
+  // BAD — addition could overflow silently, wrapping to a small value
+  export circuit deposit(account: Bytes<32>, amount: Uint<128>): [] {
+    const current = balances.lookup(account);
+    balances.insert(account, current + amount);
+  }
+
+  // GOOD — overflow check before addition
+  export circuit deposit(account: Bytes<32>, amount: Uint<128>): [] {
+    assert(amount > 0, "Deposit must be positive");
+    assert(balances.member(account), "Account not found");
+    const current = balances.lookup(account);
+    const max: Uint<128> = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+    assert(max - current >= amount, "Deposit would overflow balance");
+    balances.insert(account, current + amount);
+  }
+  ```
+
+- [ ] **Subtraction underflow check: balance is sufficient before deduction.** Subtracting more than the current balance wraps to the maximum unsigned value in ZK circuits, effectively creating tokens from nothing. Always assert that the balance is greater than or equal to the amount before subtraction.
+
+  ```compact
+  // BAD — underflow wraps to maximum value, creating tokens
+  export circuit withdraw(account: Bytes<32>, amount: Uint<128>): [] {
+    const current = balances.lookup(account);
+    balances.insert(account, current - amount);
+  }
+
+  // GOOD — assert sufficient balance before subtraction
+  export circuit withdraw(account: Bytes<32>, amount: Uint<128>): [] {
+    assert(amount > 0, "Withdrawal must be positive");
+    assert(balances.member(account), "Account not found");
+    const current = balances.lookup(account);
+    assert(current >= amount, "Insufficient balance");
+    balances.insert(account, current - amount);
+  }
+  ```
+
+- [ ] **Total supply overflow on mint operations.** When minting new tokens, the total supply increases. If the contract does not track total supply or does not check for overflow at the supply level, it is possible to mint tokens past the maximum representable value, wrapping the total supply to a small number.
+
+  ```compact
+  // BAD — no supply tracking or overflow check
+  export circuit mint(to: Bytes<32>, amount: Uint<128>): [] {
+    assert(caller == authority, "Not authorized");
+    const current = balances.lookup(to);
+    balances.insert(to, current + amount);
+  }
+
+  // GOOD — tracks and limits total supply
+  export circuit mint(to: Bytes<32>, amount: Uint<128>): [] {
+    assert(caller == authority, "Not authorized");
+    assert(amount > 0, "Amount must be positive");
+    const supply = total_supply.read();
+    assert(supply + amount <= MAX_SUPPLY, "Exceeds maximum supply");
+    total_supply.increment(amount);
+    const current = balances.member(to) ? balances.lookup(to) : 0;
+    balances.insert(to, current + amount);
+  }
+  ```
+
+- [ ] **Intermediate arithmetic fits in the declared type.** When performing multi-step arithmetic (e.g., `a + b - c`, `amount * rate / divisor`), intermediate results may overflow even if the final result fits. Verify that every intermediate step remains within the bounds of the declared type.
+
+  ```compact
+  // BAD — intermediate (a + b) may overflow even if (a + b - c) would fit
+  const result = a + b - c;
+
+  // GOOD — check intermediate result fits, or reorder to avoid overflow
+  assert(a >= c, "Underflow in a - c");
+  const result = (a - c) + b;
+  // Or: assert that a + b does not overflow before proceeding
+  ```
+
+## Authorization Checklist
+
+Check all token operations for proper caller authorization and role enforcement.
+
+- [ ] **Mint operations: who can call? Is there an authority check?** Minting creates new tokens and must be restricted to authorized callers. An `export circuit` that mints tokens without verifying the caller's identity allows anyone to inflate the token supply. This is a critical vulnerability.
+
+  ```compact
+  // BAD — anyone can mint unlimited tokens
+  export circuit mint(amount: Uint<64>): [] {
+    token.mint(amount);
+  }
+
+  // GOOD — only the authority can mint (pattern from lock.compact)
+  export circuit mint(amount: Uint<64>): [] {
+    const sk = secretKey();
+    const pk = publicKey(round, sk);
+    assert(authority == pk, "Attempted to mint without authorization");
+    token.mint(amount);
+  }
+  ```
+
+- [ ] **Burn operations: can only the owner burn their tokens?** Burning destroys tokens permanently. If the burn circuit does not verify that the caller owns the tokens being burned, an attacker can destroy other users' tokens.
+
+  ```compact
+  // BAD — anyone can burn any account's tokens
+  export circuit burn(account: Bytes<32>, amount: Uint<128>): [] {
+    const current = balances.lookup(account);
+    assert(current >= amount, "Insufficient balance");
+    balances.insert(account, current - amount);
+  }
+
+  // GOOD — only the account owner can burn
+  export circuit burn(amount: Uint<128>): [] {
+    const sk = local_secret_key();
+    const account = disclose(publicKey(sk));
+    assert(balances.member(account), "Account not found");
+    const current = balances.lookup(account);
+    assert(current >= amount, "Insufficient balance");
+    balances.insert(account, current - amount);
+  }
+  ```
+
+- [ ] **Transfer operations: sender authorization verified.** A transfer must verify that the caller is the sender (or an approved delegate). Without sender verification, anyone can move tokens out of any account.
+
+  ```compact
+  // BAD — caller not verified as the sender
+  export circuit transfer(from: Bytes<32>, to: Bytes<32>, amount: Uint<128>): [] {
+    const from_bal = balances.lookup(from);
+    assert(from_bal >= amount, "Insufficient balance");
+    balances.insert(from, from_bal - amount);
+    const to_bal = balances.member(to) ? balances.lookup(to) : 0;
+    balances.insert(to, to_bal + amount);
+  }
+
+  // GOOD — sender proves ownership via secret key
+  export circuit transfer(to: Bytes<32>, amount: Uint<128>): [] {
+    const sk = local_secret_key();
+    const from = disclose(publicKey(sk));
+    assert(balances.member(from), "Sender account not found");
+    const from_bal = balances.lookup(from);
+    assert(from_bal >= amount, "Insufficient balance");
+    balances.insert(from, from_bal - amount);
+    const to_bal = balances.member(to) ? balances.lookup(to) : 0;
+    balances.insert(to, to_bal + amount);
+  }
+  ```
+
+- [ ] **Allowance/approval: `spendAllowance` correctly deducts from approved amount.** If the contract implements a delegated spending pattern (like ERC-20 `approve` + `transferFrom`), verify that the allowance is checked and deducted atomically. A missing deduction allows unlimited spending from a single approval.
+
+  ```compact
+  // BAD — checks allowance but does not deduct it; infinite spend
+  export circuit transferFrom(owner: Bytes<32>, to: Bytes<32>, amount: Uint<128>): [] {
+    const sk = local_secret_key();
+    const spender = disclose(publicKey(sk));
+    const allowed = allowances.lookup(owner);
+    assert(allowed >= amount, "Allowance exceeded");
+    // Missing: allowances.insert(owner, allowed - amount);
+    const bal = balances.lookup(owner);
+    balances.insert(owner, bal - amount);
+    balances.insert(to, amount);
+  }
+
+  // GOOD — deducts allowance atomically with the transfer
+  export circuit transferFrom(owner: Bytes<32>, to: Bytes<32>, amount: Uint<128>): [] {
+    const sk = local_secret_key();
+    const spender = disclose(publicKey(sk));
+    const allowed = allowances.lookup(owner);
+    assert(allowed >= amount, "Allowance exceeded");
+    allowances.insert(owner, allowed - amount);
+    const bal = balances.lookup(owner);
+    assert(bal >= amount, "Insufficient balance");
+    balances.insert(owner, bal - amount);
+    const to_bal = balances.member(to) ? balances.lookup(to) : 0;
+    balances.insert(to, to_bal + amount);
+  }
+  ```
+
+- [ ] **`unsafe` variants (`unsafeTransfer`, `unsafeMint`): are they intentionally exposed?** Some token implementations expose `unsafe` versions of operations that skip safety checks (e.g., `unsafeTransfer` that does not verify `receiveShielded` on the receiving end, or `unsafeMint` that bypasses authority checks). If these are exported, verify that the exposure is intentional. Warning: tokens sent via `unsafeTransfer` to a contract address that does not call `receiveShielded` are permanently lost and irretrievable.
+
+  ```compact
+  // DANGEROUS — unsafeTransfer skips receiveShielded check on recipient
+  // Tokens sent to a contract that does not call receiveShielded are LOST
+  export circuit unsafeTransfer(
+    coin: ShieldedCoinInfo,
+    to: Either<ZswapCoinPublicKey, ContractAddress>,
+    amount: Uint<64>
+  ): [] {
+    // Does not verify recipient calls receiveShielded
+    sendShielded(coin, to, amount);
+  }
+
+  // If unsafe variants exist, ensure they are:
+  // 1. Clearly documented as unsafe
+  // 2. Not exported unless absolutely necessary
+  // 3. Only called from circuits that handle the safety checks themselves
+  ```
+
+## Shielded Token Checklist
+
+Check all shielded (zswap) token operations for correct API usage and value handling.
+
+- [ ] **`receiveShielded()` called in receiving contract.** When shielded tokens are sent to a contract address, the receiving contract MUST call `receiveShielded(disclose(coin))` to accept and register the incoming coin. If `receiveShielded` is not called, the tokens are permanently lost with no recovery mechanism. This is one of the most critical token security checks.
+
+  ```compact
+  // BAD — contract receives shielded tokens but never calls receiveShielded
+  // Tokens sent here are PERMANENTLY LOST
+  export circuit deposit(coin: ShieldedCoinInfo): [] {
+    // Process deposit logic but forget to receive the coin
+    deposits.insert(disclose(someKey), disclose(coin.value));
+  }
+
+  // GOOD — receiveShielded called to accept incoming tokens
+  // (pattern from midnight-node minter.compact)
+  export circuit receiveShieldedTest(coin: ShieldedCoinInfo): [] {
+    assert(coin.value > 0, "Deposit amount must be positive");
+    receiveShielded(disclose(coin));
+  }
+  ```
+
+- [ ] **Correct coin color used (token type identifier).** In Midnight's zswap model, each token type is identified by a "color" (a `Bytes<32>` domain separator). Using the wrong color means the operation targets the wrong token type. Verify that the domain separator passed to `mintShieldedToken` and other operations matches the intended token.
+
+  ```compact
+  // BAD — hardcoded color string that may not match the token's actual color
+  const color = pad(32, "some-token");
+
+  // GOOD — use a consistent domain separator, typically from a ledger or constant
+  // (pattern from midnight-node minter.compact)
+  export circuit mintShieldedToSelfTest(domainSep: Bytes<32>, amount: Uint<64>): ShieldedCoinInfo {
+    const recipient = ownPublicKey();
+    return mintShieldedToken(
+      disclose(domainSep),
+      disclose(amount),
+      evolveNonce(0 as Uint<128>, disclose(domainSep)),
+      left<ZswapCoinPublicKey, ContractAddress>(recipient)
+    );
+  }
+  ```
+
+- [ ] **`ShieldedCoinInfo` vs `QualifiedShieldedCoinInfo` — correct type for the operation.** These two types serve different purposes. `ShieldedCoinInfo` represents a newly minted or received coin. `QualifiedShieldedCoinInfo` represents a coin that has been qualified (bound to a specific spend context). Using the wrong type causes compilation errors or incorrect behavior. Check the stdlib signatures:
+  - `receiveShielded(ShieldedCoinInfo)` — takes unqualified coin info
+  - `sendShielded(QualifiedShieldedCoinInfo, ...)` — requires qualified coin info
+  - `sendImmediateShielded(ShieldedCoinInfo, ...)` — takes unqualified coin info
+  - `mergeCoin(QualifiedShieldedCoinInfo, QualifiedShieldedCoinInfo)` — merges two qualified coins
+
+- [ ] **Change output handled properly after partial spend.** When spending only part of a shielded coin, the remaining value must be returned as a change output. If the change is not handled, the difference between the coin value and the sent amount is lost. Check that `sendImmediateShielded` return values are processed for change coins.
+
+  ```compact
+  // BAD — sends partial value but ignores the change output
+  export circuit partialSpend(coin: ShieldedCoinInfo, amount: Uint<64>): [] {
+    receiveShielded(disclose(coin));
+    sendImmediateShielded(
+      disclose(coin),
+      right<ZswapCoinPublicKey, ContractAddress>(targetContract),
+      disclose(amount)
+    );
+    // Change coin is lost!
+  }
+
+  // GOOD — handles the return value including change
+  // (pattern from composable-relay.compact)
+  export circuit send_to_burn(coin: ShieldedCoinInfo): [] {
+    receiveShielded(disclose(coin));
+    const sendValue = coin.value == 0 ? 0 : coin.value - 1;
+    const res = sendImmediateShielded(
+      disclose(coin),
+      right<ZswapCoinPublicKey, ContractAddress>(burnContract),
+      disclose(sendValue)
+    );
+    tmpDoCall(res.sent);
+  }
+  ```
+
+- [ ] **`sendImmediateShielded` return value checked for change coins.** The `sendImmediateShielded` function returns a result that includes information about the sent coin and any change. If the return value is discarded, the caller loses the ability to handle change and cannot verify that the send succeeded.
+
+  ```compact
+  // BAD — return value discarded; change is lost and success not verified
+  export circuit send(coin: ShieldedCoinInfo, to: ContractAddress, amount: Uint<64>): [] {
+    receiveShielded(disclose(coin));
+    sendImmediateShielded(
+      disclose(coin),
+      right<ZswapCoinPublicKey, ContractAddress>(to),
+      disclose(amount)
+    );
+  }
+
+  // GOOD — capture and process the return value
+  export circuit send(coin: ShieldedCoinInfo, to: ContractAddress, amount: Uint<64>): [] {
+    receiveShielded(disclose(coin));
+    const res = sendImmediateShielded(
+      disclose(coin),
+      right<ZswapCoinPublicKey, ContractAddress>(to),
+      disclose(amount)
+    );
+    // Process res.sent and handle any change output
+    tmpDoCall(res.sent);
+  }
+  ```
+
+- [ ] **`Uint<64>` amount for zswap operations, not `Uint<128>`.** The zswap protocol operates on `Uint<64>` amounts. Functions like `mintShieldedToken` and `sendImmediateShielded` require `Uint<64>` for the amount parameter. Using `Uint<128>` will cause a type mismatch. Unshielded operations (e.g., `mintUnshieldedToken`, `sendUnshielded`) use `Uint<128>`.
+
+  Standard library function signatures for reference:
+  ```
+  mintShieldedToken(Bytes<32>, Uint<64>, Bytes<32>, Either<ZswapCoinPublicKey, ContractAddress>)
+  sendImmediateShielded(ShieldedCoinInfo, Either<ZswapCoinPublicKey, ContractAddress>, Uint<64>)
+  sendShielded(QualifiedShieldedCoinInfo, Either<ZswapCoinPublicKey, ContractAddress>, Uint<128>)
+  mintUnshieldedToken(Bytes<32>, Uint<64>, Either<ContractAddress, UserAddress>)
+  sendUnshielded(Bytes<32>, Uint<128>, Either<ContractAddress, UserAddress>)
+  ```
+
+## Unshielded Token Checklist
+
+Check all unshielded token operations for construction-time pitfalls and API correctness.
+
+- [ ] **`unshieldedBalance()` not used in conditional logic.** Calling `unshieldedBalance()` inside an `if` condition or using its return value to make branching decisions creates a construction-time balance lock. The balance is captured when the proof is constructed (on the client), not when the transaction executes on-chain. By the time the transaction lands, the actual balance may have changed, leading to incorrect logic or stale decisions.
+
+  ```compact
+  // BAD — creates construction-time balance lock; stale by execution time
+  export circuit conditionalTransfer(color: Bytes<32>, amount: Uint<128>): [] {
+    if (unshieldedBalance(disclose(color)) > amount) {
+      sendUnshielded(disclose(color), disclose(amount), recipient);
+    }
+  }
+
+  // GOOD — use dedicated comparison circuit from stdlib
+  // (pattern from midnight-js testkit)
+  export circuit conditionalTransfer(color: Bytes<32>, amount: Uint<128>): Boolean {
+    return unshieldedBalanceGt(disclose(color), disclose(amount));
+  }
+  ```
+
+- [ ] **Comparison functions used instead of raw balance reads.** The standard library provides `unshieldedBalanceGt` and `unshieldedBalanceLt` for safe balance comparisons. These functions are designed to avoid the construction-time lock problem inherent in `unshieldedBalance()`. Use them instead of reading the balance and comparing manually.
+
+  ```compact
+  // BAD — reads balance then compares; construction-time lock
+  export circuit hasEnough(color: Bytes<32>, threshold: Uint<128>): Boolean {
+    return disclose(unshieldedBalance(disclose(color)) >= threshold);
+  }
+
+  // GOOD — stdlib comparison avoids construction-time lock
+  export circuit hasEnough(color: Bytes<32>, threshold: Uint<128>): Boolean {
+    return unshieldedBalanceGt(disclose(color), disclose(threshold));
+  }
+  ```
+
+  Available stdlib comparison functions:
+  ```
+  unshieldedBalanceGt(Bytes<32>, Uint<128>) -> Boolean
+  unshieldedBalanceLt(Bytes<32>, Uint<128>) -> Boolean
+  ```
+
+- [ ] **Proper `disclose()` on amount parameters.** Unshielded token operations require disclosed (public) parameters because unshielded balances are inherently public. Forgetting `disclose()` on the color or amount will cause a compilation error since undisclosed witness values cannot flow to public ledger operations.
+
+  ```compact
+  // BAD — missing disclose; will not compile
+  export circuit send(color: Bytes<32>, amount: Uint<128>): [] {
+    sendUnshielded(color, amount, recipient);
+  }
+
+  // GOOD — all parameters properly disclosed
+  export circuit send(color: Bytes<32>, amount: Uint<128>): [] {
+    sendUnshielded(disclose(color), disclose(amount), recipient);
+  }
+  ```
+
+## Anti-Patterns Table
+
+Quick reference of common token security anti-patterns in Compact contracts.
+
+| Anti-Pattern | Risk | Correct Pattern |
+|---|---|---|
+| `export circuit mint(amount)` with no auth check | Anyone can mint unlimited tokens, destroying the token's economic model | Add `assert(caller == authority)` or role-based authorization check before minting |
+| `balance - amount` without `assert(balance >= amount)` | Underflow wraps to maximum unsigned value in ZK circuits, effectively creating tokens from nothing | Always assert `balance >= amount` before any subtraction on token amounts |
+| Missing `receiveShielded(disclose(coin))` in receiving contract | Shielded tokens sent to the contract are permanently lost with no recovery mechanism | Always call `receiveShielded(disclose(coin))` before processing any received shielded coin |
+| `if (unshieldedBalance(...) > 0)` in conditional logic | Balance is captured at proof construction time, not execution time; decision is based on stale data | Use `unshieldedBalanceGt` or `unshieldedBalanceLt` stdlib comparison circuits instead |
+| `kernel.mintShielded(pk, amount)` directly | Low-level kernel call bypasses stdlib safety checks, proper nonce handling, and coin registration | Use `mintShieldedToken(domainSep, amount, nonce, recipient)` stdlib wrapper which handles all safety concerns |
+| Allowance checked but not deducted after spend | Approved spender can drain the entire owner balance with repeated calls using the same approval | Atomically deduct the spent amount from the allowance in the same circuit that performs the transfer |
+| `sendImmediateShielded` return value discarded | Change output from partial spend is lost; tokens equal to `coinValue - sentAmount` are destroyed | Capture the return value and process `res.sent` and any change coins |
+| `Uint<128>` used for shielded token amount | Type mismatch with zswap protocol which operates on `Uint<64>`; causes compilation or runtime errors | Use `Uint<64>` for all shielded/zswap operations; reserve `Uint<128>` for unshielded operations |
+| Nullifier derived using `transientHash` | Non-deterministic; same coin produces different nullifiers each time, completely defeating double-spend prevention | Use `persistentHash` with domain separation and secret key for deterministic nullifier derivation |
+| `unsafeTransfer` to a contract address | Recipient contract may not call `receiveShielded`, causing permanent token loss | Use safe transfer wrappers that verify recipient handling, or ensure the target contract is known to call `receiveShielded` |

--- a/plugins/compact-core/skills/compact-review/references/token-security-review.md
+++ b/plugins/compact-core/skills/compact-review/references/token-security-review.md
@@ -2,6 +2,19 @@
 
 Review checklist for the **Token & Economic Security** category. This covers double-spend prevention, arithmetic overflow/underflow, authorization controls, shielded token operations, and unshielded balance safety. Apply every item below to the contract under review.
 
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation errors from type mismatches in token operations |
+| `midnight-extract-contract-structure` | `[shared]` | Detects structural issues in token handling, missing checks |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of token patterns |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for token operation signatures |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
 ## Double-Spend Prevention Checklist
 
 Check every token-spending circuit for proper nullifier handling and commitment verification.
@@ -62,6 +75,8 @@ Check every token-spending circuit for proper nullifier handling and commitment 
   }
   ```
 
+  > **Tool:** `midnight-extract-contract-structure` identifies hash function usage. Verify all nullifier derivations use `persistentHash`, not `transientHash`.
+
 - [ ] **Commitment path verified against tree root before spend.** When spending a coin, the prover supplies a Merkle path proving the coin's commitment exists in the commitment tree. The contract must verify this path against the on-chain root using `checkRoot()`. Without this check, a prover can fabricate a commitment for coins that were never minted.
 
   ```compact
@@ -86,27 +101,20 @@ Check every token-spending circuit for proper nullifier handling and commitment 
 
 Check all arithmetic operations on token amounts for type sufficiency and bounds safety.
 
-- [ ] **Token amount type: `Uint<64>` vs `Uint<128>` — is the chosen type sufficient?** Compact supports both `Uint<64>` and `Uint<128>` for token amounts. Shielded (zswap) operations require `Uint<64>`, while unshielded operations use `Uint<128>`. Using the wrong type can cause truncation or compilation errors. Verify that the type matches the token operation context.
+- [ ] **Token amount type: `Uint<64>` vs `Uint<128>` — is the chosen type sufficient?** Compact supports both `Uint<64>` and `Uint<128>` for token amounts. Most shielded operations (`mintShieldedToken`, `sendShielded`, `sendImmediateShielded`) and unshielded send operations (`sendUnshielded`) use `Uint<128>` for amounts. The exception is `mintUnshieldedToken`, which uses `Uint<64>`. Using the wrong type can cause truncation or compilation errors. Verify that the type matches the token operation context.
 
   ```compact
-  // BAD — Uint<128> for a shielded mint (zswap requires Uint<64>)
+  // GOOD — Uint<128> for shielded mint value parameter
   export circuit mintShielded(amount: Uint<128>): ShieldedCoinInfo {
     return mintShieldedToken(
-      disclose(domainSep), disclose(amount), // Type mismatch for zswap
-      evolveNonce(0 as Uint<128>, disclose(domainSep)),
-      left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey())
-    );
-  }
-
-  // GOOD — Uint<64> for shielded operations, matching zswap requirements
-  export circuit mintShielded(amount: Uint<64>): ShieldedCoinInfo {
-    return mintShieldedToken(
       disclose(domainSep), disclose(amount),
-      evolveNonce(0 as Uint<128>, disclose(domainSep)),
+      evolveNonce(0 as Uint<64>, disclose(domainSep)),
       left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey())
     );
   }
   ```
+
+  > **Tool:** `midnight-get-latest-syntax` provides the authoritative stdlib function signatures showing the exact `Uint` width for each token operation. `midnight-compile-contract` output will show type mismatch errors if the wrong width is used.
 
 - [ ] **Addition overflow check: total does not exceed maximum value.** When adding to a balance or accumulating amounts, the result must not exceed the maximum representable value for the type. In ZK circuits, overflow wraps silently, producing a small value instead of a large one. Always assert that the addition will not overflow before performing it.
 
@@ -320,6 +328,8 @@ Check all shielded (zswap) token operations for correct API usage and value hand
   }
   ```
 
+  > **Tool:** `midnight-extract-contract-structure` identifies all `receiveShielded` calls. Cross-reference against all circuits that accept `ShieldedCoinInfo` parameters — each must call `receiveShielded`. `midnight-search-compact` can find reference patterns for correct shielded token handling.
+
 - [ ] **Correct coin color used (token type identifier).** In Midnight's zswap model, each token type is identified by a "color" (a `Bytes<32>` domain separator). Using the wrong color means the operation targets the wrong token type. Verify that the domain separator passed to `mintShieldedToken` and other operations matches the intended token.
 
   ```compact
@@ -333,7 +343,7 @@ Check all shielded (zswap) token operations for correct API usage and value hand
     return mintShieldedToken(
       disclose(domainSep),
       disclose(amount),
-      evolveNonce(0 as Uint<128>, disclose(domainSep)),
+      evolveNonce(0 as Uint<64>, disclose(domainSep)),
       left<ZswapCoinPublicKey, ContractAddress>(recipient)
     );
   }
@@ -399,16 +409,18 @@ Check all shielded (zswap) token operations for correct API usage and value hand
   }
   ```
 
-- [ ] **`Uint<64>` amount for zswap operations, not `Uint<128>`.** The zswap protocol operates on `Uint<64>` amounts. Functions like `mintShieldedToken` and `sendImmediateShielded` require `Uint<64>` for the amount parameter. Using `Uint<128>` will cause a type mismatch. Unshielded operations (e.g., `mintUnshieldedToken`, `sendUnshielded`) use `Uint<128>`.
+- [ ] **Correct `Uint` width for token operations.** Token operations use specific `Uint` widths. The `mintShieldedToken` function takes `Uint<128>` for the value parameter, while `mintUnshieldedToken` takes `Uint<64>`. The `sendShielded`, `sendImmediateShielded`, and `sendUnshielded` functions all take `Uint<128>` for the amount parameter. Check the stdlib signatures below for the exact types required by each function.
 
   Standard library function signatures for reference:
   ```
-  mintShieldedToken(Bytes<32>, Uint<64>, Bytes<32>, Either<ZswapCoinPublicKey, ContractAddress>)
-  sendImmediateShielded(ShieldedCoinInfo, Either<ZswapCoinPublicKey, ContractAddress>, Uint<64>)
+  mintShieldedToken(Bytes<32>, Uint<128>, Bytes<32>, Either<ZswapCoinPublicKey, ContractAddress>)
+  sendImmediateShielded(ShieldedCoinInfo, Either<ZswapCoinPublicKey, ContractAddress>, Uint<128>)
   sendShielded(QualifiedShieldedCoinInfo, Either<ZswapCoinPublicKey, ContractAddress>, Uint<128>)
   mintUnshieldedToken(Bytes<32>, Uint<64>, Either<ContractAddress, UserAddress>)
   sendUnshielded(Bytes<32>, Uint<128>, Either<ContractAddress, UserAddress>)
   ```
+
+  > **Tool:** `midnight-get-latest-syntax` is the authoritative source for these function signatures. Cross-reference every token operation call against the syntax reference.
 
 ## Unshielded Token Checklist
 
@@ -431,6 +443,8 @@ Check all unshielded token operations for construction-time pitfalls and API cor
   }
   ```
 
+  > **Tool:** `midnight-search-docs` has guidance on construction-time balance locks and the correct use of comparison functions.
+
 - [ ] **Comparison functions used instead of raw balance reads.** The standard library provides `unshieldedBalanceGt` and `unshieldedBalanceLt` for safe balance comparisons. These functions are designed to avoid the construction-time lock problem inherent in `unshieldedBalance()`. Use them instead of reading the balance and comparing manually.
 
   ```compact
@@ -448,7 +462,9 @@ Check all unshielded token operations for construction-time pitfalls and API cor
   Available stdlib comparison functions:
   ```
   unshieldedBalanceGt(Bytes<32>, Uint<128>) -> Boolean
+  unshieldedBalanceGte(Bytes<32>, Uint<128>) -> Boolean
   unshieldedBalanceLt(Bytes<32>, Uint<128>) -> Boolean
+  unshieldedBalanceLte(Bytes<32>, Uint<128>) -> Boolean
   ```
 
 - [ ] **Proper `disclose()` on amount parameters.** Unshielded token operations require disclosed (public) parameters because unshielded balances are inherently public. Forgetting `disclose()` on the color or amount will cause a compilation error since undisclosed witness values cannot flow to public ledger operations.
@@ -478,6 +494,18 @@ Quick reference of common token security anti-patterns in Compact contracts.
 | `kernel.mintShielded(pk, amount)` directly | Low-level kernel call bypasses stdlib safety checks, proper nonce handling, and coin registration | Use `mintShieldedToken(domainSep, amount, nonce, recipient)` stdlib wrapper which handles all safety concerns |
 | Allowance checked but not deducted after spend | Approved spender can drain the entire owner balance with repeated calls using the same approval | Atomically deduct the spent amount from the allowance in the same circuit that performs the transfer |
 | `sendImmediateShielded` return value discarded | Change output from partial spend is lost; tokens equal to `coinValue - sentAmount` are destroyed | Capture the return value and process `res.sent` and any change coins |
-| `Uint<128>` used for shielded token amount | Type mismatch with zswap protocol which operates on `Uint<64>`; causes compilation or runtime errors | Use `Uint<64>` for all shielded/zswap operations; reserve `Uint<128>` for unshielded operations |
+| Wrong `Uint` width for token operations | Using the wrong `Uint` width for token functions causes type mismatches; `mintShieldedToken` takes `Uint<128>` for value, `mintUnshieldedToken` takes `Uint<64>` for minting | Check the stdlib function signatures for the exact `Uint` width required by each token operation |
 | Nullifier derived using `transientHash` | Non-deterministic; same coin produces different nullifiers each time, completely defeating double-spend prevention | Use `persistentHash` with domain separation and secret key for deterministic nullifier derivation |
 | `unsafeTransfer` to a contract address | Recipient contract may not call `receiveShielded`, causing permanent token loss | Use safe transfer wrappers that verify recipient handling, or ensure the target contract is known to call `receiveShielded` |
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Use `skipZk=true` for syntax validation. |
+| `midnight-extract-contract-structure` | Deep structural analysis: token patterns, missing `receiveShielded`, hash function usage. |
+| `midnight-analyze-contract` | Static analysis of contract structure and common patterns. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference including token operation signatures. |
+| `midnight-search-compact` | Semantic search across Compact code for token handling patterns. |
+| `midnight-search-docs` | Full-text search across official Midnight documentation. |
+| `midnight-list-examples` | List available example contracts with token implementations for reference. |

--- a/plugins/compact-core/skills/compact-review/references/witness-consistency-review.md
+++ b/plugins/compact-core/skills/compact-review/references/witness-consistency-review.md
@@ -1,0 +1,654 @@
+# Witness-Contract Consistency Review Checklist
+
+Review checklist for the **Witness-Contract Consistency** category. This bridges the Compact contract layer with the TypeScript witness layer. A mismatch between the two causes runtime failures that the Compact compiler cannot catch because the TypeScript side is outside its scope. Apply every item below to the contract and its corresponding witness implementation.
+
+## Name Matching Checklist
+
+Check that every witness declared in the Compact contract has a corresponding key in the TypeScript `witnesses` object.
+
+- [ ] **Every `witness` declaration in the Compact contract has a matching key in the TypeScript `witnesses` object.** The runtime resolves witness functions by name at proof generation time. A missing key means the prover cannot find the function, and proof generation fails with a runtime error. There is no compile-time check for this — it only fails when a circuit that calls the witness is actually invoked.
+
+  ```compact
+  // Compact contract — declares three witnesses
+  witness local_secret_key(): Bytes<32>;
+  witness get_balance(account: Bytes<32>): Uint<64>;
+  witness store_result(value: Field): [];
+  ```
+
+  ```typescript
+  // BAD — missing get_balance; runtime failure when any circuit calls it
+  export const witnesses = {
+    local_secret_key: ({ privateState }: WitnessContext<Ledger, MyState>): [MyState, Uint8Array] => {
+      return [privateState, privateState.secretKey];
+    },
+    store_result: (
+      { privateState }: WitnessContext<Ledger, MyState>,
+      value: bigint,
+    ): [MyState, []] => {
+      return [{ ...privateState, lastResult: value }, []];
+    },
+    // get_balance is MISSING — runtime failure
+  };
+
+  // GOOD — all three witnesses implemented
+  export const witnesses = {
+    local_secret_key: ({ privateState }: WitnessContext<Ledger, MyState>): [MyState, Uint8Array] => {
+      return [privateState, privateState.secretKey];
+    },
+    get_balance: (
+      { privateState }: WitnessContext<Ledger, MyState>,
+      account: Uint8Array,
+    ): [MyState, bigint] => {
+      const balance = privateState.balances.get(toHex(account));
+      if (balance === undefined) {
+        throw new Error("Account not found in private state");
+      }
+      return [privateState, balance];
+    },
+    store_result: (
+      { privateState }: WitnessContext<Ledger, MyState>,
+      value: bigint,
+    ): [MyState, []] => {
+      return [{ ...privateState, lastResult: value }, []];
+    },
+  };
+  ```
+
+- [ ] **Witness names match exactly, including casing.** Witness lookup is case-sensitive. A witness declared as `local_secret_key` in Compact must have the key `local_secret_key` in the TypeScript `witnesses` object — not `localSecretKey`, `LOCAL_SECRET_KEY`, or any other variation. This is a common mistake when developers apply JavaScript naming conventions to witness keys.
+
+  ```compact
+  // Compact
+  witness local_secret_key(): Bytes<32>;
+  witness get_merkle_path(leaf: Bytes<32>): MerkleTreePath<16, Bytes<32>>;
+  ```
+
+  ```typescript
+  // BAD — camelCase does not match Compact's snake_case declaration
+  export const witnesses = {
+    localSecretKey: ({ privateState }: WitnessContext<Ledger, MyState>): [MyState, Uint8Array] => {
+      return [privateState, privateState.secretKey];
+    },
+    getMerklePath: (
+      { privateState }: WitnessContext<Ledger, MyState>,
+      leaf: Uint8Array,
+    ): [MyState, MerkleTreePath] => {
+      return [privateState, computePath(leaf)];
+    },
+  };
+
+  // GOOD — keys match Compact declarations exactly
+  export const witnesses = {
+    local_secret_key: ({ privateState }: WitnessContext<Ledger, MyState>): [MyState, Uint8Array] => {
+      return [privateState, privateState.secretKey];
+    },
+    get_merkle_path: (
+      { privateState }: WitnessContext<Ledger, MyState>,
+      leaf: Uint8Array,
+    ): [MyState, MerkleTreePath] => {
+      return [privateState, computePath(leaf)];
+    },
+  };
+  ```
+
+- [ ] **No extra witness keys in the TypeScript object that do not exist in the Compact contract.** Extra keys are silently ignored by the runtime but indicate a maintenance problem. They may be leftover from a refactor where a witness was removed from the Compact contract but not from the TypeScript side, or they may indicate a naming mismatch where the developer thinks they implemented a witness but the key does not match.
+
+- [ ] **Witness parameter count and order match the Compact declaration.** After the `WitnessContext` first parameter, the remaining parameters must match the Compact declaration in both count and order. The circuit passes arguments positionally. A mismatch means the witness receives the wrong values.
+
+  ```compact
+  // Compact — two parameters: account then amount
+  witness transfer_private(account: Bytes<32>, amount: Uint<64>): Boolean;
+  ```
+
+  ```typescript
+  // BAD — parameters in wrong order
+  transfer_private: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    amount: bigint,     // Should be account (Uint8Array)
+    account: Uint8Array, // Should be amount (bigint)
+  ): [MyState, boolean] => {
+    // ...
+  },
+
+  // GOOD — parameters match Compact declaration order
+  transfer_private: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    account: Uint8Array, // Matches first param: Bytes<32>
+    amount: bigint,      // Matches second param: Uint<64>
+  ): [MyState, boolean] => {
+    // ...
+  },
+  ```
+
+## Type Mapping Correctness Checklist
+
+Check that Compact types are correctly translated to their TypeScript equivalents in witness parameter types and return types.
+
+- [ ] **All Compact-to-TypeScript type mappings are correct.** Every witness parameter type and return type must use the correct TypeScript representation. The table below is the authoritative mapping. A type mismatch causes proof generation failure or silently incorrect data.
+
+  | Compact Type | TypeScript Type | Common Mistake |
+  |---|---|---|
+  | `Field` | `bigint` | Using `number` (loses precision for values > 2^53) |
+  | `Boolean` | `boolean` | Correct |
+  | `Uint<N>` | `bigint` | Using `number` (loses precision for large N) |
+  | `Bytes<N>` | `Uint8Array` | Using `string` or `Buffer` |
+  | `Opaque<"string">` | `string` | Correct |
+  | `Opaque<"Uint8Array">` | `Uint8Array` | Correct |
+  | `Maybe<T>` | `{ is_some: boolean; value: T }` | Using `T \| null` or `T \| undefined` (WRONG -- must use tagged object) |
+  | `Either<L, R>` | `{ tag: "left"; value: L } \| { tag: "right"; value: R }` | Using `L \| R` union (WRONG -- must use tagged discriminated union) |
+  | `Vector<N, T>` | `T[]` (length N) | Not checking array length matches N |
+  | Struct `{ x: Field; y: Boolean }` | `{ x: bigint; y: boolean }` | Field names must match exactly |
+  | Enum | `bigint` variant index | Mapping variants to wrong indices |
+  | `[T1, T2]` (tuple) | `[T1_mapped, T2_mapped]` | Wrong element order |
+
+- [ ] **`Field` and `Uint<N>` use `bigint`, not `number`.** JavaScript `number` is a 64-bit floating-point type that loses precision for integers above 2^53. Compact `Field` values can be up to the ZK field maximum (much larger). `Uint<64>` values can reach 2^64 - 1. Using `number` silently truncates large values, producing incorrect proofs.
+
+  ```typescript
+  // BAD — number loses precision for large values
+  local_balance: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [MyState, number] => {
+    return [privateState, Number(privateState.balance)]; // Precision loss!
+  },
+
+  // GOOD — bigint preserves full precision
+  local_balance: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [MyState, bigint] => {
+    return [privateState, privateState.balance];
+  },
+  ```
+
+- [ ] **`Bytes<N>` uses `Uint8Array`, not `string` or `Buffer`.** The runtime expects `Uint8Array` for all `Bytes<N>` types. Using `string` causes a type error at proof generation. Using Node.js `Buffer` may work in some environments because `Buffer` extends `Uint8Array`, but it is not portable and can cause subtle issues in browser contexts.
+
+  ```typescript
+  // BAD — string is not Uint8Array
+  local_secret_key: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [MyState, string] => {
+    return [privateState, privateState.secretKeyHex]; // Wrong type
+  },
+
+  // GOOD — Uint8Array matches Bytes<32>
+  local_secret_key: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [MyState, Uint8Array] => {
+    return [privateState, privateState.secretKey];
+  },
+  ```
+
+- [ ] **`Maybe<T>` uses the tagged object `{ is_some: boolean; value: T }`, not `T | null` or `T | undefined`.** The runtime does not understand JavaScript nullability patterns. It expects the explicit tagged object form with both `is_some` and `value` fields present, even when `is_some` is `false`. When `is_some` is `false`, the `value` field must still be present with a zero/default value of the correct type.
+
+  ```compact
+  // Compact
+  witness find_record(id: Bytes<32>): Maybe<Uint<64>>;
+  ```
+
+  ```typescript
+  // BAD — using null for absent values
+  find_record: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    id: Uint8Array,
+  ): [MyState, bigint | null] => {
+    const record = privateState.records.get(toHex(id));
+    return [privateState, record ?? null]; // WRONG — runtime expects tagged object
+  },
+
+  // GOOD — tagged object with is_some and value
+  find_record: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    id: Uint8Array,
+  ): [MyState, { is_some: boolean; value: bigint }] => {
+    const record = privateState.records.get(toHex(id));
+    if (record !== undefined) {
+      return [privateState, { is_some: true, value: record }];
+    }
+    return [privateState, { is_some: false, value: 0n }];
+  },
+  ```
+
+- [ ] **`Either<L, R>` uses the tagged discriminated union `{ tag: "left"; value: L } | { tag: "right"; value: R }`, not a bare union `L | R`.** The runtime uses the `tag` field to determine which variant is active. Without the tag, the runtime cannot distinguish between the two sides.
+
+  ```compact
+  // Compact
+  witness classify_input(data: Bytes<32>): Either<Uint<64>, Boolean>;
+  ```
+
+  ```typescript
+  // BAD — bare union with no tag
+  classify_input: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    data: Uint8Array,
+  ): [MyState, bigint | boolean] => {
+    // WRONG — runtime cannot distinguish left from right
+    return [privateState, isNumeric(data) ? toBigInt(data) : false];
+  },
+
+  // GOOD — tagged discriminated union
+  classify_input: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    data: Uint8Array,
+  ): [MyState, { tag: "left"; value: bigint } | { tag: "right"; value: boolean }] => {
+    if (isNumeric(data)) {
+      return [privateState, { tag: "left", value: toBigInt(data) }];
+    }
+    return [privateState, { tag: "right", value: false }];
+  },
+  ```
+
+- [ ] **`Vector<N, T>` returns an array of exactly length N.** The runtime performs a length check. If the witness returns an array with fewer or more elements than the declared `N`, proof generation fails. This is especially error-prone when `N` is a compile-time constant that may change between contract versions.
+
+  ```compact
+  // Compact
+  witness get_setup(): Vector<5, Field>;
+  ```
+
+  ```typescript
+  // BAD — array length does not match Vector<5, ...>
+  get_setup: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [MyState, bigint[]] => {
+    return [privateState, [1n, 2n, 3n]]; // Only 3 elements, needs 5
+  },
+
+  // GOOD — exactly 5 elements
+  get_setup: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [MyState, bigint[]] => {
+    const setup = privateState.setup;
+    if (setup.length !== 5) {
+      throw new Error(`Setup must have exactly 5 elements, got ${setup.length}`);
+    }
+    return [privateState, setup];
+  },
+  ```
+
+- [ ] **Struct field names and types match exactly.** When a witness returns a struct, the TypeScript object must have the same field names as the Compact struct definition. Extra fields are ignored but missing fields cause failures. Field types must also match the mapping table above.
+
+  ```compact
+  // Compact
+  export struct UserProfile { name: Opaque<"string">; score: Uint<64>; active: Boolean }
+  witness get_profile(): UserProfile;
+  ```
+
+  ```typescript
+  // BAD — wrong field name ("points" instead of "score"), wrong type for active
+  get_profile: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [MyState, { name: string; points: bigint; active: number }] => {
+    return [privateState, {
+      name: privateState.name,
+      points: privateState.score,  // Wrong field name
+      active: 1,                   // Wrong type: should be boolean
+    }];
+  },
+
+  // GOOD — field names and types match Compact struct exactly
+  get_profile: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [MyState, { name: string; score: bigint; active: boolean }] => {
+    return [privateState, {
+      name: privateState.name,
+      score: privateState.score,
+      active: privateState.active,
+    }];
+  },
+  ```
+
+- [ ] **Enum values use the correct `bigint` variant index.** Compact enums are represented as zero-based `bigint` indices in TypeScript. Mapping a variant to the wrong index silently produces incorrect behavior because the contract interprets a different variant than intended.
+
+  ```compact
+  // Compact
+  export enum Status { pending, approved, rejected }
+  witness get_decision(): Status;
+  ```
+
+  ```typescript
+  // BAD — using string or wrong index
+  get_decision: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [MyState, bigint] => {
+    return [privateState, 2n]; // This is "rejected", not "approved"
+    // Or worse: return [privateState, "approved" as any]; // string, not bigint
+  },
+
+  // GOOD — use the compiler-generated constants
+  import { Status } from "./managed/my-contract/index.cjs";
+
+  get_decision: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [MyState, bigint] => {
+    return [privateState, BigInt(Status.approved)]; // 1n
+  },
+  ```
+
+## WitnessContext Pattern Checklist
+
+Check that witness functions correctly use the `WitnessContext` interface and return the expected tuple.
+
+- [ ] **Every witness function takes `WitnessContext<Ledger, PrivateState>` as its first parameter.** This is not optional. The runtime always passes the context as the first argument. A witness that omits the context parameter or declares it with the wrong type will receive arguments in the wrong positions.
+
+  ```typescript
+  // BAD — missing WitnessContext as first parameter
+  local_secret_key: (secretKey: Uint8Array): Uint8Array => {
+    return secretKey; // Wrong: this receives the WitnessContext object, not a key
+  },
+
+  // GOOD — WitnessContext is always the first parameter
+  local_secret_key: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [MyState, Uint8Array] => {
+    return [privateState, privateState.secretKey];
+  },
+  ```
+
+- [ ] **Witness accesses `context.privateState` for current private state.** The `privateState` field on `WitnessContext` contains the current private state for this contract instance. It is the only source of truth for private data. Do not store private state in module-level variables or closures — this breaks when multiple contract instances share the same witness code.
+
+  ```typescript
+  // BAD — module-level variable for private state (breaks with multiple instances)
+  let globalSecretKey: Uint8Array;
+
+  export const witnesses = {
+    local_secret_key: (
+      _context: WitnessContext<Ledger, MyState>,
+    ): [MyState, Uint8Array] => {
+      return [_context.privateState, globalSecretKey]; // Stale or wrong instance
+    },
+  };
+
+  // GOOD — always read from context.privateState
+  export const witnesses = {
+    local_secret_key: (
+      { privateState }: WitnessContext<Ledger, MyState>,
+    ): [MyState, Uint8Array] => {
+      return [privateState, privateState.secretKey];
+    },
+  };
+  ```
+
+- [ ] **Witness uses `context.contractAddress` where needed for per-deployment scoping.** When the same witness implementation serves multiple deployed instances of a contract, `contractAddress` distinguishes between them. Without it, private state from one deployment leaks into another.
+
+  ```typescript
+  // BAD — no scoping by contract address; all deployments share one entry
+  store_data: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    data: bigint,
+  ): [MyState, []] => {
+    return [{ ...privateState, storedData: data }, []]; // Overwrites for all instances
+  },
+
+  // GOOD — scoped by contractAddress
+  store_data: (
+    { privateState, contractAddress }: WitnessContext<Ledger, MyState>,
+    data: bigint,
+  ): [MyState, []] => {
+    const perContract = new Map(privateState.perContract);
+    perContract.set(contractAddress, data);
+    return [{ ...privateState, perContract }, []];
+  },
+  ```
+
+- [ ] **Witness uses `context.ledger` (not direct ledger queries) for reading on-chain state.** The `ledger` field provides a projected view of the ledger as it would look if the transaction ran against the current local view. This is the correct way to read ledger state inside a witness. Do not make separate network calls to query ledger state — the data may be inconsistent with the proof context.
+
+- [ ] **Return type is ALWAYS `[PrivateState, ReturnValue]` tuple — NOT just the return value.** The runtime expects every witness to return a two-element tuple where the first element is the (potentially updated) private state and the second is the declared return value. Returning only the value, or reversing the order, causes a runtime failure.
+
+  ```typescript
+  // BAD — returning only the value (not a tuple)
+  local_secret_key: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): Uint8Array => {
+    return privateState.secretKey; // WRONG: runtime expects [MyState, Uint8Array]
+  },
+
+  // BAD — tuple elements in wrong order
+  local_secret_key: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [Uint8Array, MyState] => {
+    return [privateState.secretKey, privateState]; // WRONG: state first, value second
+  },
+
+  // GOOD — [PrivateState, ReturnValue] in correct order
+  local_secret_key: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [MyState, Uint8Array] => {
+    return [privateState, privateState.secretKey];
+  },
+  ```
+
+- [ ] **Side-effect-only witnesses (Compact return type `[]`) return `[PrivateState, []]`.** The empty tuple `[]` in the return position is the TypeScript representation of Compact's `[]` return type. Returning `undefined`, `null`, or omitting the second element is incorrect.
+
+  ```compact
+  // Compact
+  witness save_locally(data: Field): [];
+  ```
+
+  ```typescript
+  // BAD — returning undefined instead of []
+  save_locally: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    data: bigint,
+  ): [MyState, undefined] => {
+    return [{ ...privateState, saved: data }, undefined]; // WRONG
+  },
+
+  // GOOD — empty array for [] return type
+  save_locally: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    data: bigint,
+  ): [MyState, []] => {
+    return [{ ...privateState, saved: data }, []];
+  },
+  ```
+
+## Private State Immutability Checklist
+
+Check that witness functions treat private state as immutable and return new state objects rather than mutating in place.
+
+- [ ] **Private state is updated by returning a NEW object, not by mutating the existing one in place.** The runtime treats private state as functional — each witness call receives the current state and returns a new state. Mutating the `privateState` object directly can cause unpredictable behavior because the runtime may reference the original object elsewhere. Always use the spread operator or object construction to create a new state.
+
+  ```typescript
+  // BAD — mutating privateState in place
+  increment_counter: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [MyState, bigint] => {
+    privateState.counter += 1n; // MUTATION — unpredictable behavior
+    return [privateState, privateState.counter];
+  },
+
+  // GOOD — returning a new state object via spread
+  increment_counter: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [MyState, bigint] => {
+    const newCounter = privateState.counter + 1n;
+    return [{ ...privateState, counter: newCounter }, newCounter];
+  },
+  ```
+
+- [ ] **Spread operator (`...`) used for shallow copies; deep clone used for nested objects.** The spread operator creates a shallow copy. If the private state contains nested objects (e.g., `Map`, arrays, nested records), the spread alone shares references to those inner objects. Modifying an inner object through the new state also modifies the old state. For nested data, create new instances of the nested structures.
+
+  ```typescript
+  // BAD — shallow spread, then mutating nested Map
+  update_records: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    key: Uint8Array,
+    value: bigint,
+  ): [MyState, []] => {
+    const newState = { ...privateState }; // Shallow copy
+    newState.records.set(toHex(key), value); // MUTATION of shared Map reference
+    return [newState, []];
+  },
+
+  // GOOD — create a new Map for the nested structure
+  update_records: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    key: Uint8Array,
+    value: bigint,
+  ): [MyState, []] => {
+    const newRecords = new Map(privateState.records); // New Map instance
+    newRecords.set(toHex(key), value);
+    return [{ ...privateState, records: newRecords }, []];
+  },
+  ```
+
+- [ ] **Array state fields are copied, not pushed to or spliced in place.** Similar to nested objects, arrays in private state must be replaced, not mutated. Use the spread operator on arrays or `Array.from()` to create copies before modification.
+
+  ```typescript
+  // BAD — mutating array in place
+  add_entry: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    entry: bigint,
+  ): [MyState, []] => {
+    privateState.entries.push(entry); // MUTATION of shared array
+    return [privateState, []];
+  },
+
+  // GOOD — creating a new array
+  add_entry: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    entry: bigint,
+  ): [MyState, []] => {
+    const newEntries = [...privateState.entries, entry]; // New array
+    return [{ ...privateState, entries: newEntries }, []];
+  },
+  ```
+
+- [ ] **Private state fields are marked `readonly` in the TypeScript type definition.** While `readonly` does not prevent mutation at runtime, it provides a compile-time guard that catches accidental mutations during development. This is a best practice for signaling intent.
+
+  ```typescript
+  // BAD — no readonly markers; mutations are not flagged by TypeScript
+  type MyState = {
+    secretKey: Uint8Array;
+    counter: bigint;
+    records: Map<string, bigint>;
+  };
+
+  // GOOD — readonly markers catch accidental mutations at compile time
+  type MyState = {
+    readonly secretKey: Uint8Array;
+    readonly counter: bigint;
+    readonly records: ReadonlyMap<string, bigint>;
+  };
+  ```
+
+## Witness Implementation Correctness Checklist
+
+Check witness functions for side effects, determinism, and operational issues that affect proof generation.
+
+- [ ] **Witness should not have side effects beyond private state updates.** Witnesses run during proof generation on the client side. Side effects like writing to files, sending network requests, logging to external services, or modifying global variables make the witness non-reproducible and can leak private information. The only intended "side effect" is the private state update returned in the tuple.
+
+  ```typescript
+  // BAD — network call and logging inside witness (side effects)
+  get_balance: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    account: Uint8Array,
+  ): [MyState, bigint] => {
+    console.log(`Balance queried for ${toHex(account)}`); // Leaks private info
+    fetch("https://analytics.example.com/log", {           // Network side effect
+      method: "POST",
+      body: JSON.stringify({ account: toHex(account) }),
+    });
+    return [privateState, privateState.balances.get(toHex(account)) ?? 0n];
+  },
+
+  // GOOD — pure computation from private state, no side effects
+  get_balance: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    account: Uint8Array,
+  ): [MyState, bigint] => {
+    return [privateState, privateState.balances.get(toHex(account)) ?? 0n];
+  },
+  ```
+
+- [ ] **Witness should be deterministic for the same inputs to allow proof re-generation.** If a transaction needs to be re-proven (e.g., due to a network error or ledger state change), the witness is called again. A non-deterministic witness may produce different output on the second call, causing the new proof to differ from the first and potentially fail. Avoid `Date.now()`, `Math.random()`, or other non-deterministic sources unless the value is immediately stored in private state and reused on subsequent calls.
+
+  ```typescript
+  // BAD — uses Math.random(); different result each call
+  get_nonce: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [MyState, Uint8Array] => {
+    const nonce = new Uint8Array(32);
+    crypto.getRandomValues(nonce); // Different on each call
+    return [privateState, nonce]; // Re-proof produces different nonce
+  },
+
+  // GOOD — generate once, store in private state, reuse
+  get_nonce: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+  ): [MyState, Uint8Array] => {
+    if (privateState.nonce) {
+      return [privateState, privateState.nonce]; // Reuse stored nonce
+    }
+    const nonce = new Uint8Array(32);
+    crypto.getRandomValues(nonce);
+    return [{ ...privateState, nonce }, nonce]; // Store for re-proof
+  },
+  ```
+
+- [ ] **Witness does not perform long-running or async operations that could timeout proof generation.** Witness functions are called synchronously during proof generation. Long-running computation (large data processing, complex cryptographic operations) or attempting asynchronous operations (network calls, file I/O) can cause the proof generation to timeout or fail. Keep witness logic fast and synchronous.
+
+  ```typescript
+  // BAD — async operation inside a synchronous witness
+  get_merkle_proof: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    leaf: Uint8Array,
+  ): [MyState, MerkleTreePath] => {
+    // This will NOT work — witnesses are synchronous
+    const proof = await fetchMerkleProof(leaf); // TypeError: await in non-async
+    return [privateState, proof];
+  },
+
+  // GOOD — precompute and store in private state before proof generation
+  get_merkle_proof: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    leaf: Uint8Array,
+  ): [MyState, MerkleTreePath] => {
+    const proof = privateState.precomputedProofs.get(toHex(leaf));
+    if (!proof) {
+      throw new Error("Merkle proof not precomputed — call prepareMerkleProof() first");
+    }
+    return [privateState, proof];
+  },
+  ```
+
+- [ ] **Witness throws meaningful errors for invalid state rather than returning garbage values.** When a witness cannot produce a valid result (missing data, invalid state), it should throw an `Error` with a descriptive message. This aborts the transaction before proof generation, giving the developer a clear error. Returning a default or garbage value produces a proof that may pass the circuit but represent incorrect state.
+
+  ```typescript
+  // BAD — returns 0n when balance is not found (silently incorrect)
+  get_balance: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    account: Uint8Array,
+  ): [MyState, bigint] => {
+    return [privateState, privateState.balances.get(toHex(account)) ?? 0n];
+    // If account genuinely doesn't exist, this may produce a valid but wrong proof
+  },
+
+  // GOOD — throw when data is genuinely expected to exist
+  get_balance: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    account: Uint8Array,
+  ): [MyState, bigint] => {
+    const balance = privateState.balances.get(toHex(account));
+    if (balance === undefined) {
+      throw new Error(`Account ${toHex(account)} not found in private state`);
+    }
+    return [privateState, balance];
+  },
+  ```
+
+## Anti-Patterns Table
+
+Quick reference of common witness-contract consistency anti-patterns.
+
+| Anti-Pattern | Why It's Wrong | Correct Approach |
+|---|---|---|
+| Missing witness key in TypeScript `witnesses` object | Runtime cannot find the witness function; proof generation fails when any circuit calls it | Every `witness` declaration in Compact must have a matching key in the TypeScript `witnesses` object |
+| camelCase key for snake_case Compact witness name | Witness lookup is case-sensitive; the key is silently not found and proof generation fails | Use the exact name from the Compact declaration, including casing |
+| `number` instead of `bigint` for `Field` or `Uint<N>` | JavaScript `number` loses precision above 2^53; silently produces incorrect proofs for large values | Always use `bigint` for `Field`, `Uint<N>`, and enum variant indices |
+| `string` or `Buffer` instead of `Uint8Array` for `Bytes<N>` | Runtime expects `Uint8Array`; other types cause proof generation failure or portability issues | Always use `Uint8Array` for `Bytes<N>` |
+| `T \| null` for `Maybe<T>` | Runtime expects `{ is_some: boolean; value: T }` tagged object; null/undefined is not recognized | Return `{ is_some: true, value: x }` or `{ is_some: false, value: defaultValue }` |
+| `L \| R` for `Either<L, R>` | Runtime uses the `tag` field to distinguish variants; a bare union has no tag | Return `{ tag: "left", value: x }` or `{ tag: "right", value: y }` |
+| Returning only the value (not the `[PS, Value]` tuple) | Runtime expects a two-element tuple with private state first; single value causes destructuring failure | Always return `[privateState, returnValue]` |
+| Mutating `privateState` in place | Shared reference may be used elsewhere by the runtime; in-place mutation causes unpredictable behavior | Spread and override: `{ ...privateState, field: newVal }` |
+| `Math.random()` or `Date.now()` in witness | Non-deterministic; produces different output on re-proof, causing proof generation to fail on retry | Generate once and store in private state; reuse on subsequent calls |
+| Async operations (`await`, `fetch`) in witness | Witnesses are synchronous; async code either fails or blocks indefinitely during proof generation | Precompute async results and store in private state before proof generation |
+| Module-level variable for private state | Breaks when multiple contract instances share the same witness code; stale or wrong instance data | Always read from `context.privateState` |
+| Wrong parameter order after WitnessContext | Circuit passes arguments positionally; swapped parameters mean the witness receives wrong values | Match parameter order to Compact declaration exactly |

--- a/plugins/compact-core/skills/compact-review/references/witness-consistency-review.md
+++ b/plugins/compact-core/skills/compact-review/references/witness-consistency-review.md
@@ -2,11 +2,26 @@
 
 Review checklist for the **Witness-Contract Consistency** category. This bridges the Compact contract layer with the TypeScript witness layer. A mismatch between the two causes runtime failures that the Compact compiler cannot catch because the TypeScript side is outside its scope. Apply every item below to the contract and its corresponding witness implementation.
 
+## Required MCP Tools
+
+Run these tools before starting your review. Reference their output when evaluating checklist items.
+
+| Tool | Label | Purpose |
+|------|-------|---------|
+| `midnight-compile-contract` | `[shared]` | Compilation output reveals witness-related errors |
+| `midnight-extract-contract-structure` | `[shared]` | Lists all witness declarations, their parameter types, and return types |
+| `midnight-analyze-contract` | `[shared]` | Static analysis of contract structure |
+| `midnight-get-latest-syntax` | `[shared]` | Authoritative reference for witness declaration syntax and type mappings |
+
+Tools marked `[shared]` are pre-run by the orchestrator — their output is in your prompt.
+
 ## Name Matching Checklist
 
 Check that every witness declared in the Compact contract has a corresponding key in the TypeScript `witnesses` object.
 
 - [ ] **Every `witness` declaration in the Compact contract has a matching key in the TypeScript `witnesses` object.** The runtime resolves witness functions by name at proof generation time. A missing key means the prover cannot find the function, and proof generation fails with a runtime error. There is no compile-time check for this — it only fails when a circuit that calls the witness is actually invoked.
+
+  > **Tool:** `midnight-extract-contract-structure` lists all witness declarations in the contract. Use this as your definitive list of witness names to cross-reference against the TypeScript `witnesses` object.
 
   ```compact
   // Compact contract — declares three witnesses
@@ -94,6 +109,8 @@ Check that every witness declared in the Compact contract has a corresponding ke
 
 - [ ] **Witness parameter count and order match the Compact declaration.** After the `WitnessContext` first parameter, the remaining parameters must match the Compact declaration in both count and order. The circuit passes arguments positionally. A mismatch means the witness receives the wrong values.
 
+  > **Tool:** `midnight-extract-contract-structure` provides the exact parameter list for each witness. Compare against the TypeScript implementation parameter-by-parameter.
+
   ```compact
   // Compact — two parameters: account then amount
   witness transfer_private(account: Bytes<32>, amount: Uint<64>): Boolean;
@@ -125,6 +142,8 @@ Check that Compact types are correctly translated to their TypeScript equivalent
 
 - [ ] **All Compact-to-TypeScript type mappings are correct.** Every witness parameter type and return type must use the correct TypeScript representation. The table below is the authoritative mapping. A type mismatch causes proof generation failure or silently incorrect data.
 
+  > **Tool:** `midnight-extract-contract-structure` shows the Compact types for each witness parameter and return value. `midnight-get-latest-syntax` confirms the authoritative type mapping rules. `midnight-search-docs` has detailed WitnessContext documentation.
+
   | Compact Type | TypeScript Type | Common Mistake |
   |---|---|---|
   | `Field` | `bigint` | Using `number` (loses precision for values > 2^53) |
@@ -134,10 +153,10 @@ Check that Compact types are correctly translated to their TypeScript equivalent
   | `Opaque<"string">` | `string` | Correct |
   | `Opaque<"Uint8Array">` | `Uint8Array` | Correct |
   | `Maybe<T>` | `{ is_some: boolean; value: T }` | Using `T \| null` or `T \| undefined` (WRONG -- must use tagged object) |
-  | `Either<L, R>` | `{ tag: "left"; value: L } \| { tag: "right"; value: R }` | Using `L \| R` union (WRONG -- must use tagged discriminated union) |
+  | `Either<L, R>` | `{ is_left: boolean; left: L; right: R }` | Using `L \| R` union or `{ tag: "left"; value: L }` tagged union (WRONG -- must use `is_left`/`left`/`right` structure with all fields present) |
   | `Vector<N, T>` | `T[]` (length N) | Not checking array length matches N |
   | Struct `{ x: Field; y: Boolean }` | `{ x: bigint; y: boolean }` | Field names must match exactly |
-  | Enum | `bigint` variant index | Mapping variants to wrong indices |
+  | Enum | `number` variant index | Using `bigint` or `string` instead of `number`; mapping variants to wrong indices |
   | `[T1, T2]` (tuple) | `[T1_mapped, T2_mapped]` | Wrong element order |
 
 - [ ] **`Field` and `Uint<N>` use `bigint`, not `number`.** JavaScript `number` is a 64-bit floating-point type that loses precision for integers above 2^53. Compact `Field` values can be up to the ZK field maximum (much larger). `Uint<64>` values can reach 2^64 - 1. Using `number` silently truncates large values, producing incorrect proofs.
@@ -206,7 +225,7 @@ Check that Compact types are correctly translated to their TypeScript equivalent
   },
   ```
 
-- [ ] **`Either<L, R>` uses the tagged discriminated union `{ tag: "left"; value: L } | { tag: "right"; value: R }`, not a bare union `L | R`.** The runtime uses the `tag` field to determine which variant is active. Without the tag, the runtime cannot distinguish between the two sides.
+- [ ] **`Either<L, R>` uses `{ is_left: boolean; left: L; right: R }`, not a bare union or tagged union.** The runtime expects an object with `is_left`, `left`, and `right` fields all present. The `is_left` field determines which side is active. Both `left` and `right` must be present regardless of which variant is active (use a zero/default value for the inactive side).
 
   ```compact
   // Compact
@@ -214,7 +233,7 @@ Check that Compact types are correctly translated to their TypeScript equivalent
   ```
 
   ```typescript
-  // BAD — bare union with no tag
+  // BAD — bare union with no structure
   classify_input: (
     { privateState }: WitnessContext<Ledger, MyState>,
     data: Uint8Array,
@@ -223,15 +242,24 @@ Check that Compact types are correctly translated to their TypeScript equivalent
     return [privateState, isNumeric(data) ? toBigInt(data) : false];
   },
 
-  // GOOD — tagged discriminated union
+  // BAD — tagged union (incorrect structure)
   classify_input: (
     { privateState }: WitnessContext<Ledger, MyState>,
     data: Uint8Array,
   ): [MyState, { tag: "left"; value: bigint } | { tag: "right"; value: boolean }] => {
+    // WRONG — runtime expects is_left/left/right, not tag/value
+    return [privateState, { tag: "left", value: toBigInt(data) }];
+  },
+
+  // GOOD — { is_left, left, right } with all fields present
+  classify_input: (
+    { privateState }: WitnessContext<Ledger, MyState>,
+    data: Uint8Array,
+  ): [MyState, { is_left: boolean; left: bigint; right: boolean }] => {
     if (isNumeric(data)) {
-      return [privateState, { tag: "left", value: toBigInt(data) }];
+      return [privateState, { is_left: true, left: toBigInt(data), right: false }];
     }
-    return [privateState, { tag: "right", value: false }];
+    return [privateState, { is_left: false, left: 0n, right: false }];
   },
   ```
 
@@ -294,7 +322,7 @@ Check that Compact types are correctly translated to their TypeScript equivalent
   },
   ```
 
-- [ ] **Enum values use the correct `bigint` variant index.** Compact enums are represented as zero-based `bigint` indices in TypeScript. Mapping a variant to the wrong index silently produces incorrect behavior because the contract interprets a different variant than intended.
+- [ ] **Enum values use the correct `number` variant index.** Compact enums are represented as zero-based `number` indices in TypeScript. The compiler-generated enum constants are `number` values, not `bigint`. Mapping a variant to the wrong index silently produces incorrect behavior because the contract interprets a different variant than intended.
 
   ```compact
   // Compact
@@ -303,21 +331,21 @@ Check that Compact types are correctly translated to their TypeScript equivalent
   ```
 
   ```typescript
-  // BAD — using string or wrong index
+  // BAD — using string or bigint
   get_decision: (
     { privateState }: WitnessContext<Ledger, MyState>,
-  ): [MyState, bigint] => {
-    return [privateState, 2n]; // This is "rejected", not "approved"
-    // Or worse: return [privateState, "approved" as any]; // string, not bigint
+  ): [MyState, number] => {
+    return [privateState, 2]; // This is "rejected", not "approved"
+    // Or worse: return [privateState, "approved" as any]; // string, not number
   },
 
-  // GOOD — use the compiler-generated constants
+  // GOOD — use the compiler-generated constants (which are number values)
   import { Status } from "./managed/my-contract/index.cjs";
 
   get_decision: (
     { privateState }: WitnessContext<Ledger, MyState>,
-  ): [MyState, bigint] => {
-    return [privateState, BigInt(Status.approved)]; // 1n
+  ): [MyState, number] => {
+    return [privateState, Status.approved]; // 1
   },
   ```
 
@@ -642,13 +670,24 @@ Quick reference of common witness-contract consistency anti-patterns.
 |---|---|---|
 | Missing witness key in TypeScript `witnesses` object | Runtime cannot find the witness function; proof generation fails when any circuit calls it | Every `witness` declaration in Compact must have a matching key in the TypeScript `witnesses` object |
 | camelCase key for snake_case Compact witness name | Witness lookup is case-sensitive; the key is silently not found and proof generation fails | Use the exact name from the Compact declaration, including casing |
-| `number` instead of `bigint` for `Field` or `Uint<N>` | JavaScript `number` loses precision above 2^53; silently produces incorrect proofs for large values | Always use `bigint` for `Field`, `Uint<N>`, and enum variant indices |
+| `number` instead of `bigint` for `Field` or `Uint<N>` | JavaScript `number` loses precision above 2^53; silently produces incorrect proofs for large values | Always use `bigint` for `Field` and `Uint<N>`; use `number` for enum variant indices |
 | `string` or `Buffer` instead of `Uint8Array` for `Bytes<N>` | Runtime expects `Uint8Array`; other types cause proof generation failure or portability issues | Always use `Uint8Array` for `Bytes<N>` |
 | `T \| null` for `Maybe<T>` | Runtime expects `{ is_some: boolean; value: T }` tagged object; null/undefined is not recognized | Return `{ is_some: true, value: x }` or `{ is_some: false, value: defaultValue }` |
-| `L \| R` for `Either<L, R>` | Runtime uses the `tag` field to distinguish variants; a bare union has no tag | Return `{ tag: "left", value: x }` or `{ tag: "right", value: y }` |
+| `L \| R` or `{ tag, value }` for `Either<L, R>` | Runtime expects `{ is_left: boolean; left: L; right: R }` with all fields present; bare unions and tagged unions are not recognized | Return `{ is_left: true, left: x, right: defaultR }` or `{ is_left: false, left: defaultL, right: y }` |
 | Returning only the value (not the `[PS, Value]` tuple) | Runtime expects a two-element tuple with private state first; single value causes destructuring failure | Always return `[privateState, returnValue]` |
 | Mutating `privateState` in place | Shared reference may be used elsewhere by the runtime; in-place mutation causes unpredictable behavior | Spread and override: `{ ...privateState, field: newVal }` |
 | `Math.random()` or `Date.now()` in witness | Non-deterministic; produces different output on re-proof, causing proof generation to fail on retry | Generate once and store in private state; reuse on subsequent calls |
 | Async operations (`await`, `fetch`) in witness | Witnesses are synchronous; async code either fails or blocks indefinitely during proof generation | Precompute async results and store in private state before proof generation |
 | Module-level variable for private state | Breaks when multiple contract instances share the same witness code; stale or wrong instance data | Always read from `context.privateState` |
 | Wrong parameter order after WitnessContext | Circuit passes arguments positionally; swapped parameters mean the witness receives wrong values | Match parameter order to Compact declaration exactly |
+
+## Tool Reference
+
+| Tool | Description |
+|------|-------------|
+| `midnight-compile-contract` | Compile contract with hosted compiler. Reveals witness-related compilation errors. |
+| `midnight-extract-contract-structure` | Deep structural analysis: lists all witness declarations with their exact parameter types, return types, and names. |
+| `midnight-analyze-contract` | Static analysis of contract structure and common patterns. |
+| `midnight-get-latest-syntax` | Authoritative Compact syntax reference including witness declaration rules and type mappings. |
+| `midnight-search-compact` | Semantic search across Compact code for witness implementation patterns. |
+| `midnight-search-docs` | Full-text search across official Midnight documentation for WitnessContext and type mapping details. |


### PR DESCRIPTION
## Summary

- Add shared MCP tool pre-pass to the review-compact orchestrator — runs `midnight-compile-contract`, `midnight-extract-contract-structure`, `midnight-analyze-contract`, and `midnight-get-latest-syntax` once and injects outputs into all 11 reviewer agent prompts
- Update the reviewer agent with MCP tool awareness steps (reference shared evidence, run category-specific tools, cross-reference tool hints)
- Add Required MCP Tools section, inline `> **Tool:**` hints on relevant checklist items, and Tool Reference footer to all 11 review category reference files (privacy, security, token-security, concurrency, compilation, performance, witness-consistency, architecture, code-quality, testing, documentation)
- Performance review gets the only `[category-specific]` tool (`midnight-compile-contract` with `fullCompile=true` for circuit size metrics)

## Design

See `docs/plans/2026-03-02-mcp-review-integration-design.md` for the full design document.

## Test plan

- [ ] Run `/review-compact` against a sample Compact contract and verify shared MCP tool pre-pass executes
- [ ] Verify reviewer agents reference shared evidence in their findings
- [ ] Verify Performance reviewer runs `midnight-compile-contract` with `fullCompile=true`
- [ ] Verify review still completes gracefully if MCP server is unavailable
- [ ] Spot-check inline tool hints appear correctly in 2-3 reference files

Generated with [Claude Code](https://claude.com/claude-code)