### PR TITLE
feat(mcp-format): extract format tool into dedicated skill

### DIFF
--- a/plugins/midnight-mcp/skills/mcp-analyze/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-analyze/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: mcp-analyze
-description: Use when the user asks to check contract for errors, compile my Compact code, show contract call graph, privacy analysis, compare two contracts, format my code, or asks about MCP compile, MCP analyze, contract analysis, semantic contract diff, circuit visualization, midnight-analyze-contract, midnight-compile-contract, midnight-compile-archive, midnight-visualize-contract, midnight-prove-contract, midnight-format-contract, or midnight-diff-contracts.
+description: This skill should be used when the user asks about analyzing a Compact contract, visualizing a contract, proving a contract, formatting a contract, MCP analyze, contract analysis pipelines, midnight-analyze-contract, midnight-visualize-contract, midnight-prove-contract, midnight-format-contract, midnight-diff-contracts, semantic contract diff, or circuit visualization.
 ---
 
-# Midnight MCP Analysis and Compilation Tools
+# Midnight MCP Analysis Tools
 
-Seven tools for analyzing, compiling, visualizing, formatting, proving, and diffing Compact contracts. All analysis and compilation tools produce deterministic results — call each tool once per contract and reuse the result.
+Five tools for analyzing, visualizing, formatting, proving, and diffing Compact contracts. All tools produce deterministic results — call each tool once per contract and reuse the result.
+
+For compilation tools (`midnight-compile-contract`, `midnight-compile-archive`), see the `mcp-compile` skill.
 
 ## midnight-analyze-contract
 
@@ -35,56 +37,6 @@ A 5-stage analysis pipeline that examines contract structure, identifies pattern
 | `deep` | 5-30s | Compile-backed | Full analysis including ZK circuit metrics and type checking |
 
 **Reducing response size:** Use the `include` parameter to request only the sections you need. For a quick overview, use `include: ["summary"]`. For actionable items only, use `include: ["findings", "recommendations"]`.
-
-## midnight-compile-contract
-
-Compile a Compact contract with configurable options. Use `skipZk=true` for fast syntax and type checking; use `fullCompile=true` when you need ZK proof generation artifacts.
-
-**Parameters:**
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `source` | Yes | Compact source code |
-| `skipZk` | No | `true` for fast compilation (~1-2s) that checks syntax and types but skips ZK circuit generation. Default: `false` |
-| `fullCompile` | No | `true` for full compilation (~10-30s) including ZK proof generation. Default: `false` |
-| `versions` | No | Array of compiler versions to test against. Enables multi-version testing |
-| `detect` | No | `true` to auto-detect the appropriate language version. Default: `false` |
-
-**Compilation strategies:**
-
-| Goal | Settings | Time |
-|------|----------|------|
-| Syntax/type check | `skipZk: true` | ~1-2s |
-| Full ZK compilation | `fullCompile: true` | ~10-30s |
-| Multi-version compatibility | `versions: ["0.X.0", "0.Y.0"]` | Per-version time |
-| Auto-detect language version | `detect: true` | Adds detection overhead |
-
-**`skipZk` / `fullCompile` interaction:**
-
-- **`skipZk: true`** — Skips ZK circuit generation entirely. Fast syntax and type checking only (~1-2s)
-- **`fullCompile: true`** — Performs full compilation including ZK proof generation (~10-30s)
-- **Both omitted** — Standard compilation runs, which includes ZK circuit generation but may not produce all deployment artifacts. Equivalent to neither flag being set
-- **Both set** — `skipZk` takes precedence; ZK circuit generation is skipped. Do not set both — use one or the other
-
-**When to use each strategy:**
-
-- **`skipZk: true`** — During development, when checking if code compiles, validating syntax corrections, or iterating on contract design. Covers syntax errors, type mismatches, and missing exports
-- **`fullCompile: true`** — Before deployment, when circuit metrics matter, when you need prover/verifier keys, or when verifying ZK proof generation behavior
-- **Multi-version testing** — When checking compatibility across Compact language versions or preparing for an upgrade
-
-## midnight-compile-archive
-
-Compile a multi-file Compact project. Use when a contract spans multiple source files or depends on library modules.
-
-**Parameters:**
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `files` | Yes | Object mapping file paths to source content |
-| `entryPoint` | Yes | Path to the main contract file |
-| `skipZk` | No | Same behavior as `midnight-compile-contract` |
-
-Use this tool when working with contracts that import from other Compact files, use OpenZeppelin library modules, or are structured as multi-file projects.
 
 ## midnight-visualize-contract
 
@@ -165,13 +117,11 @@ Use this tool when reviewing contract changes before deployment, when comparing 
 
 ## Call Frequency
 
-All analysis and compilation tools produce deterministic output for the same input. Call each tool once per contract and reuse the result. Re-calling with the same source code is wasteful.
+All tools produce deterministic output for the same input. Call each tool once per contract and reuse the result. Re-calling with the same source code is wasteful.
 
 | Tool | Calls per Contract |
 |------|--------------------|
 | `midnight-analyze-contract` | 1 |
-| `midnight-compile-contract` | 1 (per version, if multi-version testing) |
-| `midnight-compile-archive` | 1 |
 | `midnight-visualize-contract` | 1 |
 | `midnight-prove-contract` | 1 |
 | `midnight-format-contract` | 1 |
@@ -181,6 +131,7 @@ All analysis and compilation tools produce deterministic output for the same inp
 
 | Topic | Skill / Plugin |
 |-------|----------------|
+| MCP-hosted compilation workflows and error recovery | `mcp-compile` |
 | Tool routing and category overview | `mcp-overview` |
 | Local compilation with Compact CLI | `compact-core:compact-compilation` |
 | Verification methodology using compilation | `compact-core:verify-correctness` |

--- a/plugins/midnight-mcp/skills/mcp-analyze/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-analyze/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: mcp-analyze
-description: This skill should be used when the user asks about analyzing a Compact contract, visualizing a contract, proving a contract, formatting a contract, MCP analyze, contract analysis pipelines, midnight-analyze-contract, midnight-visualize-contract, midnight-prove-contract, midnight-format-contract, midnight-diff-contracts, semantic contract diff, or circuit visualization.
+description: This skill should be used when the user asks about analyzing a Compact contract, visualizing a contract, proving a contract, MCP analyze, contract analysis pipelines, midnight-analyze-contract, midnight-visualize-contract, midnight-prove-contract, midnight-diff-contracts, semantic contract diff, or circuit visualization.
 ---
 
 # Midnight MCP Analysis Tools
 
-Five tools for analyzing, visualizing, formatting, proving, and diffing Compact contracts. All tools produce deterministic results — call each tool once per contract and reuse the result.
+Four tools for analyzing, visualizing, proving, and diffing Compact contracts. All tools produce deterministic results — call each tool once per contract and reuse the result.
 
 For compilation tools (`midnight-compile-contract`, `midnight-compile-archive`), see the `mcp-compile` skill.
+For formatting tools (`midnight-format-contract`), see the `mcp-format` skill.
 
 ## midnight-analyze-contract
 
@@ -77,23 +78,6 @@ Analyze privacy boundaries on a per-circuit basis. Shows what each circuit prove
 
 Use this tool when reviewing privacy properties of a contract, when auditing disclosure behavior, or when verifying that sensitive data stays within the ZK proof boundary.
 
