### PR TITLE
Resolve 53 fact-check issues across 15 skills

### DIFF
--- a/plugins/compact-core/skills/compact-circuit-costs/SKILL.md
+++ b/plugins/compact-core/skills/compact-circuit-costs/SKILL.md
@@ -138,7 +138,7 @@ Check in order:
 What kind of data?
 ├── Single numeric value → Counter (cheapest)
 ├── Key-value lookups → Map<K, V>
-│   └── Need nested state? → Map<K, Map<...>> (only Map supports nesting)
+│   └── Need nested state? → Map<K, V> where V is any ledger type (Counter, Set<T>, List<T>, MerkleTree, or another Map)
 ├── Membership checks →
 │   ├── Privacy required? → MerkleTree<N, T> (insertions hidden)
 │   └── No privacy needed? → Set<T> (cheaper, simpler)

--- a/plugins/compact-core/skills/compact-compilation/SKILL.md
+++ b/plugins/compact-core/skills/compact-compilation/SKILL.md
@@ -21,7 +21,7 @@ For CLI tool installation, version management, and basic compile command syntax,
 │   ├── <circuit>.zkir           # JSON circuit description (per impure circuit)
 │   └── <circuit>.bzkir          # Binary ZKIR (per impure circuit)
 ├── keys/                        # Cryptographic keys (absent with --skip-zk)
-│   ├── <circuit>.prover         # Prover key (ProvingKeyMaterial)
+│   ├── <circuit>.prover         # Prover key (ProverKey, branded Uint8Array)
 │   └── <circuit>.verifier       # Verifier key (Uint8Array)
 └── compiler/
     └── contract-info.json       # Circuit manifest and metadata
@@ -33,12 +33,12 @@ For a detailed walkthrough of each directory, see `references/compilation-output
 
 | Artifact | Purpose | Generated For |
 |----------|---------|---------------|
-| `contract/index.d.ts` | TypeScript types: `Contract<T>`, `Ledger`, `Witnesses`, `PureCircuits` | All exported circuits |
+| `contract/index.d.ts` | TypeScript types: `Contract<PS, W>`, `Ledger`, `Witnesses`, `PureCircuits`, `ImpureCircuits<T>` | All exported circuits |
 | `contract/index.js` | Runtime implementation with version and type validation | All exported circuits |
 | `contract/index.js.map` | Source map for debugging `.compact` in VS Code | Always |
 | `zkir/<circuit>.zkir` | JSON circuit description consumed by proof server | Exported impure circuits only |
 | `zkir/<circuit>.bzkir` | Binary ZKIR for efficient proof server processing | Exported impure circuits only |
-| `keys/<circuit>.prover` | Prover key for generating ZK proofs | Exported impure circuits only |
+| `keys/<circuit>.prover` | Prover key (ProverKey, branded Uint8Array) for generating ZK proofs | Exported impure circuits only |
 | `keys/<circuit>.verifier` | Verifier key submitted on-chain during deployment | Exported impure circuits only |
 | `compiler/contract-info.json` | Circuit manifest (names, types, pure/impure flags) | Always |
 
@@ -79,10 +79,9 @@ See `examples/PureImpureDemo.compact` for a complete annotated example.
 The compiler reports circuit size metrics during compilation:
 
 ```
-Compiling 2 circuits:
-  circuit "increment" (k=13, rows=4569)
-  circuit "reset" (k=13, rows=4580)
-Overall progress [====================] 2/2
+Compiling 1 circuit:
+  circuit "increment" (k=5, rows=24)
+Overall progress [====================] 1/1
 ```
 
 | Metric | Meaning | Impact |
@@ -100,10 +99,10 @@ For details on metrics, key generation, and the proof server relationship, see `
 |---|---|---|
 | Parse | "expected '[token]' but found '[token]'" | `Void` return type, `::` enum access, `ledger { }` block |
 | Type | "no matching overload" | Wrong argument type, missing cast |
-| Disclosure | "potential witness-value disclosure must be declared" | Missing `disclose()` on witness value |
-| Overflow | Integer literal exceeds field modulus | Value > ~2^255 (BLS12-381) |
+| Disclosure | "potential witness-value disclosure must be declared but is not:" | Missing `disclose()` on witness value |
+| Overflow | Integer literal exceeds field modulus | Value > ~2^254.86 (BLS12-381 scalar field) |
 | Composable | "missing association for circuits" | Missing `contract-info.json` in dependency |
-| Internal | Exit code 255 | Compiler bug — update and report |
+| Internal | Exit code 255 | Subprocess crash (e.g., OOM) — check system resources, update, and report |
 | Runtime | "Version mismatch" (post-compilation) | `compact-runtime` version mismatch |
 
 For detailed error interpretation and debugging strategies, see `references/compiler-errors.md`.

--- a/plugins/compact-core/skills/compact-deployment/SKILL.md
+++ b/plugins/compact-core/skills/compact-deployment/SKILL.md
@@ -41,6 +41,7 @@ compact compile  setNetworkId()   deployContract()   callTx.<name>()
 | | `@midnight-ntwrk/wallet-sdk-shielded` | 1.0.0 |
 | | `@midnight-ntwrk/wallet-sdk-unshielded-wallet` | 1.0.0 |
 | | `@midnight-ntwrk/wallet-sdk-dust-wallet` | 1.0.0 |
+| | `@midnight-ntwrk/wallet-sdk-address-format` | 3.0.0 |
 | **Ledger** | `@midnight-ntwrk/ledger` | ^4.0.0 |
 | **Utilities** | `ws` | ^8.19.0 |
 
@@ -54,7 +55,7 @@ compact compile  setNetworkId()   deployContract()   callTx.<name>()
 | **Proof Server** | `http://localhost:6300` | `http://localhost:6300` | `http://localhost:6300` |
 | **Faucet** | N/A | `https://faucet.preview.midnight.network` | `https://faucet.preprod.midnight.network` |
 