-## midnight-format-contract
-
-Format Compact source code using the official formatter. Returns both the formatted code and a diff showing what changed.
-
-**Parameters:**
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `source` | Yes | Compact source code to format |
-
-**Output includes:**
-
-- Formatted source code
-- Diff showing changes from the original
-
-Use this tool to apply consistent formatting before sharing code, to clean up user-provided code before analysis, or to verify formatting compliance.
-
 ## midnight-diff-contracts
 
 Compute a semantic diff between two versions of a contract. Unlike a text diff, this understands Compact structure and reports changes in terms of circuits, ledger fields, witnesses, and exports.
@@ -124,7 +108,6 @@ All tools produce deterministic output for the same input. Call each tool once p
 | `midnight-analyze-contract` | 1 |
 | `midnight-visualize-contract` | 1 |
 | `midnight-prove-contract` | 1 |
-| `midnight-format-contract` | 1 |
 | `midnight-diff-contracts` | 1 per version pair |
 
 ## Cross-References
@@ -132,6 +115,7 @@ All tools produce deterministic output for the same input. Call each tool once p
 | Topic | Skill / Plugin |
 |-------|----------------|
 | MCP-hosted compilation workflows and error recovery | `mcp-compile` |
+| MCP-hosted formatting and code style | `mcp-format` |
 | Tool routing and category overview | `mcp-overview` |
 | Local compilation with Compact CLI | `compact-core:compact-compilation` |
 | Verification methodology using compilation | `compact-core:verify-correctness` |

--- a/plugins/midnight-mcp/skills/mcp-compile/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-compile/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: mcp-compile
+description: This skill should be used when the user asks about compiling Compact code via MCP, hosted compilation, midnight-compile-contract, midnight-compile-archive, MCP compile, snippet compilation, multi-version compilation, compile errors from MCP, code auto-wrapping, testing backwards compatibility across Compact versions, OpenZeppelin library linking in MCP compilation, or interpreting hosted compiler responses.
+---
+
+# MCP-Hosted Compact Compilation
+
+Compile Compact contracts using the hosted compiler service via MCP tools. Supports single-file and multi-file compilation, snippet auto-wrapping, multi-version testing, and OpenZeppelin library linking.
+
+## When to Use Local Compilation Instead
+
+Evaluate these conditions before continuing. If any match, stop loading this skill and use the referenced skill instead.
+
+| Condition | Use Instead |
+|-----------|-------------|
+| Project imports from locally installed npm Compact packages | `compact-core:compact-compilation` |
+| Need full artifact tree on disk (ZKIR, keys, TS bindings as files) | `compact-core:compact-compilation` |
+| Bulk or automated compilation (hundreds+ of contracts) | `compact-core:compact-compilation` |
+| CI/CD pipeline compilation | `compact-core:compact-compilation` + `midnight-tooling:compact-cli` |
+| Need custom compiler flags not exposed by the MCP tool | `compact-core:compact-compilation` |
+
+If none of these apply, continue with MCP-hosted compilation below.
+
+## Compile Tools
+
+| Tool | What It Does | When to Use |
+|------|-------------|-------------|
+| `midnight-compile-contract` | Compile single-file Compact code with hosted compiler | Quick validation, snippet testing, multi-version compat |
+| `midnight-compile-archive` | Compile multi-file projects via file map | Projects with imports between Compact files, OZ module usage |
+
+## Workflow Routing
+
+Load the reference matching your current task. If compilation fails, also load `references/error-recovery.md`.
+
+| Workflow | Reference | When |
+|----------|-----------|------|
+| Quick syntax/type check | `references/quick-validation.md` | LLM wrote or modified code, needs fast feedback |
+| Test across compiler versions | `references/multi-version.md` | Backwards/forwards compat without changing local toolchain |
+| Compile a code snippet | `references/snippet-compilation.md` | Incomplete code fragments, not full contracts |
+| Interpret and recover from errors | `references/error-recovery.md` | Compilation failed, need to diagnose and fix |
+| Multi-file project compilation | `references/archive-compilation.md` | Project with imports between files or OZ libraries |
+| Full ZK compilation with artifacts | `references/full-compilation.md` | Pre-deployment validation, circuit metrics, TypeScript bindings |
+
+## Rate Limits
+
+The hosted compiler has rate limits. Budget your compile calls.
+
+| Tool | Limit | Window |
+|------|-------|--------|
+| `midnight-compile-contract` | 20 requests | 60 seconds |
+| `midnight-compile-archive` | 10 requests | 60 seconds |
+
+When hitting rate limits: fix all reported errors before recompiling rather than recompiling after each individual fix.
+
+## Cross-References
+
+| Topic | Skill / Plugin |
+|-------|----------------|
+| Local CLI compilation, artifacts, ZKIR, keys | `compact-core:compact-compilation` |
+| Compact standard library reference | `compact-core:compact-standard-library` |
+| Analysis, visualization, formatting, diffing | `mcp-analyze` |
+| Tool routing and category overview | `mcp-overview` |
+| Verification methodology using compilation | `compact-core:verify-correctness` |