-The proof server always runs locally (to protect private data). The local network uses the `undeployed` network ID with the `dev` node preset. The local ports match the Lace wallet's "Undeployed" network settings — no custom endpoint configuration required.
+The proof server should run locally for DApp development (to protect private data). The local network uses the `undeployed` network ID. The local ports match the Lace wallet's "Undeployed" network settings — no custom endpoint configuration required.
 
 ## Core Deployment Pattern
 
@@ -96,9 +97,9 @@ console.log(`Tx ${txData.public.txId} in block ${txData.public.blockHeight}`);
 | `FoundContract<C>` | `midnight-js-contracts` | Joined contract (same as deployed but found by address) |
 | `CompiledContract` | `compact-js` | Prepared contract with witnesses and ZK assets |
 | `ImpureCircuitId<C>` | `compact-js` | Branded circuit key type for type-safe provider generics |
-| `ContractAddress` | `ledger` | Hex-encoded contract address string |
+| `ContractAddress` | `compact-runtime` | Hex-encoded contract address string |
 | `FinalizedDeployTxData<C>` | `midnight-js-contracts` | Deployment result (contractAddress, txId, blockHeight) |
-| `FinalizedCallTxData` | `midnight-js-contracts` | Circuit call result (txId, blockHeight, status) |
+| `FinalizedCallTxData<C, ICK>` | `midnight-js-contracts` | Circuit call result (txId, blockHeight, status) |
 | `WalletProvider` | `midnight-js-types` | balanceTx, getCoinPublicKey, getEncryptionPublicKey |
 | `MidnightProvider` | `midnight-js-types` | submitTx |
 
@@ -109,7 +110,7 @@ console.log(`Tx ${txData.public.txId} in block ${txData.public.blockHeight}`);
 | Missing `globalThis.WebSocket = WebSocket` in Node.js | Add at top of entry point before any SDK imports |
 | Proof server not running | Start with `docker run -p 6300:6300 midnightntwrk/proof-server:7.0.0 -- midnight-proof-server -v` |
 | Wrong or missing `setNetworkId()` call | Call once at startup before creating providers; must match the network you're connecting to |
-| Wallet not funded (DUST balance zero) | Fund with tNight from faucet, then wait for DUST generation from staked NIGHT |
+| Wallet not funded (DUST balance zero) | Fund with tNight from faucet, register NIGHT UTXOs via `registerForDustGeneration()`, then wait for DUST generation |
 | Using `contract` instead of `compiledContract` in deploy options | Use `compiledContract` (created via `CompiledContract.make().pipe(...)`) |
 
 ## Reference Files

--- a/plugins/compact-core/skills/compact-init-project/references/project-structure.md
+++ b/plugins/compact-core/skills/compact-init-project/references/project-structure.md
@@ -126,7 +126,8 @@ Counter template requires Compact compiler >= 0.28.0 (current: compactc-v0.29.0)
 
 | Service | URL |
 |---------|-----|
-| Indexer | `https://indexer.preprod.midnight.network` |
+| Indexer (GraphQL) | `https://indexer.preprod.midnight.network/api/v3/graphql` |
+| Indexer (WebSocket) | `wss://indexer.preprod.midnight.network/api/v3/graphql/ws` |
 | RPC | `https://rpc.preprod.midnight.network` |
 | Faucet | `https://faucet.preprod.midnight.network/` |
 | Docs | `https://docs.midnight.network` |

--- a/plugins/compact-core/skills/compact-language-ref/SKILL.md
+++ b/plugins/compact-core/skills/compact-language-ref/SKILL.md
@@ -43,7 +43,7 @@ Compact provides three arithmetic operators. Division and modulo do not exist in
 | `-` | Subtract | `Uint<0..m>` | Runtime error if result would be negative |
 | `*` | Multiply | `Uint<0..m*n>` | Result widens; cast back before assignment |
 
-When either operand is `Field`, the result is `Field` and wraps modulo the field prime. Mixing `Field` and `Uint` in one expression is a type error -- cast the `Uint` first: `myUint as Field`. Because arithmetic widens result types, cast before assigning: `balance = (balance + amount) as Uint<64>;`.
+When either operand is `Field`, the result is `Field` and wraps modulo the field prime. Cast `Uint` to `Field` explicitly only if you want to force field arithmetic semantics. Because arithmetic widens result types, cast before assigning: `balance = (balance + amount) as Uint<64>;`.
 
 ### Comparison Operators
 
@@ -84,7 +84,7 @@ Compact uses the `as` keyword for casts. TypeScript-style angle-bracket casts ar
 | `Field` | `Uint<0..n>` | Checked (runtime) | `f as Uint<64>` |
 | `Field` | `Boolean` | Conversion | `f as Boolean` (0 -> false, else true) |
 | `Field` | `Bytes<N>` | Conversion (checked) | `f as Bytes<32>` |
-| `Boolean` | `Uint<0..n>` | Conversion | `flag as Uint<0..1>` (false -> 0, true -> 1) |
+| `Boolean` | `Uint<0..n>` | Conversion | `flag as Uint<0..1>` (false -> 0, true -> 1). Checked when n=0 (fails at runtime if true) |
 | `Boolean` | `Field` | Conversion | `flag as Field` (false -> 0, true -> 1) |
 | `Uint<0..m>` | `Boolean` | Conversion | `myUint as Boolean` (0 -> false, non-zero -> true) |
 | `Bytes<N>` | `Field` | Conversion (checked) | `b as Field` |
@@ -202,11 +202,11 @@ Use these when mixing persistent and transient operations in a single circuit.
 | Function | Signature | Purpose |
 |----------|-----------|---------|
 | `pad` | `pad(length, value): Bytes<N>` | Create fixed-size `Bytes<N>` from a string literal; pads with zero bytes; both args must be literals |
-| `disclose` | `disclose(value: T): T` | Mark a witness-derived value as publicly visible; required for ledger writes, conditionals, and returns |
+| `disclose` | `disclose(value: T): T` | Mark a witness-derived value as publicly visible; required for ledger writes, cross-contract calls, and returns |
 | `assert` | `assert(condition: Boolean, message: string): []` | Abort the transaction if condition is false; the only error-handling mechanism |
 | `default` | `default<T>: T` | Return the default value for any type (false, 0, all-zero bytes, first enum variant, etc.); keyword expression, not a function call |
 
-`disclose` is required whenever a witness-derived value flows to a ledger operation, controls a conditional, or is returned from an exported circuit. Commitments protect their inputs and the commitment result from disclosure. No `disclose()` wrapper is needed, even when storing the commitment in the ledger.
+`disclose` is required whenever a witness-derived value is stored in the public ledger, returned from an exported circuit, or passed to another contract via a cross-contract call. Commitments protect their inputs and the commitment result from disclosure. No `disclose()` wrapper is needed, even when storing the commitment in the ledger.
 
 For full documentation on each function including examples, disclosure rules, and persistent vs. transient guidance, see `references/stdlib-functions.md`.
 

--- a/plugins/compact-core/skills/compact-ledger/SKILL.md
+++ b/plugins/compact-core/skills/compact-ledger/SKILL.md
@@ -24,7 +24,7 @@ sealed ledger secret: Field;                 // Internal, set once in constructo
 | `sealed` | Can only be set during constructor (directly or via helper circuits called by constructor) |
 | `export sealed` | Both: publicly readable and immutable after deployment |
 
-Valid ledger types: any Compact type (`Field`, `Boolean`, `Bytes<N>`, `Uint<N>`, enums, structs), `Counter`, `Map<K, V>`, `Set<T>`, `List<T>`, `MerkleTree<N, T>`, `HistoricMerkleTree<N, T>`, and nested ADTs like `Map<K, Map<K2, V>>`.
+Valid ledger types: any Compact type (`Field`, `Boolean`, `Bytes<N>`, `Uint<N>`, enums, structs), `Counter`, `Map<K, V>`, `Set<T>`, `List<T>`, `MerkleTree<N, T>`, `HistoricMerkleTree<N, T>`, and nested ADTs like `Map<K, Map<K2, V>>`. **Note:** Nested ADTs are only permitted as `Map` values — e.g., `Map<K, Set<T>>` or `Map<K, List<T>>` are valid, but `Set<Map<K,V>>`, `List<Map<K,V>>`, etc. are invalid.
 
 For exhaustive syntax rules and modifier details, see `references/types-and-operations.md`.
 
@@ -68,7 +68,7 @@ export ledger count: Counter;
 witness local_secret_key(): Bytes<32>;
 
 constructor() {
-  owner = disclose(get_public_key(local_secret_key()));
+  owner = disclose(public_key(local_secret_key()));
   phase = Phase.registration;
   // count starts at 0 by default — no initialization needed
 }
@@ -104,9 +104,9 @@ For detailed per-operation visibility analysis, MerkleTree vs Set privacy compar
 
 The `Kernel` type provides access to contract metadata and token operations:
 
-```compact
-ledger kernel: Kernel;
+The `kernel` field is predefined by `import CompactStandardLibrary;` — do not declare it manually. Use it directly:
 
+```compact
 export circuit getSelf(): ContractAddress {
   return kernel.self();
 }

--- a/plugins/compact-core/skills/compact-patterns/SKILL.md
+++ b/plugins/compact-core/skills/compact-patterns/SKILL.md
@@ -20,9 +20,9 @@ A comprehensive catalog of 18 reusable contract design patterns for Midnight Com
 | 7 | Commit-Reveal | Commitment | Intermediate | Hide a value, prove it later | `persistentHash`, salt management |
 | 8 | Sealed-Bid Auction | Commitment | Advanced | Private bidding with fair resolution | Commit-reveal + escrow + time-lock |
 | 9 | Escrow | Value | Intermediate | Hold funds until conditions are met | `receiveShielded`, `sendShielded` |
-| 10 | Treasury / Pot | Value | Intermediate | Manage pooled funds with controlled withdrawal | `QualifiedShieldedCoinInfo`, `mergeCoin` |
+| 10 | Treasury / Pot | Value | Intermediate | Manage pooled funds with controlled withdrawal | `QualifiedShieldedCoinInfo`, `mergeCoinImmediate` |
 | 11 | Multi-Party Auth (Multi-Sig) | Governance | Advanced | Require M-of-N approvals for actions | `Map` approvals, `Counter` threshold |
-| 12 | Voting / Governance | Governance | Advanced | Democratic decision-making with privacy | Commit-reveal + nullifiers + MerkleTree |
+| 12 | Voting / Governance | Governance | Advanced | Democratic decision-making with privacy | Commit-reveal + nullifiers + HistoricMerkleTree |
 | 13 | Registry / Allowlist | Identity | Beginner | Managed membership lists | `Set<Bytes<32>>`, admin gates |
 | 14 | Credential Verification | Identity | Intermediate | Prove properties without revealing data | `persistentCommit`, threshold checks |
 | 15 | Domain-Separated Identity | Identity | Beginner | Multi-purpose keys from single secret | `persistentHash` + domain prefixes |

--- a/plugins/compact-core/skills/compact-privacy-disclosure/SKILL.md
+++ b/plugins/compact-core/skills/compact-privacy-disclosure/SKILL.md
@@ -33,8 +33,7 @@ Privacy is the default in Compact. All witness-derived data is private unless ex
 |---------|---------|-----|
 | Ledger write (direct) | `owner = disclose(pk)` | Value becomes public on-chain |
 | Ledger write (ADT method) | `map.insert(disclose(key), val)` | Arguments to ADT ops are public |