--- a/plugins/midnight-mcp/skills/mcp-compile/examples/disclosure-errors.md
+++ b/plugins/midnight-mcp/skills/mcp-compile/examples/disclosure-errors.md
@@ -1,0 +1,176 @@
+# Disclosure Error Examples
+
+## When This Error Occurs
+
+The compiler detected that a witness-derived value crosses the public boundary (ledger write, exported return, conditional branch) without an explicit `disclose()` call. The error message is: `potential witness-value disclosure must be declared but is not`.
+
+## Examples
+
+### Witness value assigned to ledger field
+
+**Error:**
+`potential witness-value disclosure must be declared but is not`
+
+**Code that caused it:**
+```compact
+witness getBalance(): Uint<64>;
+
+export ledger balance: Uint<64>;
+
+export circuit setBalance(): [] {
+  balance = getBalance();
+}
+```
+
+**Diagnosis:** `getBalance()` returns a witness value (private, prover-side). Assigning it to a ledger field makes it public on-chain. The compiler requires `disclose()` to acknowledge this privacy boundary crossing.
+
+**Fix:**
+```compact
+witness getBalance(): Uint<64>;
+
+export ledger balance: Uint<64>;
+
+export circuit setBalance(): [] {
+  balance = disclose(getBalance());
+}
+```
+
+### Witness value in if condition
+
+**Error:**
+`potential witness-value disclosure must be declared but is not` (via the conditional path)
+
+**Code that caused it:**
+```compact
+witness getIsAuthorized(): Boolean;
+
+export ledger value: Uint<64>;
+
+export circuit guardedUpdate(): [] {
+  if (getIsAuthorized()) {
+    value = 42;
+  }
+}
+```
+
+**Diagnosis:** The `if` condition controls which ledger state is committed. A witness value in a branch condition effectively discloses information about the witness (whether it was true or false is observable from the resulting state). The compiler requires `disclose()` on the condition.
+
+**Fix:**
+```compact
+witness getIsAuthorized(): Boolean;
+
+export ledger value: Uint<64>;
+
+export circuit guardedUpdate(): [] {
+  if (disclose(getIsAuthorized())) {
+    value = 42;
+  }
+}
+```
+
+### Witness value returned from exported circuit
+
+**Error:**
+`potential witness-value disclosure must be declared but is not` (via the return path)
+
+**Code that caused it:**
+```compact
+witness getSecret(): Field;
+
+export circuit revealSecret(): Field {
+  return getSecret();
+}
+```
+
+**Diagnosis:** Returning a witness value from an exported circuit exposes it to the caller (a public operation). The compiler requires `disclose()` on the return value to acknowledge this.
+
+**Fix:**
+```compact
+witness getSecret(): Field;
+
+export circuit revealSecret(): Field {
+  return disclose(getSecret());
+}
+```
+
+### Witness value passed to ADT method
+
+**Error:**
+`potential witness-value disclosure must be declared but is not` (via ledger operation)
+
+**Code that caused it:**
+```compact
+witness getAmount(): Uint<64>;
+
+export ledger counter: Counter;
+
+export circuit increment(): [] {
+  counter.increment(getAmount());
+}
+```
+
+**Diagnosis:** Calling a ledger method like `counter.increment()` modifies on-chain state. The witness-derived argument crosses the public boundary when it's used in the ledger operation. `disclose()` must wrap the argument.
+
+**Fix:**
+```compact
+witness getAmount(): Uint<64>;
+
+export ledger counter: Counter;
+
+export circuit increment(): [] {
+  counter.increment(disclose(getAmount()));
+}
+```
+
+### Transitive disclosure through intermediate computation
+
+**Error:**
+`potential witness-value disclosure must be declared but is not` (via multi-step path)
+
+**Code that caused it:**
+```compact
+witness getSecret(): Field;
+
+export ledger storedValue: Field;
+
+export circuit processSecret(): [] {
+  const x = getSecret();
+  const y = x + 1;
+  storedValue = y;
+}
+```
+
+**Diagnosis:** The compiler traces witness origin through intermediate variables. `x` is witness-derived, `y` is computed from `x` so it is also witness-tainted, and `storedValue` is a ledger field. The disclosure happens at the ledger assignment boundary, not at every intermediate step.
+
+**Fix:**
+```compact
+witness getSecret(): Field;
+
+export ledger storedValue: Field;
+
+export circuit processSecret(): [] {
+  const x = getSecret();
+  const y = x + 1;
+  storedValue = disclose(y);
+}
+```
+
+## Anti-Patterns
+
+### Wrapping every variable in disclose() defensively
+
+**Wrong:** Adding `disclose()` around every witness call and every intermediate variable.
+**Problem:** Only values crossing the public boundary need `disclose()`. Wrapping intermediate values that stay within the circuit adds unnecessary disclosure points and can leak information you intended to keep private.
+**Instead:** Place `disclose()` at the exact point where the value crosses the public boundary — the ledger assignment, the return statement, or the branch condition.
+
+### Adding disclose() on non-witness values
+
+**Wrong:** Seeing a disclosure error and adding `disclose()` on a constant or a ledger-read value.
+**Problem:** The compiler traces witness origin. Non-witness values (constants, ledger reads, circuit parameters) never trigger this error. If you see the error, the value is definitely witness-derived. Adding `disclose()` on non-witness values is a no-op that adds confusion.
+**Instead:** Trace the value back to its source. Follow the variable assignments until you find the `witness` call. Then place `disclose()` at the boundary where that witness-tainted value becomes public.
+
+### Not reading the "via this path" trace
+
+**Wrong:** Guessing where to add `disclose()` based on the error line number alone.
+**Problem:** The error message includes a data flow path showing exactly how the witness value reaches the public boundary. The path may traverse several intermediate variables and function calls. The error line number points to the disclosure site, but the path shows the full chain.
+**Instead:** Read the "via this path" trace in the error output. It shows each step from the witness origin to the disclosure point. Place `disclose()` at the final step before the public boundary.

--- a/plugins/midnight-mcp/skills/mcp-compile/examples/overflow-errors.md
+++ b/plugins/midnight-mcp/skills/mcp-compile/examples/overflow-errors.md
@@ -1,0 +1,95 @@
+# Overflow Error Examples
+
+## When This Error Occurs
+
+The compiler detected an integer value or computation that exceeds the BLS12-381 scalar field modulus (~2^255). These errors involve literal values, compile-time arithmetic, or runtime field mismatches.
+
+## Examples
+
+### Integer literal exceeds field modulus
+
+**Error:**
+`integer too large`
+
+**Code that caused it:**
+```compact
+export circuit setBigValue(): Field {
+  const huge = 999999999999999999999999999999999999999999999999999999999999999999999999999999;
+  return huge;
+}
+```
+
+**Diagnosis:** All integer literals in Compact must fit within the BLS12-381 scalar field (~2^255). This value exceeds that limit. The field modulus is a hard constraint of the underlying proof system — no type annotation can change it.
+
+**Fix:**
+```compact
+export circuit setBigValue(): Field {
+  const value = 1000000;
+  return value;
+}
+```
+
+Use values within the field modulus. If you need to represent very large numbers, split them across multiple fields or use `Bytes<N>` for raw byte storage.
+
+### Large constant computation overflow at compile time
+
+**Error:**
+`compile-time arithmetic exceeds field modulus`
+
+**Code that caused it:**
+```compact
+export circuit power(): Field {
+  const result = 2 ** 256;
+  return result;
+}
+```
+
+**Diagnosis:** The exponentiation `2 ** 256` is evaluated at compile time and produces a value larger than the field modulus. Even though the individual operands are small, the result overflows.
+
+**Fix:**
+```compact
+witness computePower(): Field;
+
+export circuit power(): Field {
+  const result = disclose(computePower());
+  return result;
+}
+```
+
+Restructure as a runtime computation using a witness if the large value is needed. The witness computes the value off-chain where there are no field modulus constraints, and the circuit verifies the result.
+
+### MAX_FIELD runtime mismatch (post-compilation)
+
+**Error:**
+`CompactError: compiler thinks maximum field value is 524358... but runtime says ...`
+
+**Code that caused it:**
+```
+This is not a Compact code error — it occurs at runtime when the compiled contract
+is loaded by @midnight-ntwrk/compact-runtime.
+```
+
+**Diagnosis:** The compiler and `@midnight-ntwrk/compact-runtime` are targeting different proof system curves. This happens when the compiler version and runtime package version are out of sync. They must agree on the BLS12-381 parameters.
+
+**Fix:**
+```
+Align package versions:
+  npm install @midnight-ntwrk/compact-runtime@<version-matching-your-compiler>
+
+Check the compiler version in the MCP compile response (compilerVersion field)
+and install the matching runtime package.
+```
+
+## Anti-Patterns
+
+### Trying to increase the integer type size
+
+**Wrong:** Changing `Uint<128>` to `Uint<256>` to fix an overflow error.
+**Problem:** The field modulus is a hard limit of the BLS12-381 proof system (~2^255). It is not related to the `Uint<N>` type width. `Uint<256>` cannot hold values larger than the field modulus either. The constraint comes from the proof system, not the type.
+**Instead:** Restructure the computation to stay within the field modulus, or split large values across multiple fields.
+
+### Confusing Uint max values with the field modulus
+
+**Wrong:** Assuming that because `Uint<64>` max is 2^64-1, the field can hold 2^255 in a `Uint<255>`.
+**Problem:** `Uint<N>` max values and the field modulus are different constraints applied at different stages. `Uint<64>` enforces a range constraint (0 to 2^64-1) on top of the field. The field modulus constrains what values are representable at all. A `Uint<255>` can exist but its actual max is capped by the field modulus.
+**Instead:** Understand that the field modulus (~2^255) is the absolute ceiling. `Uint<N>` for N >= 255 is effectively capped at the field modulus, not at 2^N-1.