-| Conditional (`if`) | `if (disclose(x == y)) { ... }` | Branch choice reveals information |
-| Conditional (`assert`) | `assert(disclose(x > 0), "msg")` | Assertion result is observable |
+| Conditional (`if`) with ledger writes | `if (disclose(x == y)) { balance = ... }` | Branch choice reveals information when it contains ledger writes |
 | Return from exported circuit | `return disclose(value)` | Return value leaves the ZK proof |
 | Cross-contract call | Calling another contract's circuit | Arguments cross trust boundary |
 | Constructor sealed field | `owner = disclose(pk)` | Sealed values are set publicly |
@@ -57,11 +56,11 @@ Privacy is the default in Compact. All witness-derived data is private unless ex
 | `persistentHash<T>` | `(value: T): Bytes<32>` | **No** | Hash could theoretically be brute-forced |
 | `transientHash<T>` | `(value: T): Field` | **No** | Same reasoning as persistentHash |
 
-Even though commits clear taint on the *input*, the commitment *result* still needs `disclose()` when written to ledger:
+Commits clear taint on the *input*, and `persistentCommit`/`transientCommit` results are implicitly disclosed when written to ledger via commit operations:
 
 ```compact
 const commitment = persistentCommit<Field>(secretValue, randomness);
-storedCommitment = disclose(commitment);  // disclose() for ledger write, not for witness tracking
+storedCommitment = commitment;  // commit results are implicitly disclosed by persistentCommit/transientCommit
 ```
 
 ## Common Disclosure Mistakes

--- a/plugins/compact-core/skills/compact-review/SKILL.md
+++ b/plugins/compact-core/skills/compact-review/SKILL.md
@@ -37,7 +37,7 @@ Apply these severity levels consistently across all categories:
 | **High** | Security vulnerability or privacy leak exploitable under certain conditions | Unnecessary disclose() on sensitive data, missing overflow check on token amounts |
 | **Medium** | Correctness issue, compilation problem, or significant performance concern | Wrong type cast that will fail at runtime, MerkleTree depth 32 when 10 suffices |
 | **Low** | Code quality, style, or minor best practice deviation | Inconsistent naming, unused import, missing sealed modifier |
-| **Suggestion** | Enhancement opportunity, not a problem | Could use pureCircuit for better reuse, consider adding assertion message |
+| **Suggestion** | Enhancement opportunity, not a problem | Could use `pure` circuit modifier for better reuse, consider adding assertion message |
 
 ## Output Format
 

--- a/plugins/compact-core/skills/compact-standard-library/SKILL.md
+++ b/plugins/compact-core/skills/compact-standard-library/SKILL.md
@@ -40,7 +40,7 @@ This is the single authoritative index of everything `import CompactStandardLibr
 | `map.has(key)` | Does not exist | `map.member(key)` |
 | `map.set(key, value)` | Does not exist | `map.insert(key, value)` |
 | `map.delete(key)` | Does not exist | `map.remove(key)` |
-| `CurvePoint` (old name) | Deprecated | `NativePoint` (current name, post-camelCase migration) |
+| `CurvePoint` (old name) | Deprecated | `NativePoint` (current name, renamed from CurvePoint in 0.20.28) |
 
 ## Complete Export Inventory
 
@@ -51,11 +51,11 @@ Every export from `import CompactStandardLibrary;`, organized by category. Use t
 | Name | Kind | Brief Description | Reference Location |
 |------|------|-------------------|--------------------|
 | `Maybe<T>` | type | Optional value container | `references/types-and-constructors.md` |
-| `Either<L, R>` | type | Disjoint union (sum type) | `references/types-and-constructors.md` |
+| `Either<A, B>` | type | Disjoint union (sum type) | `references/types-and-constructors.md` |
 | `NativePoint` | type | Elliptic curve point | `references/types-and-constructors.md` |
 | `MerkleTreeDigest` | type | Merkle root hash wrapper | `references/types-and-constructors.md` |
 | `MerkleTreePathEntry` | type | Sibling + direction in path | `references/types-and-constructors.md` |
-| `MerkleTreePath<N, T>` | type | Path from leaf to root | `references/types-and-constructors.md` |
+| `MerkleTreePath<#n, T>` | type | Path from leaf to root | `references/types-and-constructors.md` |
 | `ContractAddress` | type | Contract address wrapper | `references/types-and-constructors.md` |
 | `ZswapCoinPublicKey` | type | Coin public key for shielded ops | `references/types-and-constructors.md` |
 | `UserAddress` | type | User address wrapper | `references/types-and-constructors.md` |
@@ -91,16 +91,16 @@ Every export from `import CompactStandardLibrary;`, organized by category. Use t
 | `ecMul` | circuit | Scalar multiply NativePoint | `references/cryptographic-functions.md` |
 | `ecMulGenerator` | circuit | Scalar multiply generator | `references/cryptographic-functions.md` |
 | `hashToCurve<T>` | circuit | Map value to NativePoint | `references/cryptographic-functions.md` |
-| `nativePointX` | circuit | Get X coordinate of NativePoint | `references/cryptographic-functions.md` |
-| `nativePointY` | circuit | Get Y coordinate of NativePoint | `references/cryptographic-functions.md` |
-| `constructNativePoint` | circuit | Construct NativePoint from X, Y | `references/cryptographic-functions.md` |
+| `nativePointX` | circuit | Get X coordinate of NativePoint (deprecated: use `jubjubPointX` in v0.30.0+) | `references/cryptographic-functions.md` |
+| `nativePointY` | circuit | Get Y coordinate of NativePoint (deprecated: use `jubjubPointY` in v0.30.0+) | `references/cryptographic-functions.md` |
+| `constructNativePoint` | circuit | Construct NativePoint from X, Y (deprecated: use `constructJubjubPoint` in v0.30.0+) | `references/cryptographic-functions.md` |
 
 ### Merkle Tree Path Circuits
 
 | Name | Kind | Brief Description | Reference Location |
 |------|------|-------------------|--------------------|