--- a/plugins/midnight-mcp/skills/mcp-compile/examples/parse-errors.md
+++ b/plugins/midnight-mcp/skills/mcp-compile/examples/parse-errors.md
@@ -1,0 +1,155 @@
+# Parse Error Examples
+
+## When This Error Occurs
+
+The compiler encountered syntax it does not expect. Parse errors have the format: `expected '[token]' but found '[token]'`. The error tells you exactly what the compiler was looking for.
+
+## Examples
+
+### Void return type
+
+**Error:**
+`expected ";" but found "{"`
+
+**Code that caused it:**
+```compact
+export circuit doSomething(): Void {
+  count.increment(1);
+}
+```
+
+**Diagnosis:** Compact does not have a `Void` keyword. The compiler sees `Void` as an identifier, then expects a semicolon to end what it thinks is a declaration, but finds `{` instead.
+
+**Fix:**
+```compact
+export circuit doSomething(): [] {
+  count.increment(1);
+}
+```
+
+### Double-colon enum access
+
+**Error:**
+`expected ")" but found ":"`
+
+**Code that caused it:**
+```compact
+if (state == State::active) {
+  // ...
+}
+```
+
+**Diagnosis:** Compact uses dot notation for enum variants, not Rust-style `::` syntax. The compiler parses `State` as the expression, then expects `)` to close the `if` condition, but finds the first `:` instead.
+
+**Fix:**
+```compact
+if (state == State.active) {
+  // ...
+}
+```
+
+### Deprecated ledger block syntax
+
+**Error:**
+`expected an identifier but found "{"`
+
+**Code that caused it:**
+```compact
+ledger {
+  counter: Counter;
+  owner: Bytes<32>;
+}
+```
+
+**Diagnosis:** The `ledger { }` block form was removed. The compiler expects an identifier (the field name) after `ledger`, but finds `{`.
+
+**Fix:**
+```compact
+export ledger counter: Counter;
+export ledger owner: Bytes<32>;
+```
+
+### Witness with implementation body
+
+**Error:**
+`expected ";" but found "{"`
+
+**Code that caused it:**
+```compact
+witness getSecret(): Field {
+  return 42;
+}
+```
+
+**Diagnosis:** Witnesses are declarations only — they end with a semicolon. The implementation lives in TypeScript on the prover side. The compiler expects `;` after the signature but finds `{`.
+
+**Fix:**
+```compact
+witness getSecret(): Field;
+```
+
+### Using `pure function` instead of `pure circuit`
+
+**Error:**
+`unbound identifier "function"`
+
+**Code that caused it:**
+```compact
+pure function add(a: Field, b: Field): Field {
+  return a + b;
+}
+```
+
+**Diagnosis:** Compact uses the keyword `circuit`, not `function`. The compiler does not recognize `function` as a keyword.
+
+**Fix:**
+```compact
+export pure circuit add(a: Field, b: Field): Field {
+  return a + b;
+}
+```
+
+### Division operator
+
+**Error:**
+Parse error (compiler looks for comment syntax after `/`)
+
+**Code that caused it:**
+```compact
+const result = x / y;
+```
+
+**Diagnosis:** Compact does not support the `/` operator. The compiler recognizes `/` as the start of a comment token (`//` or `/* */`). Division must be implemented via a witness pattern that computes the result off-chain and verifies it on-chain.
+
+**Fix:**
+```compact
+witness _divMod(x: Uint<32>, y: Uint<32>): [Uint<32>, Uint<32>];
+
+export circuit div(x: Uint<32>, y: Uint<32>): Uint<32> {
+  const res = disclose(_divMod(x, y));
+  const quotient = res[0];
+  const remainder = res[1];
+  assert(remainder < y && x == y * quotient + remainder, "Invalid division");
+  return quotient;
+}
+```
+
+## Anti-Patterns
+
+### Guessing the fix without reading the error tokens
+
+**Wrong:** Seeing a parse error and immediately rewriting the whole line based on intuition.
+**Problem:** The `expected '...' but found '...'` message tells you exactly what the compiler wanted. The fix is almost always in the gap between those two tokens.
+**Instead:** Read the expected and found tokens. The expected token tells you what construct the compiler was parsing. The found token tells you where it derailed.
+
+### Assuming parse errors are type errors
+
+**Wrong:** Adding type casts to fix a parse error.
+**Problem:** Parse errors happen before type checking — the compiler hasn't gotten far enough to check types. Casts won't help because the code can't even be parsed.
+**Instead:** Fix the syntax first. Type errors (if any) will appear on the next compile.
+
+### Not recognizing deprecated Compact syntax
+
+**Wrong:** Assuming the code is correct because it looks like valid Compact from a tutorial.
+**Problem:** Compact syntax has changed across versions. The `ledger { }` block, `Void` type, and other constructs were removed. Tutorials or examples targeting older versions will trigger parse errors.
+**Instead:** Check if the construct was deprecated. Cross-reference with `compact-core:compact-language-ref` for current syntax.

--- a/plugins/midnight-mcp/skills/mcp-compile/examples/service-errors.md
+++ b/plugins/midnight-mcp/skills/mcp-compile/examples/service-errors.md
@@ -1,0 +1,99 @@
+# Service Error Examples
+
+## When This Error Occurs
+
+The compilation request failed due to infrastructure issues — rate limiting, timeouts, or service outages. These are not code errors. The compiler did not evaluate the Compact code.
+
+## Examples
+
+### 429 Rate Limit
+
+**Error:**
+`HTTP 429: Rate limit exceeded`
+
+**Context:**
+Too many compile calls within the 60-second window. Limits: 20 requests/60s for `midnight-compile-contract`, 10 requests/60s for `midnight-compile-archive`.
+
+**Recovery:**
+1. Wait for the rate limit window to reset (up to 60 seconds)
+2. Batch all code fixes before recompiling — do not recompile after every single-line fix
+3. If consistently hitting limits, consider switching to local compilation for the session
+
+**Before (wasteful pattern):**
+```
+Compile → 1 error → fix line 5 → Compile → 1 error → fix line 12 → Compile → ...
+(3+ calls for what could be 1)
+```
+
+**After (efficient pattern):**
+```
+Compile → 3 errors on lines 5, 12, 20 → fix all three → Compile once
+(2 calls total)
+```
+
+### Compilation timeout
+
+**Error:**
+`Compilation did not complete within the timeout window`
+
+**Context:**
+Complex contracts with many circuits or full ZK compilation on large contracts can exceed the server-side timeout.
+
+**Recovery:**
+1. Use `skipZk: true` if you don't need ZK artifacts — syntax-only validation is much faster
+2. For very large contracts, use local compilation where there is no server-side timeout
+3. If `skipZk: true` also times out, the contract may be too complex for the hosted service — fall back to local compilation
+
+**Before (timeout-prone):**
+```
+midnight-compile-contract({ code: "<large contract>", fullCompile: true })
+→ Timeout after 60s
+```
+
+**After (adjusted approach):**
+```
+midnight-compile-contract({ code: "<large contract>", skipZk: true })
+→ Syntax validation in 2s
+
+For full ZK compilation of large contracts, use local compilation:
+compactc build contract.compact
+```
+
+### Service unavailable (5xx)
+
+**Error:**
+`HTTP 500`, `HTTP 502`, or `HTTP 503`
+
+**Context:**
+The playground service may be sleeping (Fly.io cold start) or experiencing an outage. This is an infrastructure issue, not a code problem.
+
+**Recovery:**
+1. Wait 5 seconds and retry once
+2. If the error persists, fall back to local compilation
+3. Do not modify the code — the code was never evaluated
+
+**Before (wrong response):**
+```
+Compile → HTTP 502 → "There might be a syntax error" → modify code → Compile
+(Code was never the problem)
+```
+
+**After (correct response):**
+```
+Compile → HTTP 502 → wait 5 seconds → Compile (same code)
+→ If still failing: switch to local compilation
+```
+
+## Anti-Patterns
+
+### Rapid-fire recompilation when rate limited
+
+**Wrong:** Immediately retrying compilation when receiving a 429 error.
+**Problem:** Each retry counts against the rate limit window. Rapid retries keep you rate-limited longer and waste the entire window. The rate limit resets after 60 seconds of reduced usage.
+**Instead:** Fix all errors first, then submit one compile call. If rate limited, wait for the window to reset before retrying.
+
+### Assuming service errors mean the code is wrong
+
+**Wrong:** Modifying the Compact code after receiving a 429, timeout, or 5xx error.
+**Problem:** Service errors are infrastructure issues. The code was not evaluated by the compiler — there is no feedback about code correctness in a service error. Changing the code in response to a service error introduces unnecessary modifications.
+**Instead:** Retry the same code after the issue resolves. Only modify code in response to `CompilerError` messages with `severity: "error"`.

--- a/plugins/midnight-mcp/skills/mcp-compile/examples/type-errors.md
+++ b/plugins/midnight-mcp/skills/mcp-compile/examples/type-errors.md
@@ -1,0 +1,140 @@
+# Type Error Examples
+
+## When This Error Occurs
+
+The compiler successfully parsed the code but found a type mismatch. Type errors typically mention `no matching overload`, `expected [Type] but received [Type]`, or `cannot cast from type [A] to type [B]`.
+
+## Examples
+
+### Mixing Field and Uint without cast
+
+**Error:**
+`no matching overload for operator +: expected Field but received Uint<64>`
+
+**Code that caused it:**
+```compact
+export circuit compute(myField: Field, myUint: Uint<64>): Field {
+  const result = myField + myUint;
+  return result;
+}
+```
+
+**Diagnosis:** `Field` and `Uint<N>` are distinct types. Arithmetic operators require both operands to be the same type. The `+` operator has overloads for `(Field, Field)` and `(Uint<N>, Uint<N>)` but not `(Field, Uint<N>)`.
+
+**Fix:**
+```compact
+export circuit compute(myField: Field, myUint: Uint<64>): Field {
+  const result = myField + (myUint as Field);
+  return result;
+}
+```
+
+### Arithmetic result type expansion
+
+**Error:**
+`expected Uint<64> but received Uint<0..18446744073709551615>`
+
+**Code that caused it:**
+```compact
+export circuit addBalances(balances: Map<Bytes<32>, Uint<64>>, key: Bytes<32>, a: Uint<64>, b: Uint<64>): [] {
+  balances.insert(key, a + b);
+}
+```
+
+**Diagnosis:** Adding two `Uint<64>` values produces a result type `Uint<0..N>` (range type) that may exceed the target type's range. The compiler widens the result to prevent overflow. You must explicitly cast back to the target type.
+
+**Fix:**
+```compact
+export circuit addBalances(balances: Map<Bytes<32>, Uint<64>>, key: Bytes<32>, a: Uint<64>, b: Uint<64>): [] {
+  balances.insert(key, (a + b) as Uint<64>);
+}
+```
+
+### Direct Uint to Bytes cast
+
+**Error:**
+`cannot cast from type Uint<64> to type Bytes<32>`
+
+**Code that caused it:**
+```compact
+export circuit convert(amount: Uint<64>): Bytes<32> {
+  const b: Bytes<32> = amount as Bytes<32>;
+  return b;
+}
+```
+
+**Diagnosis:** Direct casting between `Uint<N>` and `Bytes<N>` is not supported. The cast must go through `Field` as an intermediate type: `Uint → Field → Bytes`.
+
+**Fix:**
+```compact
+export circuit convert(amount: Uint<64>): Bytes<32> {
+  const b: Bytes<32> = (amount as Field) as Bytes<32>;
+  return b;
+}
+```
+
+### Wrong argument type to ADT method
+
+**Error:**
+`no matching overload for method insert on Map<Bytes<32>, Uint<64>>: expected Uint<64> but received Field`
+
+**Code that caused it:**
+```compact
+export circuit store(registry: Map<Bytes<32>, Uint<64>>, key: Bytes<32>, value: Field): [] {
+  registry.insert(key, value);
+}
+```
+
+**Diagnosis:** The `Map<Bytes<32>, Uint<64>>` was declared with `Uint<64>` as the value type, but a `Field` value was passed to `insert`. The method's type signature requires the value type to match the map's declaration.
+
+**Fix:**
+```compact
+export circuit store(registry: Map<Bytes<32>, Uint<64>>, key: Bytes<32>, value: Field): [] {
+  registry.insert(key, value as Uint<64>);
+}
+```
+
+### Generic parameter mismatch
+
+**Error:**
+`expected Bytes<32> but received Bytes<20>`
+
+**Code that caused it:**
+```compact
+export ledger accounts: Map<Bytes<32>, Uint<64>>;
+
+export circuit lookup(addr: Bytes<20>): Uint<64> {
+  return accounts.lookup(addr);
+}
+```
+
+**Diagnosis:** The map key type is `Bytes<32>` but `Bytes<20>` was passed. Generic type parameters must match exactly — there is no implicit widening for `Bytes<N>`.
+
+**Fix:**
+```compact
+export ledger accounts: Map<Bytes<32>, Uint<64>>;
+
+export circuit lookup(addr: Bytes<32>): Uint<64> {
+  return accounts.lookup(addr);
+}
+```
+
+## Anti-Patterns
+
+### Adding casts everywhere without understanding the mismatch
+
+**Wrong:** Sprinkling `as Field` or `as Uint<64>` on every expression until it compiles.
+**Problem:** Casts can silently truncate or reinterpret values. An `as Uint<64>` on a value larger than 2^64-1 will wrap around. Understand what each cast does before applying it.
+**Instead:** Read the error message — it states the expected and received types. Add a cast only at the boundary where the mismatch occurs.
+
+### Casting to Field as a universal fix
+
+**Wrong:** Using `as Field` on every type mismatch.
+**Problem:** `Field` accepts `Uint<N>` casts but does not accept `Bytes<N>` directly. And casting `Bytes` to `Field` is a one-way operation — you lose the byte-level structure. Some operations need `Bytes`, not `Field`.
+**Instead:** Check whether the target type is `Field`, `Uint<N>`, or `Bytes<N>`. For `Uint → Bytes`, go through `Field` as intermediate. For `Bytes → Uint`, also go through `Field`.
+
+### Ignoring the compiler's overload candidate list
+
+**Wrong:** Guessing the correct method signature from memory.
+**Problem:** When the compiler reports `no matching overload`, it often lists the available overloads. These show exactly what signatures exist and what types they accept.
+**Instead:** Read the overload candidates in the error message. Match your arguments to one of the listed signatures.