-| `merkleTreePathRoot<N, T>` | circuit | Compute root from leaf + path | `references/cryptographic-functions.md` |
-| `merkleTreePathRootNoLeafHash<N>` | circuit | Compute root from pre-hashed leaf | `references/cryptographic-functions.md` |
+| `merkleTreePathRoot<#n, T>` | circuit | Compute root from leaf + path | `references/cryptographic-functions.md` |
+| `merkleTreePathRootNoLeafHash<#n>` | circuit | Compute root from pre-hashed leaf | `references/cryptographic-functions.md` |
 
 ### Utility Builtins
 
@@ -164,11 +164,11 @@ Types provided by the standard library. All are available after `import CompactS
 | Type | Generic Parameters | Fields Summary | Default Value |
 |------|--------------------|----------------|---------------|
 | `Maybe<T>` | `T` -- any type | `is_some: Boolean`, `value: T` | `{ is_some: false, value: default<T> }` |
-| `Either<L, R>` | `L`, `R` -- any types | `is_left: Boolean`, `left: L`, `right: R` | `{ is_left: false, left: default<L>, right: default<R> }` (right variant, based on struct defaults) |
+| `Either<A, B>` | `A`, `B` -- any types | `is_left: Boolean`, `left: A`, `right: B` | `{ is_left: false, left: default<A>, right: default<B> }` (right variant, based on struct defaults) |
 | `NativePoint` | none | `x: Field`, `y: Field` | `{ x: 0, y: 0 }` |
 | `MerkleTreeDigest` | none | `field: Field` | `{ field: 0 }` |
 | `MerkleTreePathEntry` | none | `sibling: MerkleTreeDigest`, `goesLeft: Boolean` | `{ sibling: { field: 0 }, goesLeft: false }` |
-| `MerkleTreePath<N, T>` | `#N` -- depth, `T` -- leaf type | `leaf: T`, `path: Vector<N, MerkleTreePathEntry>` | Default leaf + default path |
+| `MerkleTreePath<#N, T>` | `#N` -- depth, `T` -- leaf type | `leaf: T`, `path: Vector<#N, MerkleTreePathEntry>` | Default leaf + default path |
 | `ContractAddress` | none | `bytes: Bytes<32>` | `{ bytes: 0x00...00 }` |
 | `ZswapCoinPublicKey` | none | `bytes: Bytes<32>` | `{ bytes: 0x00...00 }` |
 | `UserAddress` | none | `bytes: Bytes<32>` | `{ bytes: 0x00...00 }` |
@@ -229,13 +229,13 @@ All EC operations use `NativePoint`, not the deprecated `CurvePoint`.
 | `ecMul` | `(a: NativePoint, b: Field): NativePoint` | Scalar multiplication |
 | `ecMulGenerator` | `(b: Field): NativePoint` | Multiply generator by scalar |
 | `hashToCurve<T>` | `(value: T): NativePoint` | Map arbitrary value to curve point |
-| `nativePointX` | `(p: NativePoint): Field` | Get X coordinate |
-| `nativePointY` | `(p: NativePoint): Field` | Get Y coordinate |
-| `constructNativePoint` | `(x: Field, y: Field): NativePoint` | Construct point from coordinates |
+| `nativePointX` | `(p: NativePoint): Field` | Get X coordinate (deprecated: use `jubjubPointX` in v0.30.0+) |
+| `nativePointY` | `(p: NativePoint): Field` | Get Y coordinate (deprecated: use `jubjubPointY` in v0.30.0+) |
+| `constructNativePoint` | `(x: Field, y: Field): NativePoint` | Construct point from coordinates (deprecated: use `constructJubjubPoint` in v0.30.0+) |
 
 Use cases: Pedersen commitments, key derivation building blocks, custom signature schemes. For example, Pedersen blinding: `ecAdd(ecMulGenerator(rc), ecMul(colorBase, value))`.
 
-> **Verification:** EC functions operate on `NativePoint`, not the deprecated `CurvePoint`. The type was renamed in the camelCase migration. Always verify with `midnight-compile-contract` when using EC operations, as these are newer additions. See `references/cryptographic-functions.md` for full documentation and examples.
+> **Verification:** EC functions operate on `NativePoint`, not the deprecated `CurvePoint`. The type was renamed from CurvePoint in release 0.20.28.0. Always verify with `midnight-compile-contract` when using EC operations, as these are newer additions. See `references/cryptographic-functions.md` for full documentation and examples.
 
 ## Merkle Tree Path Functions
 
@@ -257,7 +257,7 @@ For full documentation with off-chain path generation patterns and HistoricMerkl
 | `assert` | `assert(condition: Boolean, message: string): []` | Abort transaction if false |
 | `default<T>` | `default<T>` | Default value for any type |
 
-`disclose` is required whenever a witness-derived value flows to a ledger operation, controls a conditional, or is returned from an exported circuit. `pad` requires both arguments to be compile-time literals. `assert` is the only error-handling mechanism in Compact.
+`disclose` is required whenever a witness-derived value flows to a ledger operation, is used in a cross-contract call, or is returned from an exported circuit. `pad` requires both arguments to be compile-time literals. `assert` is the only error-handling mechanism in Compact.
 
 For deep documentation on each function including examples and disclosure rules, see `compact-language-ref/references/stdlib-functions.md`.
 