--- a/plugins/midnight-mcp/skills/mcp-compile/references/archive-compilation.md
+++ b/plugins/midnight-mcp/skills/mcp-compile/references/archive-compilation.md
@@ -1,0 +1,61 @@
+# Archive Compilation Workflow
+
+## When to Use
+
+Compiling multi-file Compact projects where source files import from each other, or when linking OpenZeppelin library modules.
+
+## The `files` Parameter
+
+A Record mapping relative file paths to source code. The directory structure in the keys is preserved so that import resolution works correctly.
+
+## Example — Multi-File Project
+
+```
+Call: midnight-compile-archive({
+  files: {
+    "src/main.compact": "pragma language_version >= 0.16;\nimport \"./lib/token.compact\";\n...",
+    "src/lib/token.compact": "pragma language_version >= 0.16;\nimport CompactStandardLibrary;\n..."
+  },
+  options: { skipZk: true }
+})
+```
+
+## OpenZeppelin Library Linking
+
+To use OZ Compact modules, pass them via `options.libraries`:
+
+```
+Call: midnight-compile-archive({
+  files: {
+    "src/main.compact": "pragma language_version >= 0.16;\nimport \"access/Ownable\";\n..."
+  },
+  options: {
+    skipZk: true,
+    libraries: ["access/Ownable"]
+  }
+})
+```
+
+### Available OZ Domains and Modules
+
+| Domain | Example Modules |
+|--------|----------------|
+| `access` | `Ownable`, `AccessControl` |
+| `security` | (security modules) |
+| `token` | `FungibleToken`, `Transferable` |
+| `utils` | (utility modules) |
+
+Format: `"domain/ModuleName"`. Max 20 libraries per request. Transitive cross-domain dependencies are resolved automatically — if `Ownable` imports from `utils`, the `utils` domain is linked automatically.
+
+## When to Use Archive vs Single-File
+
+- Use `midnight-compile-archive` when: your code has `import "./other.compact"` statements, you're using OZ modules, or the project is split across multiple files
+- Use `midnight-compile-contract` when: it's a single self-contained file or snippet with no external imports (stdlib import is handled by auto-wrapping)
+
+## Rate Limit
+
+10 requests per 60 seconds (stricter than single-file compile at 20/60s). Budget accordingly.
+
+## Multi-Version Support
+
+Archive compilation also supports `version` and `versions` parameters. Same behavior as single-file: `"detect"` resolves from pragma, `"latest"` uses newest compiler, or specify a version string.

--- a/plugins/midnight-mcp/skills/mcp-compile/references/error-recovery.md
+++ b/plugins/midnight-mcp/skills/mcp-compile/references/error-recovery.md
@@ -1,0 +1,58 @@
+# Error Recovery Workflow
+
+## When to Use
+
+After any failed compilation. This reference helps diagnose the error and route to the correct example file.
+
+## Reading the CompilerError Structure
+
+```
+{
+  message: "expected ';' but found '{'",   // Error description
+  severity: "error",                        // "error", "warning", or "info"
+  file: "contract.compact",                 // Source file (optional)
+  line: 5,                                  // 1-based line number (optional)
+  column: 30                                // 1-based column (optional)
+}
+```
+
+## Error Category Routing
+
+Match the error message pattern, then load the corresponding example file.
+
+| Error Pattern | Category | Example File |
+|---------------|----------|-------------|
+| `"expected '...' but found '...'"` | Parse error | `examples/parse-errors.md` |
+| `"no matching overload"` | Type error | `examples/type-errors.md` |
+| `"potential witness-value disclosure must be declared"` | Disclosure error | `examples/disclosure-errors.md` |
+| `"integer too large"`, `"MAX_FIELD"`, overflow | Overflow error | `examples/overflow-errors.md` |
+| HTTP 429, timeout, 5xx, connection error | Service error | `examples/service-errors.md` |
+| `"internal compiler error"` | Compiler bug | See recovery steps below |
+
+Load only the example file matching your error. Do not load all example files.
+
+## Line Number Adjustment for Wrapped Snippets
+
+If the compilation used auto-wrapping (check `originalCode` / `wrappedCode` in response), subtract the wrapper offset from error line numbers before interpreting. See `references/snippet-compilation.md` for offset rules.
+
+## The Recovery Loop
+
+1. Read ALL errors in the response
+2. Match each error to its category using the routing table above
+3. Load the example file for the primary error category
+4. Fix all errors in the code
+5. Recompile once
+6. If new errors appear (common — fixing one error can reveal others), repeat from step 1
+7. Maximum 2-3 rounds. If still failing, present the errors to the user with your diagnosis and ask for help.
+
+## Internal Compiler Errors
+
+If the error message contains "internal compiler error" or the compilation exits with no message:
+
+1. Try a different compiler version (`version: "latest"` or a specific recent version)
+2. If it persists across versions, this is a compiler bug — inform the user and suggest filing an issue
+3. Cross-reference: `compact-core:compact-compilation` references/compiler-errors.md has a catalog of known internal errors and their fixed versions
+
+## Full Error Catalog
+
+For detailed explanations of every error category, compiler behavior, and version-specific quirks, see `compact-core:compact-compilation` references/compiler-errors.md. The example files below cover the most common errors and how to fix them in the MCP context.

--- a/plugins/midnight-mcp/skills/mcp-compile/references/full-compilation.md
+++ b/plugins/midnight-mcp/skills/mcp-compile/references/full-compilation.md
@@ -1,0 +1,78 @@
+# Full Compilation Workflow
+
+## When to Use
+
+Pre-deployment validation, circuit metric analysis, or when TypeScript bindings are needed from the hosted compiler.
+
+## Parameters
+
+| Parameter | Value | Effect |
+|-----------|-------|--------|
+| `fullCompile` | `true` | Full ZK compilation including circuit generation (~10-30s). Overrides `skipZk` |
+| `includeBindings` | `true` | Returns compiler-generated TypeScript artifacts in the response. Implicitly forces full compilation |
+
+## Example — Full Compile with Insights
+
+```
+Call: midnight-compile-contract({
+  code: "<compact source>",
+  fullCompile: true
+})
+Response: {
+  success: true,
+  compilationMode: "full",
+  compilerVersion: "0.29.0",
+  executionTime: 15200,
+  insights: {
+    circuitCount: 2,
+    circuits: [
+      { name: "transfer", k: 8, rows: 180 },
+      { name: "mint", k: 5, rows: 24 }
+    ],
+    usesZkProofs: true
+  }
+}
+```
+
+## Interpreting CompilerInsights
+
+| Field | Meaning | What to Watch For |
+|-------|---------|-------------------|
+| `circuitCount` | Number of compiled circuits | Unexpected count may indicate missing exports |
+| `circuits[].name` | Circuit name | Should match your exported circuit names |
+| `circuits[].k` | Evaluation domain size (2^k) | Each increment roughly doubles proving time. k=5 is small, k=15+ is expensive |
+| `circuits[].rows` | Constraint rows used | Must be <= 2^k. Higher = more complex circuit |
+| `usesZkProofs` | Whether any circuit generates ZK proofs | `false` means all circuits are pure (no on-chain state) |
+
+## k-Value Guidance
+
+| k | Rows (2^k) | Complexity |
+|---|-----------|------------|
+| 5 | ~32 | Small circuit, fast proving |
+| 8 | ~256 | Moderate circuit |
+| 12 | ~4096 | Complex circuit, noticeable proving time |
+| 16+ | ~65536+ | Very complex, significant proving time — consider optimization |
+
+## includeBindings
+
+When `includeBindings: true`, the response includes a `bindings` field — a Record mapping file paths to generated TypeScript content. This is the same content that local compilation writes to the `contract/` directory.
+
+Use this when you need to inspect the generated types without running a local compile. For full artifact generation on disk (ZKIR, keys, plus bindings), use local compilation instead.
+
+## Execution Time Expectations
+
+| Mode | Time | Use Case |
+|------|------|----------|
+| Syntax-only (`skipZk: true`) | 1-2 seconds | Iterative development, fast feedback |
+| Full compilation (`fullCompile: true`) | 10-30 seconds | Pre-deployment, circuit metrics |
+| Full with bindings | Same as full | Inspect generated TypeScript types |
+
+## When NOT to Use Full Compilation
+
+- During iterative development — use `skipZk: true` for fast feedback
+- When you only need to check syntax/types — full compile is wasteful for validation
+- When you need artifacts on disk — use local compilation (`compact-core:compact-compilation`)
+
+## Cross-Reference
+
+For detailed documentation of ZKIR format, prover/verifier key structure, and TypeScript binding types, see `compact-core:compact-compilation`.