@@ -334,13 +334,13 @@ Unshielded token functions:
 | `map.has(key)` | `map.member(key)` | `.has()` does not exist on Map |
 | `map.set(key, value)` | `map.insert(key, value)` | `.set()` does not exist on Map |
 | `map.delete(key)` | `map.remove(key)` | `.delete()` does not exist on Map |
-| `CurvePoint` | `NativePoint` | `CurvePoint` was renamed in the camelCase migration |
+| `CurvePoint` | `NativePoint` | `CurvePoint` was renamed to `NativePoint` in release 0.20.28.0 (part of broader release with unshielded token support) |
 | `CoinInfo` | `ShieldedCoinInfo` | `CoinInfo` was renamed to `ShieldedCoinInfo` |
 | `SendResult` | `ShieldedSendResult` | `SendResult` was renamed to `ShieldedSendResult` |
 | `persistentHash(value)` (no generic) | `persistentHash<T>(value)` | Generic parameter is required |
 | `some(42)` (no generic) | `some<Field>(42)` | Generic parameter is required for constructor circuits |
 | `circuit fn(): Void` | `circuit fn(): []` | Return type is `[]` (empty tuple), not `Void` |
-| `merkleTreePathRoot(path)` (no generic) | `merkleTreePathRoot<N, T>(path)` | Requires depth and leaf type generics |
+| `merkleTreePathRoot(path)` (no generic) | `merkleTreePathRoot<#n, T>(path)` | Requires depth and leaf type generics |
 
 ## Reference Routing
 

--- a/plugins/compact-core/skills/compact-structure/SKILL.md
+++ b/plugins/compact-core/skills/compact-structure/SKILL.md
@@ -68,8 +68,8 @@ The pragma specifies a minimum version without patch numbers. The standard libra
 | Category | Types |
 |----------|-------|
 | **Primitives** | `Field`, `Boolean`, `Bytes<N>`, `Uint<N>`, `Uint<0..MAX>` |
-| **Collections** | `Vector<N, T>`, `List<T>`, `Maybe<T>`, `Either<L, R>` |
-| **Ledger ADTs** | `Counter`, `Map<K, V>`, `Set<T>`, `MerkleTree<N, T>`, `HistoricMerkleTree<N, T>` |
+| **Collections** | `Vector<N, T>`, `Maybe<T>`, `Either<L, R>` |
+| **Ledger ADTs** | `Counter`, `Map<K, V>`, `Set<T>`, `List<T>`, `MerkleTree<N, T>`, `HistoricMerkleTree<N, T>` |
 | **Opaque** | `Opaque<"string">`, `Opaque<"Uint8Array">` |
 | **Custom** | `enum`, `struct` |
 
@@ -85,7 +85,7 @@ ledger privateField: Field;                 // Not exported, internal only
 export sealed ledger immutable: Bytes<32>;  // Set once in constructor, immutable
 ```
 
-All ledger operations (reads, writes, ADT method calls) are publicly visible on-chain except for `MerkleTree` and `HistoricMerkleTree` insertions, which hide leaf values.
+All ledger operations (reads, writes, ADT method calls) are publicly visible on-chain except for `MerkleTree` and `HistoricMerkleTree` insertions, which store values using cryptographic hashes.
 
 For ADT operations (Counter, Map, Set, List, MerkleTree), consult `references/ledger-declarations.md`.
 
@@ -100,7 +100,7 @@ export pure circuit compute(x: Field): Field { ... }
 ```
 
 - `export` makes the circuit a transaction entry point
-- `pure` means no ledger state access (helper computation only)
+- `pure` means no ledger state access AND no witness calls (computation from inputs only)
 - Non-exported circuits are internal helpers
 
 For circuit rules, witness declarations, constructors, and pure circuits, consult `references/circuits-and-witnesses.md`.

--- a/plugins/compact-core/skills/compact-testing/SKILL.md
+++ b/plugins/compact-core/skills/compact-testing/SKILL.md
@@ -5,7 +5,7 @@ description: This skill should be used when the user asks about testing Compact 
 
 # Compact Contract Testing
 
-Compact contracts compile to JavaScript (`index.cjs`), so you test them using standard JS test runners -- specifically Vitest. There is no official Compact test framework; you import the generated `Contract` class and runtime helpers directly, then assert against ledger state and return values. This skill covers the Simulator pattern for wrapping contract lifecycle, the context creation and reassignment lifecycle, assertion strategies for ledger state and errors, and compilation validation as a test gate. For witness implementation details, see `compact-witness-ts`. For contract anatomy (ledger, circuits, witnesses), see `compact-structure`.
+Compact contracts compile to JavaScript (`index.js`), so you test them using standard JS test runners -- specifically Vitest. There is no official Compact test framework; you import the generated `Contract` class and runtime helpers directly, then assert against ledger state and return values. This skill covers the Simulator pattern for wrapping contract lifecycle, the context creation and reassignment lifecycle, assertion strategies for ledger state and errors, and compilation validation as a test gate. For witness implementation details, see `compact-witness-ts`. For contract anatomy (ledger, circuits, witnesses), see `compact-structure`.
 
 ## Quick Start
 
@@ -20,9 +20,9 @@ setNetworkId("undeployed");
 
 const contract = new Contract({ /* witnesses, if any */ });
 const initialState = { privateCounter: 0 };
-const deployCtx = createConstructorContext(sampleContractAddress(), initialState, "0100");
+const deployCtx = createConstructorContext(initialState, "0100");
 const { currentPrivateState, currentContractState } = contract.initialState(deployCtx);
-let ctx = createCircuitContext(sampleContractAddress(), currentContractState, currentPrivateState, "0200");
+let ctx = createCircuitContext(sampleContractAddress(), "0200", currentContractState, currentPrivateState);
 
 const result = contract.impureCircuits.increment(ctx);
 ctx = result.context;