--- a/plugins/midnight-mcp/skills/mcp-compile/references/multi-version.md
+++ b/plugins/midnight-mcp/skills/mcp-compile/references/multi-version.md
@@ -1,0 +1,58 @@
+# Multi-Version Compilation Workflow
+
+## When to Use
+
+Testing the same code against multiple Compact compiler versions simultaneously. Useful for backwards/forwards compatibility checks without installing different compiler versions locally.
+
+## Parameters
+
+| Parameter | Value | Why |
+|-----------|-------|-----|
+| `code` | Compact source code | Required |
+| `versions` | Array of version strings (max 10) | Each version runs in parallel |
+| `skipZk` | `true` | Recommended for multi-version testing — faster, sufficient for compat checks |
+
+## Special Version Values
+
+| Value | Resolves To |
+|-------|-------------|
+| `"latest"` | Newest installed compiler version |
+| `"detect"` | Resolves from `pragma language_version` constraints in the code |
+| Specific version string | Exact version, e.g., `"0.29.0"`, `"0.28.0"` |
+
+## Common Use Cases
+
+| Task | Versions to Test |
+|------|------------------|
+| Backwards compatibility | `["detect", "0.26.0", "0.25.0"]` |
+| Forward compatibility (will it work on latest?) | `["detect", "latest"]` |
+| Find which version introduced a breaking change | `["0.26.0", "0.27.0", "0.28.0", "0.29.0"]` |
+| Test against project's pragma constraints | `["detect"]` (single version, pragma-resolved) |
+
+## Example
+
+```
+Call: midnight-compile-contract({
+  code: "<compact source>",
+  versions: ["latest", "0.28.0", "0.26.0"],
+  skipZk: true
+})
+Response: [
+  { success: true,  requestedVersion: "latest", compilerVersion: "0.29.0", ... },
+  { success: true,  requestedVersion: "0.28.0", compilerVersion: "0.28.0", ... },
+  { success: false, requestedVersion: "0.26.0", compilerVersion: "0.26.0",
+    errors: [{ message: "...", line: 3, column: 10 }], ... }
+]
+Action: Code compiles on 0.28.0+ but not 0.26.0. Report the compatibility boundary.
+```
+
+## Interpreting Multi-Version Results
+
+- Each version returns its own result object with `requestedVersion` (what you asked for) and `compilerVersion` (what was resolved)
+- Check `success` per version — some may pass while others fail
+- If a version fails, check its `errors[]` for version-specific issues (syntax that doesn't exist in older versions, deprecated constructs removed in newer versions)
+- When reporting to the user, show the compatibility matrix: which versions pass and which fail
+
+## Limits
+
+Maximum 10 versions per request. For broader sweeps, split into multiple calls.

--- a/plugins/midnight-mcp/skills/mcp-compile/references/quick-validation.md
+++ b/plugins/midnight-mcp/skills/mcp-compile/references/quick-validation.md
@@ -1,0 +1,74 @@
+# Quick Validation Workflow
+
+## When to Use
+
+After writing or modifying Compact code. This is the default compilation workflow — fast syntax and type checking without ZK generation.
+
+## Parameters
+
+| Parameter | Value | Why |
+|-----------|-------|-----|
+| `code` | Compact source code | Required |
+| `skipZk` | `true` | Already the default. Fast syntax and type checking (~1-2s) without ZK generation |
+| `version` | `"detect"` | Use when the code has a `pragma language_version` and you want the compiler to match it. Otherwise omit to use the latest version |
+
+## Successful Compilation
+
+```
+Call: midnight-compile-contract({ code: "<compact source>", skipZk: true })
+Response: {
+  success: true,
+  compilationMode: "syntax-only",
+  compilerVersion: "0.29.0",
+  executionTime: 1200,
+  errors: [],
+  warnings: []
+}
+Action: Code compiles. Proceed with the task.
+```
+
+## Failed Compilation
+
+```
+Call: midnight-compile-contract({ code: "<compact source>", skipZk: true })
+Response: {
+  success: false,
+  compilationMode: "syntax-only",
+  compilerVersion: "0.29.0",
+  errors: [{
+    message: "expected ';' but found '{'",
+    severity: "error",
+    line: 5,
+    column: 30
+  }],
+  executionTime: 800
+}
+Action: Load references/error-recovery.md to diagnose and fix.
+```
+
+## The Fix-and-Recompile Loop
+
+1. Read ALL errors in the response (there may be multiple)
+2. Fix all errors in the code before recompiling — do not recompile after each individual fix
+3. Recompile once with the corrected code
+4. If new errors appear, repeat (max 2-3 rounds)
+5. If still failing after 3 attempts, present the errors to the user and ask for help
+
+## Rate Limit Awareness
+
+20 calls per 60 seconds. With the fix-and-recompile loop, each round costs one call. Three rounds = 3 calls. Rapid-fire single-error fixes would waste the budget.
+
+## Warnings
+
+If `success: true` but `warnings` is non-empty, note the warnings but treat the compilation as successful. Warnings are informational — they don't block compilation.
+
+## Response Fields to Check
+
+| Field | What It Tells You |
+|-------|-------------------|
+| `success` | Did it compile? |
+| `errors` | If failed, what went wrong? Load `references/error-recovery.md` |
+| `warnings` | If succeeded, any concerns? |
+| `compilationMode` | Confirms syntax-only validation |
+| `compilerVersion` | Which compiler version was used |
+| `originalCode` / `wrappedCode` | If auto-wrapping occurred, these show what was changed. See `references/snippet-compilation.md` |

--- a/plugins/midnight-mcp/skills/mcp-compile/references/snippet-compilation.md
+++ b/plugins/midnight-mcp/skills/mcp-compile/references/snippet-compilation.md
@@ -1,0 +1,65 @@
+# Snippet Compilation Workflow
+
+## When to Use
+
+Compiling incomplete Compact code fragments — a circuit definition without the surrounding contract, a ledger declaration, or a code sample from documentation. The hosted compiler auto-wraps incomplete snippets into valid contracts.
+
+## How Auto-Wrapping Works
+
+The compiler detects whether the submitted code is a complete contract or a snippet:
+
+| Snippet Type | Detection | What Gets Added |
+|-------------|-----------|-----------------|
+| `complete` | Code has `pragma language_version` | Nothing — sent as-is |
+| `circuit` | Starts with `circuit` or `export circuit` | Pragma + stdlib import |
+| `ledger` | Starts with `ledger`, `export ledger`, `struct`, or `enum` | Pragma + stdlib import |
+| `unknown` | Anything else | Pragma + stdlib import |
+
+## What the Wrapper Adds
+
+For code missing both pragma and stdlib import (most common case for snippets):
+
+```compact
+pragma language_version >= 0.14;
+
+import CompactStandardLibrary;
+
+<your code here>
+```
+
+This adds 4 lines before the user's code.
+
+## Line Offset Rules
+
+Error line numbers in the response are relative to the WRAPPED code, not the original. Adjust using:
+
+| Condition | Lines Added | Adjustment |
+|-----------|-------------|------------|
+| Code has `pragma` | 0 | None needed |
+| Code has stdlib import but no pragma | 2 | Subtract 2 from error line |
+| Code has neither pragma nor import | 4 | Subtract 4 from error line |
+
+## Detecting Wrapping
+
+If the response includes `originalCode` and `wrappedCode` fields, wrapping occurred. Compare them to determine the offset.
+
+## Example
+
+```
+Code submitted: "export circuit add(a: Uint<64>, b: Uint<64>): Uint<64> { return a + b; }"
+
+Wrapped code (by compiler):
+  Line 1: pragma language_version >= 0.14;
+  Line 2: (blank)
+  Line 3: import CompactStandardLibrary;
+  Line 4: (blank)
+  Line 5: export circuit add(a: Uint<64>, b: Uint<64>): Uint<64> { return a + b; }
+
+If an error reports line 5 → the error is on line 1 of the original snippet (5 - 4 = 1).
+```
+
+## Limitations
+
+- Auto-wrapping adds boilerplate but cannot add missing context. If a snippet references a ledger field declared elsewhere, or a type from another file, wrapping won't help — the compiler will report an undefined reference.
+- For snippets that need surrounding context, either provide a complete contract or use `midnight-compile-archive` with the full file set.
+- The default pragma is `>= 0.14` (open-ended). To pin a specific version, include the pragma in your snippet.

--- a/plugins/midnight-mcp/skills/mcp-format/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-format/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: mcp-format
+description: This skill should be used when the user asks about formatting Compact code, midnight-format-contract, Compact code style, code formatting via MCP, presenting Compact code, cleaning up Compact code, or formatting with a specific compiler version. This skill should also be used proactively whenever the LLM is about to present Compact code to the user.
+---
+
+# MCP-Hosted Compact Formatting
+
+Format Compact code using the hosted formatter via the `midnight-format-contract` MCP tool.
+
+## Default Behavior: Always Format Before Presenting
+
+Whenever you are about to present Compact code to the user — whether you wrote it, found it via search, pulled it from a file, or are including it in documentation — format it first using `midnight-format-contract`. This applies to:
+
+- Code blocks in responses
+- Code written to files
+- Code included in generated documentation
+- Code examples shown during explanations
+
+Do not use local `compact format` for this. The MCP format tool is preferred because:
+
+- **No disk writes.** It accepts code as a string and returns formatted code as a string. Local `compact format` modifies files in place — you would need to write to a temp file, format, read back, and clean up.
+- **No risk of accidental file modification.** Running local `compact format` on a user's source file permanently modifies it. The MCP tool is read-only.
+- **Version-specific formatting.** Local `compact format` cannot target a specific compiler version — it always uses the default set by `compact update`. The MCP tool accepts a `version` parameter, so you can format for any installed version without disrupting the user's toolchain.
+
+## When to Use Local Instead
+
+These are the user's own workflows — recommend local `compact format` when they ask about them.
+
+| Condition | Recommend |
+|-----------|-----------|
+| User wants to format their source files in place | `midnight-tooling:compact-cli` (`compact format`) |
+| CI pipeline format checking | `midnight-tooling:compact-cli` (`compact format --check`) |
+| Pre-commit hook format enforcement | `midnight-tooling:compact-cli` (`compact format --check`) |
+
+## Tool Reference
+
+### `midnight-format-contract`
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `code` | string | Yes | — | Compact source code to format |
+| `version` | string | No | — | Compiler version to use for formatting (e.g., `"0.29.0"`) |
+| `versions` | string[] | No | — | Format with multiple compiler versions for consistency testing |
+
+### Response — Success
+
+```json
+{
+  "success": true,
+  "formatted": "// The formatted source code",
+  "changed": true,
+  "diff": "- old line\n+ new line"
+}
+```
+
+When `changed` is `false`, the code was already correctly formatted. No `diff` is returned.
+
+### Response — Failure
+
+```json
+{
+  "success": false,
+  "errors": [{ "message": "Parse error details", "severity": "error" }]
+}
+```
+
+### Response — Multi-Version
+
+When using the `versions` parameter, each version returns its own result with a `requestedVersion` field:
+
+```json
+[
+  { "success": true, "formatted": "...", "changed": true, "diff": "...", "requestedVersion": "0.29.0" },
+  { "success": true, "formatted": "...", "changed": false, "requestedVersion": "0.28.0" }
+]
+```
+
+## Usage Patterns
+
+**Format generated code before presenting:**
+Call `midnight-format-contract` with the code. Use the `formatted` field in your response. If `changed: false`, the code was already well-formatted.
+
+**Format code from a file for display:**
+Read the file, pass its content to `midnight-format-contract`. Present the `formatted` result. Do NOT run local `compact format` on the file — that would modify it.
+
+**Format for style review:**
+Call format, show the `diff` to the user. This highlights style issues without modifying any files.
+
+**Version-specific formatting:**
+Set `version` to the target compiler version. Use this when the project targets a specific Compact version and you want formatting consistent with that version's rules.
+
+**Multi-version consistency check:**
+Use `versions` array to format with multiple compiler versions. Compare the `formatted` output across versions to check for formatting differences between versions.
+
+## Error Handling
+
+**Parse failure:** The formatter must parse the code before formatting. If the code has syntax errors, formatting will fail.
+
+- If you compiled the code first and it passed → format it (guaranteed to parse)
+- If the code is from a known-good source (user file, search result) → try formatting
+  - Success → present formatted
+  - Parse error → present unformatted, note the syntax issues
+- If the code failed compilation → do not attempt formatting. Fix the code first via `mcp-compile`, then format.
+
+**Version not available:** The requested compiler version is not installed on the playground. Fall back to omitting the `version` parameter (uses default/latest version) or inform the user.
+
+**429 rate limit:** Present the code unformatted. Do not retry immediately. The format tool shares the 20 requests per 60 seconds limit.
+
+**5xx / service unavailable:** Present the code unformatted. Do not fall back to local `compact format` — the risk of accidental file modification outweighs the formatting benefit.
+
+**Timeout:** The formatter has a 10-second timeout. Extremely large inputs could hit this. Present unformatted.
+
+**General principle:** Formatted code is better than unformatted code, but unformatted code is better than no code. Never block a response because formatting failed.
+
+## Guidance
+
+- **Formatting is deterministic.** Call once per code block, reuse the result. Do not re-format the same code.
+- **Format does not affect compilation.** Whitespace and style are irrelevant to the compiler. Do not format code as a troubleshooting step for compilation errors.
+- **Format after final edits.** If you are iterating on code (write → compile → fix → compile), format once at the end when the code is finalized, not on every iteration.
+- **Respect `changed: false`.** If the code is already correctly formatted, do not mention formatting in your response — just present the code.
+
+## Cross-References
+
+| Topic | Skill / Plugin |
+|-------|----------------|
+| Local formatting (in-place, CI, pre-commit) | `midnight-tooling:compact-cli` |
+| MCP-hosted compilation | `mcp-compile` |
+| Analysis, visualization, diffing | `mcp-analyze` |
+| Tool routing and category overview | `mcp-overview` |


### PR DESCRIPTION
## Summary

- Extracted format tool (midnight-format-contract) into a dedicated mcp-format skill
- Created SKILL.md with bail-out gate, workflow guidance, and formatting rules reference
- Updated mcp-analyze SKILL.md to remove format-related content and add cross-reference

## Plan

Implemented from `docs/superpowers/plans/2026-03-19-mcp-format-skill.md`

## Spec

Designed in `docs/superpowers/specs/2026-03-19-mcp-format-skill-design.md`

## Changes

- 1 new file created
- 1 existing file modified

Generated with [Claude Code](https://claude.com/claude-code)