@@ -41,9 +41,9 @@ class MySimulator {
 
   constructor(initialPrivateState: MyPrivateState) {
     this.contract = new Contract<MyPrivateState>(witnesses);
-    const deployCtx = createConstructorContext(sampleContractAddress(), initialPrivateState, "0100");
+    const deployCtx = createConstructorContext(initialPrivateState, "0100");
     const { currentPrivateState, currentContractState } = this.contract.initialState(deployCtx);
-    this.ctx = createCircuitContext(sampleContractAddress(), currentContractState, currentPrivateState, "0200");
+    this.ctx = createCircuitContext(sampleContractAddress(), "0200", currentContractState, currentPrivateState);
   }
 
   myCircuit(args) {
@@ -68,7 +68,7 @@ See `references/simulator-pattern.md` for the full pattern with multi-user suppo
 | Circuit rejects bad input | `expect(() => ...).toThrow("failed assert: ...")` | Error testing |
 | Private state updates correctly | `ctx.currentPrivateState.field` | Private state assertion |
 | Multi-user interaction | Switch `currentPrivateState` between calls | Multi-actor |
-| Pure computation | `contract.pureCircuits.<name>(args)` | Pure circuit test |
+| Pure computation | `contract.circuits.<name>(args)` | Pure circuit test |
 | Contract compiles | `compact compile` exits 0 | Compilation gate |
 
 ## Key API Reference
@@ -97,7 +97,7 @@ See `references/simulator-pattern.md` for the full pattern with multi-user suppo
 | Not updating context after circuit call | Always reassign: `ctx = result.context` |
 | Using `contract.circuits` for impure ops | Use `contract.impureCircuits` for state-changing circuits |
 | Expecting string equality on `Bytes<N>` | Compare `Uint8Array` with `.toEqual()`, not `===` |
-| Missing `deps.interopDefault: true` in vitest config | Required for CommonJS `index.cjs` imports |
+| Missing `deps.interopDefault: true` in vitest config | Required for CommonJS `index.js` imports |
 | Testing with wrong `compact-runtime` version | Must match the version the compiler expects |
 | Witness key mismatch | Witness object keys must exactly match Compact `witness` names |
 

--- a/plugins/compact-core/skills/compact-tokens/SKILL.md
+++ b/plugins/compact-core/skills/compact-tokens/SKILL.md
@@ -47,14 +47,14 @@ Key functions:
 | `sendImmediateShielded` | `(input: ShieldedCoinInfo, target: Either<ZswapCoinPublicKey, ContractAddress>, value: Uint<128>)` | `ShieldedSendResult` |
 | `mergeCoin` | `(a: QualifiedShieldedCoinInfo, b: QualifiedShieldedCoinInfo)` | `ShieldedCoinInfo` |
 | `mergeCoinImmediate` | `(a: QualifiedShieldedCoinInfo, b: ShieldedCoinInfo)` | `ShieldedCoinInfo` |
-| `evolveNonce` | `(index: Uint<128>, nonce: Bytes<32>)` | `Bytes<32>` |
+| `evolveNonce` | `(index: Uint<64>, nonce: Bytes<32>)` | `Bytes<32>` |
 | `shieldedBurnAddress` | `()` | `Either<ZswapCoinPublicKey, ContractAddress>` |
 | `ownPublicKey` | `()` | `ZswapCoinPublicKey` |
 
 ```compact
 export circuit mint(amount: Uint<64>): ShieldedCoinInfo {
   counter.increment(1);
-  const newNonce = evolveNonce(counter.read() as Uint<128>, nonce);
+  const newNonce = evolveNonce(counter.read() as Uint<64>, nonce);
   nonce = newNonce;
   return mintShieldedToken(
     domain, disclose(amount), nonce,

--- a/plugins/compact-core/skills/compact-transaction-model/SKILL.md
+++ b/plugins/compact-core/skills/compact-transaction-model/SKILL.md
@@ -69,7 +69,6 @@ Operations in the fallible phase may fail without reversing guaranteed-phase eff
 // Assumes ledger declarations:
 //   export ledger balance: Map<Bytes<32>, Uint<64>>;
 //   export ledger transferCount: Counter;
-//   ledger kernel: Kernel;
 //   witness localSecretKey(): Bytes<32>;
 
 export circuit transfer(to: Bytes<32>, amount: Uint<64>): [] {
@@ -151,10 +150,11 @@ Each contract on Midnight maintains state as two components:
 ### State Lifecycle During Execution
 
 1. The contract's current state is loaded from the ledger before each call.
-2. A context object (contract address, newly allocated coins, block time, block hash) and an empty effects set are placed on the Impact VM stack alongside the state. Both context and effects are flagged as **tainted**.
-3. The Impact program executes, mutating the state on the stack. Any non-size-bounded operation on a tainted value propagates the taint to the result.
+2. A context object (contract address, newly allocated coins, block time, block hash, block's 32-bit max timestamp divergence) and an empty effects set are placed on the Impact VM stack alongside the state. Both context and effects are flagged as **weak**.
+   > **Caution:** Currently, only the first two of these are correctly initialized!
+3. The Impact program executes, mutating the state on the stack. The propagation rules for weakness are opcode-specific.
 4. The resulting effects are compared to the declared effects in the transcript; mismatches cause failure.
-5. The resulting state is stored only if it is "strong" (not tainted). If the state has been tainted — for example, by copying context or effects data into it — the call fails.
+5. The resulting state is stored only if it is "strong" (not weak). If the state has been weakened — for example, by copying context or effects data into it — the call fails.
 
 ### Concurrency and Conflicts
 
@@ -164,7 +164,7 @@ Each contract on Midnight maintains state as two components:
 
 ## Fees & Gas
 
-DUST is Midnight's fee token. It is a shielded, non-transferable resource derived from NIGHT.
+DUST is Midnight's shielded network resource used exclusively to pay for transaction fees. It is a non-transferable resource derived from NIGHT.
 
 | Property | Detail |
 |----------|--------|
@@ -202,13 +202,13 @@ The proof for each contract call is generated client-side when the user invokes 
 | Expecting cross-contract calls to work | Use transaction composition (multiple calls in one transaction) instead | Cross-contract calls are not yet available |
 | Not handling partial success in the DApp | Check transaction status in TypeScript client code | A "partial success" means guaranteed worked but fallible failed |
 | Omitting `kernel.checkpoint()` when fallible operations are needed | Add `kernel.checkpoint()` before fallible section | Without it, the entire circuit is guaranteed-only and any failure rejects the whole transaction |
-| Copying context or effects into contract state | Keep context/effects data on-stack only | Context and effects are tainted; any non-size-bounded operation on them propagates taint, and tainted state cannot be stored |
+| Copying context or effects into contract state | Keep context/effects data on-stack only | Context and effects are weak; weakness propagation is opcode-specific, and weak state cannot be stored |
 
 ## Reference Routing
 
 | Topic | Reference File |
 |-------|---------------|
-| Three execution stages, phase semantics, state lifecycle, tainted vs strong values | `references/execution-phases.md` |
+| Three execution stages, phase semantics, state lifecycle, weak vs strong values | `references/execution-phases.md` |
 | Contract state model, concurrency, conflict minimization, append-only patterns | `references/state-and-conflicts.md` |
 | DUST generation, SyntheticCost dimensions, gas-to-fee conversion, dynamic pricing | `references/fees-and-gas.md` |
 | Zswap offers, inputs/outputs, balance vectors, transaction merging, Pedersen binding | `references/zswap-and-offers.md` |

--- a/plugins/compact-core/skills/compact-witness-ts/SKILL.md
+++ b/plugins/compact-core/skills/compact-witness-ts/SKILL.md
@@ -15,20 +15,22 @@ Running `compact compile src/mycontract.compact src/managed/mycontract` produces
 src/managed/mycontract/
 ├── contract/
 │   ├── index.js        # Runtime implementation
+│   ├── index.js.map    # Source map
 │   └── index.d.ts      # Type declarations
 ├── compiler/           # Compiler metadata
 ├── keys/               # ZK proving/verifying keys
-└── zkir/               # ZK intermediate representation
+└── zkir/               # ZK intermediate representation (.bzkir files)
 ```
 
 Key exports from `contract/index.js`:
 
 ```typescript
-import { Ledger, Witnesses, Circuits, Contract, pureCircuits } from "./managed/mycontract/contract/index.js";
+import { Ledger, Witnesses, ImpureCircuits, Circuits, Contract, pureCircuits } from "./managed/mycontract/contract/index.js";
 ```
 
 - **`Ledger`** — TypeScript type matching the contract's ledger declarations
 - **`Witnesses`** — Interface defining required witness implementations
+- **`ImpureCircuits`** — Type describing circuit functions that require witnesses (parameterized by private state `PS`)
 - **`Circuits`** — Type describing available circuit functions
 - **`Contract`** — Class that binds witnesses to circuits
 - **`pureCircuits`** — Module-level const export for local-only pure circuit calls (no proof generated)
@@ -50,9 +52,9 @@ import { Ledger, Witnesses, Circuits, Contract, pureCircuits } from "./managed/m
 | `Maybe<T>` | `{ is_some: boolean; value: T }` | Must export from Compact to use type |
 | `Either<L, R>` | `{ is_left: boolean; left: L; right: R }` | Flat object with discriminator |
 | `Counter` | `bigint` | Via `ledger()` |
-| `Map<K, V>` | Custom accessor object | Via `ledger()`; has `member()`, `size`, `isEmpty`, `Symbol.iterator` |
-| `Set<T>` | Custom accessor object | Via `ledger()`; has `member()`, `size`, `isEmpty`, `Symbol.iterator` |
-| `MerkleTreePath<N, T>` | Nested structure | Array of sibling hashes + directions |
+| `Map<K, V>` | Custom accessor object | Via `ledger()`; has `member()`, `size()`, `isEmpty()`, `Symbol.iterator` |
+| `Set<T>` | Custom accessor object | Via `ledger()`; has `member()`, `size()`, `isEmpty()`, `Symbol.iterator` |
+| `MerkleTreePath<value_type>` | Nested structure | Array of sibling hashes + directions |
 
 For complete type mapping details, runtime validation, and casting rules, see `references/type-mappings.md`.
 
@@ -129,17 +131,20 @@ store_data: (
 The compiler-generated `Contract` class binds witnesses to circuits:
 
 ```typescript
-import { MyContract } from "@midnight-ntwrk/mycontract-contract";
+import { Contract, pureCircuits, ledger } from "./managed/mycontract/contract/index.js";
 
-// Instantiate with witnesses
-const contractInstance = new MyContract.Contract(witnesses);
+// Local testing only — instantiate Contract directly with witnesses
+const contractInstance = new Contract(witnesses);
+
+// Production — use CompiledContract.make() from @midnight-ntwrk/compact-js
+import { CompiledContract } from "@midnight-ntwrk/compact-js";
+const compiledContract = await CompiledContract.make(contractInstance);
 
 // Pure circuits — module-level export, local computation, no proof, no transaction
-import { pureCircuits } from "./managed/mycontract/contract/index.js";
 const hash = pureCircuits.computeHash(inputData);
 
 // Read ledger state from on-chain data
-const ledgerState = MyContract.ledger(contractStateData);
+const ledgerState = ledger(contractStateData);
 const currentValue = ledgerState.myField;
 ```
 


### PR DESCRIPTION
Addresses GitHub issues #29-#43 covering incorrect API signatures, wrong type parameters, fabricated examples, phantom functions, terminology errors, and missing documentation in all compact-core skill files.