### PR TITLE
feat(mcp-search): add search technique library with references and examples

### DIFF
--- a/plugins/midnight-mcp/commands/search.md
+++ b/plugins/midnight-mcp/commands/search.md
@@ -1,6 +1,6 @@
 ---
 description: Search Midnight code, documentation, and SDK patterns with technique-aware query optimization, preset modes, and interactive guided search
-allowed-tools: AskUserQuestion, Read, Glob, Grep, mcp__midnight__midnight-search-compact, mcp__midnight__midnight-search-typescript, mcp__midnight__midnight-search-docs, mcp__midnight__midnight-fetch-docs, mcp__midnight__midnight-list-examples, mcp__midnight__midnight-suggest-tool
+allowed-tools: AskUserQuestion, Read, Glob, Grep, mcp__midnight__midnight-search-compact, mcp__midnight__midnight-search-typescript, mcp__midnight__midnight-search-docs, mcp__midnight__midnight-fetch-docs, mcp__midnight__midnight-list-examples
 argument-hint: "[<query>] [--compact | --typescript | --docs | --all] [--quick | --thorough | --debug | --examples | --migration] [--trusted-only] [--rewrite] [--multi-query] [--step-back] [--hyde] [--decompose] [--rerank] [--dedupe] [--iterative] [--version-aware] [--env]"
 ---
 

--- a/plugins/midnight-mcp/commands/search.md
+++ b/plugins/midnight-mcp/commands/search.md
@@ -1,0 +1,133 @@
+---
+description: Search Midnight code, documentation, and SDK patterns with technique-aware query optimization, preset modes, and interactive guided search
+allowed-tools: AskUserQuestion, Read, Glob, Grep, mcp__midnight__midnight-search-compact, mcp__midnight__midnight-search-typescript, mcp__midnight__midnight-search-docs, mcp__midnight__midnight-fetch-docs, mcp__midnight__midnight-list-examples, mcp__midnight__midnight-suggest-tool
+argument-hint: "[<query>] [--compact | --typescript | --docs | --all] [--quick | --thorough | --debug | --examples | --migration] [--trusted-only] [--rewrite] [--multi-query] [--step-back] [--hyde] [--decompose] [--rerank] [--dedupe] [--iterative] [--version-aware] [--env]"
+---
+
+Search Midnight content using the MCP search tools with technique-aware query optimization.
+
+## Step 1: Parse Arguments and Flags
+
+Parse `$ARGUMENTS` into:
+- **Query**: everything that is not a flag
+- **Source flags**: `--compact`, `--typescript`, `--docs`, `--all`
+- **Preset flag**: `--quick`, `--thorough`, `--debug`, `--examples`, `--migration`
+- **Modifier flags**: `--trusted-only`
+- **Technique flags**: `--rewrite`, `--multi-query`, `--step-back`, `--hyde`, `--decompose`, `--rerank`, `--dedupe`, `--iterative`, `--version-aware`, `--env`
+
+If no arguments at all → go to **Step 2: Interactive Mode**.
+If query present but no preset → apply `--quick` as default preset.
+If preset present → resolve preset to its technique set (see preset table below).
+If technique flags present alongside a preset → merge (preset techniques + individual techniques).
+
+### Preset Technique Mapping
+
+| Preset | Techniques |
+|--------|-----------|
+| `--quick` | intent-classification, source-routing |
+| `--thorough` | multi-query, step-back, cross-tool-orchestration, relevance-reranking, coverage-balancing, deduplication |
+| `--debug` | error-to-doc, symbol-aware-search, environmental-grounding |
+| `--examples` | example-mining, query-rewriting, trusted-source-filtering |
+| `--migration` | version-aware-search, diff-aware-search, environmental-grounding, freshness-reranking |
+
+## Step 2: Interactive Mode
+
+If no arguments were provided, start a guided search session:
+
+1. Ask: "What are you looking for? (code example, documentation, API reference, debugging help, or something else?)"
+2. Based on the answer, ask follow-up questions:
+   - For code: "Which language — Compact or TypeScript?" and "Can you describe the pattern or feature?"
+   - For documentation: "What topic? And do you need a tutorial/guide or a reference page?"
+   - For debugging: "What's the error message or unexpected behavior?"
+   - For migration: "What version are you migrating from and to?"
+3. Ask: "How thorough should the search be? Quick lookup, or comprehensive research?"
+4. Construct the query, source flags, and preset from the answers.
+5. Continue to **Step 3**.
+
+Use `AskUserQuestion` for each question. One question per message.
+
+## Step 3: Load Technique References
+
+Based on the active techniques (from preset + individual flags), read the relevant reference and example files from the `mcp-search` skill directory.
+
+Use the Read tool to load each needed reference. For each technique you will apply, also load its example file for guidance.
+
+Reference file mapping:
+- Query rewriting, multi-query, step-back, HyDE, decomposition → `skills/mcp-search/references/query-expansion.md`
+- Environmental grounding, conversation grounding, entity extraction, facet extraction → `skills/mcp-search/references/context-gathering.md`
+- Intent classification, source routing, trusted-source filtering, parameter optimization, cross-tool orchestration → `skills/mcp-search/references/tool-routing.md`
+- Relevance reranking, trust-aware reranking, freshness reranking, deduplication, coverage balancing, answerability scoring → `skills/mcp-search/references/result-refinement.md`
+- Retrieve-read-retrieve, query refinement, confidence assessment, contradiction detection → `skills/mcp-search/references/iterative-search.md`
+- Symbol-aware search, error-to-doc, example mining, version-aware search, diff-aware search → `skills/mcp-search/references/code-search.md`
+
+## Step 4: Pre-Search Processing
+
+Apply the active pre-search techniques to the query:
+
+1. **Environmental grounding** (if `--env` or preset includes it): read `package.json` and `*.compact` files to discover version context.
+2. **Entity extraction**: detect and normalize Midnight-specific entities in the query.
+3. **Facet extraction**: identify implicit filters for tool selection and parameter configuration.
+4. **Query rewriting** (if active): transform the query into keyword-rich form.
+5. **Multi-query generation** (if active): produce 2-3 variant queries.
+6. **Step-back queries** (if active): generate abstract version.
+7. **HyDE** (if active): generate pseudo-answer, extract key terms.
+8. **Decomposition** (if active): split into sub-queries.
+
+## Step 5: Tool Selection and Configuration
+
+1. **Intent classification**: classify the search intent.
+2. **Source routing**: select tool(s) based on intent, entities, facets, and source flags.
+   - If source flags were provided, use those tools.
+   - If no source flags, auto-route based on intent classification.
+3. **Trusted-source filtering** (if `--trusted-only`):
+   - For `midnight-search-compact`: set `filter.repository` to restrict to trusted orgs.
+   - For `midnight-search-typescript`: note for client-side trust-aware reranking.
+4. **Parameter optimization**: set `limit`, `category`, `includeExamples`, `includeTypes` per tool.
+
+## Step 6: Execute Search
+
+Call the selected MCP search tool(s) with the constructed queries and parameters.
+
+If multi-query is active, call the tool once per query variant. Combine all result sets.
+
+If cross-tool orchestration is active, call multiple tools as determined in Step 5.
+
+## Step 7: Post-Search Processing
+
+Apply the active post-search techniques to the result set:
+
+1. **Relevance reranking** (if active or always as baseline): re-evaluate results against the original intent.
+2. **Trust-aware reranking** (if `--trusted-only` or active): boost trusted sources.
+3. **Freshness reranking** (if active): boost recent content.
+4. **Deduplication** (if active): collapse near-identical results.
+5. **Coverage balancing** (if active): check facet coverage, note gaps.
+6. **Answerability scoring**: rank by how directly results answer the question.
+
+## Step 8: Iterative Refinement (if active)
+
+If `--iterative` is active or if confidence is low:
+
+1. Assess result confidence.
+2. If gaps exist, formulate targeted follow-up queries.
+3. Execute follow-up search (max 1 additional round).
+4. Merge new results with existing results.
+5. Re-apply post-search processing.
+
+## Step 9: Present Results
+
+Present the final result set to the user:
+
+1. Group results by relevance/source if multiple tools were used.
+2. For each result, show: source repository, relevance assessment, and the content.
+3. Note any gaps in coverage.
+4. Note any contradictions detected between results.
+5. If confidence is low, note the uncertainty and suggest verification approaches.
+
+## Step 10: No-Results Fallback
+
+If no relevant results were found:
+
+1. Suggest alternative query formulations.
+2. Suggest trying a different tool or preset.
+3. Suggest checking `midnight-list-examples` for curated examples.
+4. Note that the information may not be in the search index — suggest checking source code directly.

--- a/plugins/midnight-mcp/skills/mcp-search/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-search/SKILL.md
@@ -8,6 +8,8 @@ description: This skill should be used when the user asks about searching Midnig
 
 Search techniques and tool guidance for the four Midnight MCP search tools. This skill provides a technique library organized as cluster references with per-technique example files. Load only what you need for the current task.
 
+**Not this skill:** If the user asks what MCP tools are available, how tools are categorized, or for a general overview of Midnight tooling, use `mcp-overview` instead. This skill is for *executing* searches, not describing the tools.
+
 ## Search Tools
 
 | Tool | Corpus | Use When |
@@ -23,15 +25,15 @@ Identify your current search task, then load the listed reference files. If mult
 
 | Intent / Task | Reference Files |
 |---------------|----------------|
-| Quick lookup of a specific thing | `references/tool-routing.md` |
-| Find code examples for a pattern | `references/query-expansion.md` + `references/tool-routing.md` + `references/code-search.md` |
-| Find conceptual documentation | `references/query-expansion.md` + `references/tool-routing.md` |
-| Debug an error using search | `references/code-search.md` + `references/tool-routing.md` |
-| Comprehensive research on a topic | `references/query-expansion.md` + `references/context-gathering.md` + `references/tool-routing.md` + `references/result-refinement.md` |
-| Search with project context | `references/context-gathering.md` + `references/tool-routing.md` |
-| Migration / version upgrade search | `references/context-gathering.md` + `references/code-search.md` + `references/tool-routing.md` |
-| Refine poor initial results | `references/iterative-search.md` + `references/result-refinement.md` |
-| Understand server-side limitations | `references/server-enhanced.md` |
+| Quick lookup of a specific thing | `references/tool-routing.md` (5 techniques) |
+| Find code examples for a pattern | `references/query-expansion.md` (5) + `references/tool-routing.md` (5) + `references/code-search.md` (5) |
+| Find conceptual documentation | `references/query-expansion.md` (5) + `references/tool-routing.md` (5) |
+| Debug an error using search | `references/code-search.md` (5) + `references/tool-routing.md` (5) |
+| Comprehensive research on a topic | `references/query-expansion.md` (5) + `references/context-gathering.md` (4) + `references/tool-routing.md` (5) + `references/result-refinement.md` (6) |
+| Search with project context | `references/context-gathering.md` (4) + `references/tool-routing.md` (5) |
+| Migration / version upgrade search | `references/context-gathering.md` (4) + `references/code-search.md` (5) + `references/tool-routing.md` (5) |
+| Refine poor initial results | `references/iterative-search.md` (4) + `references/result-refinement.md` (6) |
+| Understand server-side limitations | `references/server-enhanced.md` (7) |
 
 ## Loading Example Files
 

--- a/plugins/midnight-mcp/skills/mcp-search/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-search/SKILL.md
@@ -51,59 +51,7 @@ Results from other sources may be valid but require independent verification bef
 
 ## `/midnight-mcp:search` Command
 
-Users can invoke `/midnight-mcp:search` to run searches with explicit technique control.
-
-### Modes
-
-| Mode | Invocation | Behavior |
-|------|-----------|----------|
-| Interactive | `/midnight-mcp:search` | Guided Q&A — asks what the user needs, constructs and executes the search |
-| Quick | `/midnight-mcp:search <query>` | Auto-routed with `--quick` defaults |
-| Explicit | `/midnight-mcp:search <query> --thorough --compact` | User-specified flags |
-
-### Source Flags
-
-| Flag | MCP Tool(s) |
-|------|-------------|
-| `--compact` | `midnight-search-compact` |
-| `--typescript` | `midnight-search-typescript` |
-| `--docs` | `midnight-search-docs` |
-| `--all` | All three search tools |
-
-Source flags are combinable. If none specified, auto-routes based on query.
-
-### Modifier Flags
-
-| Flag | Effect |
-|------|--------|
-| `--trusted-only` | Restricts Compact searches to trusted repos via `filter.repository`. For TypeScript searches (no server-side filter), applies client-side trust-aware reranking. No effect on docs. |
-
-### Presets
-
-| Preset | Activates | Use Case |
-|--------|-----------|----------|
-| `--quick` | Intent classification, source routing, single query | Fast lookup |
-| `--thorough` | Multi-query, step-back, cross-tool orchestration, reranking, coverage balancing, dedup | Comprehensive research |
-| `--debug` | Error-to-doc rewriting, symbol-aware search, environmental grounding | Debugging from an error |
-| `--examples` | Example mining, query rewriting, trusted-source filtering | Finding runnable code |
-| `--migration` | Version-aware, diff-aware, environmental grounding, freshness reranking | Upgrading versions |
-
-### Individual Technique Flags
-
-| Flag | Technique |
-|------|-----------|
-| `--rewrite` | Query rewriting |
-| `--multi-query` | Multi-query generation |
-| `--step-back` | Step-back queries |
-| `--hyde` | HyDE pseudo-answer generation |
-| `--decompose` | Decomposition |
-| `--rerank` | Relevance reranking |
-| `--dedupe` | Deduplication |
-| `--iterative` | Retrieve-read-retrieve |
-| `--version-aware` | Version-aware search |
-| `--env` | Environmental grounding |
-
-Preset + individual flags: preset techniques plus additional individual techniques. No flags with query: `--quick`. No flags, no query: interactive mode.
+Users can invoke `/midnight-mcp:search` for technique-aware search with preset modes (`--quick`, `--thorough`, `--debug`, `--examples`, `--migration`), source flags, and individual technique flags. See the command file for full flag reference and execution steps.
 
 ## Cross-References
 

--- a/plugins/midnight-mcp/skills/mcp-search/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-search/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mcp-search
-description: This skill should be used when the user asks about midnight search, searching Compact code, searching TypeScript SDK code, searching Midnight documentation, fetching docs, MCP search tools, semantic search over Midnight repos, midnight-search-compact, midnight-search-typescript, midnight-search-docs, midnight-fetch-docs, optimizing search queries for the Midnight MCP server, search techniques, query rewriting, multi-query search, search reranking, or improving search result quality.
+version: 1.0.0
+description: This skill should be used when the user asks about searching Midnight code, searching Compact examples, searching TypeScript SDK code, finding Midnight documentation, fetching docs pages, using MCP search tools (midnight-search-compact, midnight-search-typescript, midnight-search-docs, midnight-fetch-docs), the /midnight-mcp:search command, optimizing search queries, search techniques like query rewriting or multi-query generation, improving search result quality, or reranking search results.
 ---
 
 # Midnight MCP Search

--- a/plugins/midnight-mcp/skills/mcp-search/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-search/SKILL.md
@@ -1,141 +1,40 @@
 ---
 name: mcp-search
-description: Use when the user asks to find Compact examples, look up SDK types, search Midnight codebase, evaluate search result reliability, or asks about midnight search, searching Compact code, searching TypeScript SDK code, searching Midnight documentation, fetching docs, MCP search tools, semantic search over Midnight repos, optimizing search queries, midnight-search-compact, midnight-search-typescript, midnight-search-docs, or midnight-fetch-docs.
+description: This skill should be used when the user asks about midnight search, searching Compact code, searching TypeScript SDK code, searching Midnight documentation, fetching docs, MCP search tools, semantic search over Midnight repos, midnight-search-compact, midnight-search-typescript, midnight-search-docs, midnight-fetch-docs, optimizing search queries for the Midnight MCP server, search techniques, query rewriting, multi-query search, search reranking, or improving search result quality.
 ---
 
-# Midnight MCP Search Tools
+# Midnight MCP Search
 
-Four search tools provide access to Compact code, TypeScript SDK code, indexed documentation, and live documentation pages. Each tool targets a different corpus and has different reliability characteristics.
+Search techniques and tool guidance for the four Midnight MCP search tools. This skill provides a technique library organized as cluster references with per-technique example files. Load only what you need for the current task.
 
-## midnight-search-compact
+## Search Tools
 
-Semantic search across Compact code and patterns from Midnight Foundation, partners, and ecosystem projects.
+| Tool | Corpus | Use When |
+|------|--------|----------|
+| `midnight-search-compact` | Compact code from Foundation, partners, ecosystem | Finding code patterns, examples, stdlib usage |
+| `midnight-search-typescript` | TypeScript SDK code and types | Finding SDK API usage, type definitions, DApp integration |
+| `midnight-search-docs` | Official documentation index | Finding conceptual explanations, guides, architecture |
+| `midnight-fetch-docs` | Live docs.midnight.network pages | Fetching a specific known page, getting full content |
 
-**When to use:** Finding Compact code patterns, usage examples, standard library usage, contract structure patterns, or verifying that a Compact construct exists in real code.
+## Intent-to-Reference Routing
 
-**Parameters:**
+Identify your current search task, then load the listed reference files. If multiple rows match, combine the reference lists (deduplicate).
 
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `query` | Yes | Search query — specific terms produce better results than vague descriptions |
+| Intent / Task | Reference Files |
+|---------------|----------------|
+| Quick lookup of a specific thing | `references/tool-routing.md` |
+| Find code examples for a pattern | `references/query-expansion.md` + `references/tool-routing.md` + `references/code-search.md` |
+| Find conceptual documentation | `references/query-expansion.md` + `references/tool-routing.md` |
+| Debug an error using search | `references/code-search.md` + `references/tool-routing.md` |
+| Comprehensive research on a topic | `references/query-expansion.md` + `references/context-gathering.md` + `references/tool-routing.md` + `references/result-refinement.md` |
+| Search with project context | `references/context-gathering.md` + `references/tool-routing.md` |
+| Migration / version upgrade search | `references/context-gathering.md` + `references/code-search.md` + `references/tool-routing.md` |
+| Refine poor initial results | `references/iterative-search.md` + `references/result-refinement.md` |
+| Understand server-side limitations | `references/server-enhanced.md` |
 
-**Interpreting results:**
+## Loading Example Files
 
-- **`relevanceScore`** — Higher is better. Scores below 0.3 are often tangentially related
-- **`source.repository`** — Check the source organization. Code from `midnightntwrk`, `OpenZeppelin`, or `LFDT-Minokawa` repositories is more likely to be correct and current than community or third-party code
-- Indexed code may be outdated. A function appearing in search results does not guarantee it exists in the current release. Cross-reference with `compact-core:compact-standard-library` or compilation for confirmation
-
-**Example queries:**
-
-| Goal | Good Query | Why |
-|------|-----------|-----|
-| Find token transfer patterns | `token transfer shielded` | Specific terms matching Compact patterns |
-| Find access control examples | `access control owner witness` | Multiple related terms narrow results |
-| Find ledger state patterns | `ledger state Map Counter` | Specific type names improve relevance |
-
-## midnight-search-typescript
-
-Search TypeScript SDK code, types, and API implementations.
-
-**When to use:** Finding SDK API usage patterns, TypeScript type definitions, DApp integration code, provider setup, or wallet interaction patterns.
-
-**Parameters:**
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `query` | Yes | Search query targeting TypeScript/SDK concepts |
-
-**Interpreting results:**
-
-- Same `relevanceScore` and `source.repository` checks apply as with `midnight-search-compact`
-- TypeScript results include generated types from contract compilation — these reflect actual compiler output
-- Import paths change between SDK versions. Always check `source.repository` version metadata
-
-## midnight-search-docs
-
-Full-text search of the official Midnight documentation index.
-
-**When to use:** Finding conceptual explanations, architecture overviews, configuration guides, getting-started content, or network information.
-
-**Parameters:**
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `query` | Yes | Search query targeting documentation content |
-
-**Interpreting results:**
-
-- The documentation search index may lag behind published docs. Published docs themselves can lag behind actual releases
-- Check `relevanceScore` — low-scoring results are often tangentially related or pulled from unrelated sections
-- Documentation is most reliable for high-level concepts and architecture; least reliable for exact API signatures and version-specific behavior
-- Always verify critical information found in docs using an independent source (compilation, `npm view`, or source code)
-
-## midnight-fetch-docs
-
-Live fetch of documentation pages from docs.midnight.network. Returns the rendered content of a specific documentation page.
-
-**When to use:** When you know the specific documentation page you need, when the search index returns outdated results, or when you need the full content of a page rather than search snippets.
-
-**Parameters:**
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `path` | Yes | Documentation path relative to docs.midnight.network |
-
-**Common documentation paths:**
-
-| Path | Content |
-|------|---------|
-| `/devnet/getting-started` | Getting started guide |
-| `/devnet/building-your-first-dapp` | First DApp tutorial |
-| `/compact/reference` | Compact language reference |
-| `/compact/standard-library` | Standard library reference |
-| `/node/overview` | Node architecture overview |
-| `/indexer/overview` | Indexer overview |
-| `/proof-server/overview` | Proof server overview |
-| `/token/overview` | Token and tokenomics overview |
-
-## Query Optimization
-
-The quality of search results depends heavily on query construction.
-
-### Effective Query Patterns
-
-| Strategy | Example | Why It Works |
-|----------|---------|-------------|
-| Use specific Compact terms | `Counter Bytes Map ledger` | Matches actual type and construct names |
-| Include the domain | `shielded token transfer circuit` | Narrows to the right code patterns |
-| Name the construct | `witness function parameter` | Matches declaration patterns |
-| Combine noun + action | `deploy contract provider` | Matches SDK usage patterns |
-
-### Ineffective Query Patterns
-
-| Pattern | Problem | Better Alternative |
-|---------|---------|-------------------|
-| `how do I make a contract` | Too vague, natural language | `contract ledger circuit export` |
-| `error handling` | Too generic | `assert require revert Compact` |
-| `best practices` | Not searchable | Ask about the specific pattern |
-
-### Combining Search Tools
-
-For comprehensive results on a topic, combine `midnight-search-compact` with `midnight-search-docs`:
-
-1. Use `midnight-search-compact` to find real code implementing the pattern
-2. Use `midnight-search-docs` to find the conceptual explanation and any caveats
-
-This two-call approach covers both implementation and documentation. Do not exceed 2 search calls per question — additional calls rarely add value beyond what the first two provide.
-
-## Interpreting Results
-
-All search tools return a `relevanceScore` with each result. Use these thresholds consistently across all four tools:
-
-| Score Range | Interpretation |
-|-------------|---------------|
-| 0.7 and above | High confidence — result is directly relevant to the query |
-| 0.3 to 0.7 | Moderate confidence — review the result to confirm relevance before relying on it |
-| Below 0.3 | Low confidence — result is often tangentially related; do not treat as authoritative |
-
-Low-scoring results can still contain useful context, but always verify critical information from low-scoring results against an independent source (compilation, `npm view`, or official documentation).
+Each reference file describes techniques and names their example files. After reading a reference file, evaluate which techniques you will apply. Load the example file **only** for techniques you intend to use. Do not load example files for techniques you are skipping.
 
 ## Trusted Sources
 
@@ -148,6 +47,62 @@ When evaluating search results, prioritize results from these organizations:
 | LFDT-Minokawa | `LFDT-Minokawa` | Infrastructure and tooling |
 
 Results from other sources may be valid but require independent verification before relying on them.
+
+## `/midnight-mcp:search` Command
+
+Users can invoke `/midnight-mcp:search` to run searches with explicit technique control.
+
+### Modes
+
+| Mode | Invocation | Behavior |
+|------|-----------|----------|
+| Interactive | `/midnight-mcp:search` | Guided Q&A — asks what the user needs, constructs and executes the search |
+| Quick | `/midnight-mcp:search <query>` | Auto-routed with `--quick` defaults |
+| Explicit | `/midnight-mcp:search <query> --thorough --compact` | User-specified flags |
+
+### Source Flags
+
+| Flag | MCP Tool(s) |
+|------|-------------|
+| `--compact` | `midnight-search-compact` |
+| `--typescript` | `midnight-search-typescript` |
+| `--docs` | `midnight-search-docs` |
+| `--all` | All three search tools |
+
+Source flags are combinable. If none specified, auto-routes based on query.
+
+### Modifier Flags
+
+| Flag | Effect |
+|------|--------|
+| `--trusted-only` | Restricts Compact searches to trusted repos via `filter.repository`. For TypeScript searches (no server-side filter), applies client-side trust-aware reranking. No effect on docs. |
+
+### Presets
+
+| Preset | Activates | Use Case |
+|--------|-----------|----------|
+| `--quick` | Intent classification, source routing, single query | Fast lookup |
+| `--thorough` | Multi-query, step-back, cross-tool orchestration, reranking, coverage balancing, dedup | Comprehensive research |
+| `--debug` | Error-to-doc rewriting, symbol-aware search, environmental grounding | Debugging from an error |
+| `--examples` | Example mining, query rewriting, trusted-source filtering | Finding runnable code |
+| `--migration` | Version-aware, diff-aware, environmental grounding, freshness reranking | Upgrading versions |
+
+### Individual Technique Flags
+
+| Flag | Technique |
+|------|-----------|
+| `--rewrite` | Query rewriting |
+| `--multi-query` | Multi-query generation |
+| `--step-back` | Step-back queries |
+| `--hyde` | HyDE pseudo-answer generation |
+| `--decompose` | Decomposition |
+| `--rerank` | Relevance reranking |
+| `--dedupe` | Deduplication |
+| `--iterative` | Retrieve-read-retrieve |
+| `--version-aware` | Version-aware search |
+| `--env` | Environmental grounding |
+
+Preset + individual flags: preset techniques plus additional individual techniques. No flags with query: `--quick`. No flags, no query: interactive mode.
 
 ## Cross-References
 

--- a/plugins/midnight-mcp/skills/mcp-search/examples/answerability-scoring.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/answerability-scoring.md
@@ -1,0 +1,105 @@
+# Answerability Scoring Examples
+
+## When to Apply
+
+As a final filter before using results to answer the user's question.
+
+## Examples
+
+### Counter Increment — Complete vs Tangential
+
+**Before:**
+```
+User asks: "how to use Counter increment"
+Results:
+  A. Complete circuit with Counter.increment(1) in a ledger context (answerable)
+  B. Changelog entry: "Counter type was added in v0.2.0" (not answerable)
+  C. Test file that asserts Counter value after increment (partially answerable)
+```
+
+**After:**
+```
+Scored:
+  A. Answerable — shows exactly how to call Counter.increment in context → primary result
+  C. Partially answerable — shows expected behavior after increment → supplementary
+  B. Not answerable — mentions Counter but does not show how to use increment → dropped
+```
+
+**Why:** Result A provides the complete pattern the user needs. Result C shows testing context that supplements the answer. Result B merely mentions Counter's existence, which does not answer "how to use" it.
+
+### Token Transfer Pattern — Implementation vs Import
+
+**Before:**
+```
+User asks: "token transfer pattern"
+Results:
+  A. Full contract with transfer circuit, ledger, and witness (answerable)
+  B. One-line import: `import { transfer } from "./token"` (not answerable alone)
+  C. Documentation paragraph explaining the token model (partially answerable)
+```
+
+**After:**
+```
+Scored:
+  A. Answerable — complete implementation showing the pattern → primary result
+  C. Partially answerable — conceptual explanation → supplementary context
+  B. Not answerable on its own — shows the import but not the implementation → dropped or footnote
+```
+
+**Why:** The user asked for a "pattern," which implies a complete implementation. The one-line import tells us a transfer module exists but does not show the pattern itself.
+
+### Deploy to Testnet — Tutorial vs Passing Mention
+
+**Before:**
+```
+User asks: "deploy to testnet"
+Results:
+  A. Step-by-step deployment tutorial for testnet (answerable)
+  B. Sentence mentioning testnet in an unrelated architecture discussion (not answerable)
+  C. Configuration snippet showing testnet endpoint (partially answerable)
+```
+
+**After:**
+```
+Scored:
+  A. Answerable — complete deployment instructions → primary result
+  C. Partially answerable — useful configuration detail → supplementary
+  B. Not answerable — testnet is mentioned in passing → dropped
+```
+
+**Why:** Result A is a complete, actionable answer. Result C provides a useful detail (the endpoint). Result B mentions testnet but is about architecture, not deployment.
+
+## Anti-Patterns
+
+### Treating Any Keyword Match as Answerable
+
+**Wrong:**
+```
+Result mentions "Counter" and "increment" → mark as answerable
+```
+
+**Problem:** A result may contain both keywords without showing how to use them together. A changelog that says "Counter increment performance improved" mentions both terms but does not answer "how to increment a Counter."
+
+**Instead:** Check whether the result provides actionable information for the specific question, not just whether it contains the right keywords.
+
+### Requiring Every Result to Be Independently Sufficient
+
+**Wrong:**
+```
+Result C shows a useful configuration snippet but not the full deployment process → drop it
+```
+
+**Problem:** Supplementary results add value when combined with a primary result. A configuration snippet alongside a deployment tutorial gives the user a more complete picture.
+
+**Instead:** Score results as "answerable" (complete), "partially answerable" (supplementary), or "not answerable" (drop). Include partially answerable results as supporting context.
+
+### Not Checking Answerability at All
+
+**Wrong:**
+```
+Present all 10 results from the search, in score order, without assessing whether any of them actually answer the question
+```
+
+**Problem:** The user receives a mix of relevant and irrelevant results with no guidance. They have to evaluate each result themselves, which defeats the purpose of having an LLM assistant.
+
+**Instead:** Always assess answerability before presenting results. Lead with the most answerable results and drop or deprioritize results that merely mention the topic.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/confidence-assessment.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/confidence-assessment.md
@@ -1,0 +1,107 @@
+# Confidence Assessment Examples
+
+## When to Apply
+
+After every search, before presenting results to the user.
+
+## Examples
+
+### High Confidence — Multiple Trusted Sources Agree
+
+**Before:**
+```
+Query: "Counter increment ledger"
+Results:
+  1. Counter increment example from midnightntwrk/examples (score: 0.75)
+  2. Counter usage in midnightntwrk/midnight-examples (score: 0.71)
+  3. Counter documentation from midnight-search-docs (score: 0.68)
+All three show the same pattern, consistent information
+```
+
+**After:**
+```
+Assessment: HIGH confidence
+→ 3 results from trusted sources agree
+→ Pattern is consistent across code and documentation
+→ Present results directly without caveats
+```
+
+**Why:** Multiple trusted sources showing the same pattern is strong evidence. No follow-up search needed.
+
+### Medium Confidence — Partial Answer from Lower-Trust Source
+
+**Before:**
+```
+Query: "recursive proof composition"
+Results:
+  1. Community blog post about proof composition (score: 0.45)
+  2. A test file mentioning "compose" in a proof context (score: 0.38)
+No official documentation or Foundation code found
+```
+
+**After:**
+```
+Assessment: MEDIUM confidence
+→ Relevant results exist but from lower-trust sources
+→ No official documentation confirms the pattern
+→ Present results with note: "This pattern appears in community code but is not documented in official sources. Verify with compilation before relying on it."
+→ Consider follow-up search on midnight-search-docs
+```
+
+**Why:** Community sources may be correct but lack the authority of official documentation. The user should be aware that this is not officially documented.
+
+### Low Confidence — No Relevant Results
+
+**Before:**
+```
+Query: "recursive circuit composition Compact"
+Results:
+  1. Generic "composition" mention in an architecture doc (score: 0.22)
+  2. Unrelated circuit example (score: 0.18)
+Neither addresses recursive composition
+```
+
+**After:**
+```
+Assessment: LOW confidence
+→ No results address the specific question
+→ Do not present these results as answers
+→ Inform user: "No results found for recursive circuit composition in the search index. This feature may not exist in the current Compact version, or it may not be indexed. Try checking the Compact language reference directly or asking in the Midnight community channels."
+```
+
+**Why:** Presenting irrelevant results as answers is worse than admitting the information was not found. Low confidence triggers either a follow-up search or an honest "not found" response.
+
+## Anti-Patterns
+
+### Presenting Low-Confidence Results as Definitive
+
+**Wrong:**
+```
+Single community result with score 0.35 → present as "here's how to do it"
+```
+
+**Problem:** A single low-scoring result from an untrusted source is not a reliable answer. Presenting it as definitive may lead the user to implement an incorrect or outdated pattern.
+
+**Instead:** Flag the uncertainty. Present the result as "one possible approach found in community code" and recommend verification.
+
+### Always Flagging Uncertainty
+
+**Wrong:**
+```
+3 high-quality results from midnightntwrk → "these results may not be accurate, please verify"
+```
+
+**Problem:** Unnecessary caveats on high-confidence results undermine trust. When multiple official sources agree, the answer is reliable.
+
+**Instead:** Reserve uncertainty flags for medium and low confidence results. High confidence results from trusted sources do not need caveats.
+
+### Conflating Search Confidence with Result Trustworthiness
+
+**Wrong:**
+```
+High confidence search results from untrusted source → present without caveats
+```
+
+**Problem:** Search confidence (did we find relevant results?) and result trustworthiness (is the source reliable?) are different concerns. A confident search can return results from unreliable sources.
+
+**Instead:** Assess confidence (did we find what we were looking for?) and trust (are the sources reliable?) separately. Both must be adequate before presenting results without caveats.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/contradiction-detection.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/contradiction-detection.md
@@ -1,0 +1,107 @@
+# Contradiction Detection Examples
+
+## When to Apply
+
+When multiple search results provide conflicting information about the same topic.
+
+## Examples
+
+### Documentation vs Code — Counter Decrement
+
+**Before:**
+```
+Results:
+  A. Documentation says Counter supports decrement operations
+  B. Code examples only show Counter.increment() — no decrement found
+→ Silently assume documentation is correct
+```
+
+**After:**
+```
+Contradiction detected:
+  Source A (docs): "Counter supports increment and decrement"
+  Source B (code): only Counter.increment() found in examples
+
+Flag to user: "Documentation suggests Counter supports decrement, but no code examples demonstrate it. This may be planned but unimplemented, or the documentation may be ahead of the current version. Verify by compiling a test contract with Counter decrement — use `compact-core:compact-compilation` to check."
+```
+
+**Why:** Silently picking one source hides important uncertainty. The user needs to know about the contradiction so they can verify before relying on either source.
+
+### Different Import Paths — Version Difference
+
+**Before:**
+```
+Results:
+  A. Shows: import { ContractAddress } from "@midnight-ntwrk/midnight-js-contracts"
+  B. Shows: import { ContractAddress } from "@midnight-ntwrk/compact-runtime"
+→ Pick one arbitrarily
+```
+
+**After:**
+```
+Contradiction detected:
+  Source A (midnightntwrk/examples, recent): import from "@midnight-ntwrk/midnight-js-contracts"
+  Source B (midnightntwrk/old-examples, older): import from "@midnight-ntwrk/compact-runtime"
+
+Flag to user: "Two different import paths found for ContractAddress. Source A uses the current package name (@midnight-ntwrk/midnight-js-contracts) and is more recent. Source B uses an older package name that may have been renamed. Check your project's package.json to confirm which package you have installed."
+```
+
+**Why:** The contradiction is likely a version difference. Noting both sources with their dates lets the user determine which applies to their project.
+
+### Conflicting Guidance on disclose
+
+**Before:**
+```
+Results:
+  A. One result says disclose is mandatory for public ledger state
+  B. Another result implies disclose is handled automatically
+→ Pick the one that sounds more authoritative
+```
+
+**After:**
+```
+Contradiction detected:
+  Source A: "All public ledger state must use disclose"
+  Source B: "Public ledger state is automatically disclosed"
+
+Flag to user: "Conflicting information found about disclose behavior. Source A states disclose is mandatory and explicit. Source B implies it is automatic. This may depend on the Compact language version or specific context. Recommend checking `compact-core:compact-privacy-disclosure` skill for authoritative guidance, or verify with compilation."
+```
+
+**Why:** Privacy semantics are critical in Midnight. Presenting incorrect disclose guidance could lead to unintended data exposure. Both sources should be flagged with a recommendation to verify.
+
+## Anti-Patterns
+
+### Silently Picking the Preferred Result
+
+**Wrong:**
+```
+Two results disagree → pick the one that matches your assumption → present as the answer
+```
+
+**Problem:** Your assumption may be wrong. The user deserves to know that sources disagree so they can make an informed decision or verify independently.
+
+**Instead:** Present both results with their sources and trust/freshness context. Let the user or a verification skill resolve the conflict.
+
+### Treating All Contradictions as Errors
+
+**Wrong:**
+```
+Two results show different import paths → report: "there is an error in the documentation"
+```
+
+**Problem:** Many contradictions are version differences, not errors. Different SDK versions legitimately have different import paths, different API signatures, and different behavior.
+
+**Instead:** Consider whether the contradiction could be a version difference. Note the version context of each source and flag it as "likely version difference" rather than "error."
+
+### Flagging Superficial Differences as Contradictions
+
+**Wrong:**
+```
+Result A: `const counter = new Counter(0);`
+Result B: `let counter = new Counter(0);`
+→ Flag as contradiction
+```
+
+**Problem:** `const` vs `let` is a style difference, not a semantic contradiction. Both work. Flagging trivial differences wastes the user's attention.
+
+**Instead:** Only flag contradictions that affect behavior: different function names, different parameter types, different return values, different semantics.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/conversation-grounding.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/conversation-grounding.md
@@ -1,0 +1,108 @@
+# Conversation Grounding Examples
+
+## When to Apply
+
+When prior conversation turns contain entity names, versions, file paths, contract names, or other specifics that the current query lacks.
+
+## Examples
+
+### Injecting Contract Name from Prior Context
+
+**Before:**
+```
+Conversation history: User discussed their `TokenVault` contract in turn 3
+Current query: "how do I add access control"
+Search: "access control Compact"
+```
+
+**After:**
+```
+Search: "access control witness TokenVault contract"
+```
+
+**Why:** The user is asking about access control in the context of their `TokenVault` contract. Including the contract name helps surface results from similar token vault implementations.
+
+### Carrying Forward Type Context
+
+**Before:**
+```
+Conversation history: User was debugging MerkleTree depth issues in turns 5-7
+Current query: "how do I check the current size"
+Search: "check current size"
+```
+
+**After:**
+```
+Search: "MerkleTree size depth count elements"
+```
+
+**Why:** "Check the current size" is ambiguous without context. The prior discussion about MerkleTree depth makes it clear the user is asking about MerkleTree size, not a generic size check.
+
+### Including Package and Version Context
+
+**Before:**
+```
+Conversation history: User is debugging an import error with @midnight-ntwrk/midnight-js-contracts v2.1.0
+Current query: "why can't I import ContractAddress"
+Search: "import ContractAddress"
+```
+
+**After:**
+```
+Search: "ContractAddress import @midnight-ntwrk/midnight-js-contracts v2"
+```
+
+**Why:** The package name and version from prior context narrow the search to results from the correct SDK version, avoiding outdated v1 import paths.
+
+### Network Target from Earlier Discussion
+
+**Before:**
+```
+Conversation history: User established they are targeting testnet in turn 2
+Current query: "how do I configure the provider"
+Search: "configure provider"
+```
+
+**After:**
+```
+Search: "provider configuration testnet endpoint"
+```
+
+**Why:** Provider configuration differs between devnet, testnet, and mainnet. The testnet context from earlier conversation ensures results show testnet-specific configuration.
+
+## Anti-Patterns
+
+### Injecting Stale Context
+
+**Wrong:**
+```
+Conversation history: User discussed Counter in turns 1-3, then switched to MerkleTree in turns 4-8
+Current query about MerkleTree: inject "Counter" from stale context
+```
+
+**Problem:** The user has moved past Counter. Injecting it into MerkleTree queries adds noise and may return irrelevant results about Counter instead of MerkleTree.
+
+**Instead:** Only ground from recent, relevant conversation turns. If the user has moved to a new topic, drop earlier entities.
+
+### Over-Grounding with Too Many Entities
+
+**Wrong:**
+```
+Inject contract name + 3 type names + version + network + file path into a single query
+```
+
+**Problem:** Too many grounded terms make the query overly narrow. The search engine tries to match all terms, returning few or no results.
+
+**Instead:** Inject 1-2 of the most relevant grounded entities. Prioritize entities that disambiguate the query.
+
+### Grounding When the User Is Exploring Something New
+
+**Wrong:**
+```
+User has been working on token contracts, now asks: "how does the indexer work?"
+Search: "indexer token contract TokenVault"
+```
+
+**Problem:** The user is asking about the indexer as a new topic, not about how the indexer relates to their token contract. Grounding from the token context pollutes the results.
+
+**Instead:** Recognize when the user is shifting topics. Do not ground from prior context when the new query is clearly about a different domain.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/coverage-balancing.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/coverage-balancing.md
@@ -1,0 +1,110 @@
+# Coverage Balancing Examples
+
+## When to Apply
+
+When the query has multiple facets or sub-topics, and results cluster around only one facet.
+
+## Examples
+
+### State Management Patterns — Missing Type Coverage
+
+**Before:**
+```
+Query: "Compact state management patterns"
+Results: 8 about Counter, 2 about ledger declarations
+→ Missing: Map, Set, MerkleTree patterns
+```
+
+**After:**
+```
+Identified gap: no results for Map, Set, or MerkleTree state management
+Follow-up search: "Map Set MerkleTree state management Compact"
+→ Combined results now cover Counter, Map, Set, MerkleTree, and ledger patterns
+
+Presented by facet:
+  Counter patterns (3 results)
+  Map patterns (2 results)
+  Set patterns (1 result)
+  MerkleTree patterns (2 results)
+  Ledger declarations (2 results)
+```
+
+**Why:** "State management" has multiple facets — different state types. The initial results clustered around Counter because it is the most common. A follow-up search fills the gaps.
+
+### Testing and Deployment — Missing Testing Coverage
+
+**Before:**
+```
+Query: "how to test and deploy Compact contracts"
+Results: 7 about deployment, 3 about provider setup
+→ Missing: testing patterns entirely
+```
+
+**After:**
+```
+Identified gap: no results about testing
+Follow-up search: "Compact contract testing simulator verify"
+→ Combined results now cover both deployment and testing
+
+Presented by facet:
+  Deployment (4 results — kept the most relevant from original)
+  Testing (3 results from follow-up)
+```
+
+**Why:** The deployment side dominated because more indexed content covers deployment than testing. Without the follow-up, the user gets an incomplete answer.
+
+### Cross-Language Question — Missing TypeScript Coverage
+
+**Before:**
+```
+Query: "building a DApp with Compact and TypeScript"
+All results from midnight-search-compact — no TypeScript coverage
+```
+
+**After:**
+```
+Identified gap: no TypeScript SDK results
+Follow-up: midnight-search-typescript query: "DApp TypeScript SDK integration provider"
+→ Combined results cover both Compact and TypeScript sides
+
+Presented by domain:
+  Compact contract patterns (from midnight-search-compact)
+  TypeScript SDK integration (from midnight-search-typescript)
+```
+
+**Why:** The initial search only covered the Compact side. A DApp question requires both Compact (contract) and TypeScript (frontend/integration) coverage.
+
+## Anti-Patterns
+
+### Assuming the First Result Set Is Complete
+
+**Wrong:**
+```
+Query about multiple topics → get results → present them without checking coverage
+```
+
+**Problem:** Search engines return results ranked by relevance to the overall query, which naturally clusters around the dominant facet. Minor facets get underrepresented.
+
+**Instead:** After every multi-facet query, check whether all facets are represented in the results. If not, do a targeted follow-up.
+
+### Doing Follow-Up Searches for Every Facet
+
+**Wrong:**
+```
+Query has 4 facets → results cover 3 of them → do 4 separate follow-up searches
+```
+
+**Problem:** Only the underrepresented facet needs a follow-up. Searching for facets already well-covered wastes API calls.
+
+**Instead:** Only search for genuinely missing coverage. If 3 of 4 facets are covered, search for the one that is missing.
+
+### Presenting Results in Score Order for Multi-Facet Queries
+
+**Wrong:**
+```
+Results from multiple facets → sort by score → present as flat list
+```
+
+**Problem:** Score-ordered presentation mixes facets together. The user cannot easily see which parts of their question are covered and which are not.
+
+**Instead:** Group results by facet when the query has multiple distinct sub-topics. This makes coverage visible.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/cross-tool-orchestration.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/cross-tool-orchestration.md
@@ -1,0 +1,107 @@
+# Cross-Tool Orchestration Examples
+
+## When to Apply
+
+When a single tool cannot provide complete coverage — typically for comprehensive research, or when code examples need conceptual context.
+
+## Examples
+
+### How and Why: Token Transfer Implementation
+
+**Before:**
+```
+User query: "How do I implement token transfers in Compact?"
+Single tool: midnight-search-compact query: "token transfer"
+→ Returns code but no explanation of the token model
+```
+
+**After:**
+```
+Call 1: midnight-search-compact query: "token transfer shielded circuit"
+→ Returns real implementation patterns
+
+Call 2: midnight-search-docs query: "token transfer model privacy"
+→ Returns conceptual guidance on the token model
+```
+
+**Why:** The user needs both implementation code and conceptual understanding. Compact search provides the "how," docs search provides the "why." Presenting both gives a complete answer.
+
+### End-to-End: Contract Deployment from TypeScript
+
+**Before:**
+```
+User query: "Show me how to deploy a contract from TypeScript"
+Single tool: midnight-search-typescript query: "deploy contract"
+→ Returns SDK deployment code but not the contract itself
+```
+
+**After:**
+```
+Call 1: midnight-search-typescript query: "deploy contract provider TypeScript"
+→ Returns SDK deployment patterns
+
+Call 2: midnight-search-compact query: "contract export circuit deployment example"
+→ Returns the contract side that gets deployed
+```
+
+**Why:** Deployment spans two domains: the TypeScript SDK code that deploys, and the Compact contract being deployed. Both are needed for a complete answer.
+
+### Discovery + Full Content: Compact Language Changes
+
+**Before:**
+```
+User query: "What changed in Compact language version 0.2.0?"
+Single tool: midnight-search-docs query: "Compact language version 0.2.0 changes"
+→ Returns snippets but not the full changelog
+```
+
+**After:**
+```
+Call 1: midnight-search-docs query: "Compact language version 0.2.0 changes migration"
+→ Returns snippets pointing to the relevant page
+
+Call 2: midnight-fetch-docs path: "/compact/changelog" (or the discovered page path)
+→ Returns the full page content with complete details
+```
+
+**Why:** Search discovers which page contains the information. Fetch retrieves the complete content. This two-step pattern avoids guessing page paths while still getting full content.
+
+## Anti-Patterns
+
+### Calling All Three Search Tools on Every Question
+
+**Wrong:**
+```
+User asks: "what is Counter?"
+Call 1: midnight-search-compact query: "Counter"
+Call 2: midnight-search-typescript query: "Counter"
+Call 3: midnight-search-docs query: "Counter"
+```
+
+**Problem:** Most questions need 1-2 tools. Calling all three wastes API calls and tokens. "What is Counter?" is a Compact language question — `midnight-search-compact` is sufficient, possibly with `midnight-search-docs` for conceptual explanation.
+
+**Instead:** Classify the intent and route to the appropriate tool(s). Use cross-tool orchestration only when the question genuinely spans domains.
+
+### Using Search + Fetch When Search Alone Suffices
+
+**Wrong:**
+```
+Search returns clear, complete code snippet
+→ Also fetch the full page the snippet came from
+```
+
+**Problem:** If the search result already contains the complete answer, fetching the full page adds tokens without new information.
+
+**Instead:** Use search + fetch only when search snippets are insufficient — truncated code, incomplete explanations, or when you need surrounding context.
+
+### Calling the Same Tool Twice with Slightly Different Queries
+
+**Wrong:**
+```
+Call 1: midnight-search-compact query: "token transfer"
+Call 2: midnight-search-compact query: "shielded token send"
+```
+
+**Problem:** This is multi-query, not cross-tool orchestration. If you need multiple queries against the same tool, combine them using the multi-query technique in one logical step.
+
+**Instead:** Use cross-tool orchestration for calling different tools. Use multi-query for calling the same tool with variant queries.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/decomposition.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/decomposition.md
@@ -1,0 +1,114 @@
+# Decomposition Examples
+
+## When to Apply
+
+When the question involves multiple independent concerns that should be searched separately.
+
+## Examples
+
+### Shielded Voting Contract with Token Gating
+
+**Before:**
+```
+Single query: "shielded voting contract with token gating"
+→ Too many concepts for one search — results are diluted
+```
+
+**After:**
+```
+Sub-query 1: "voting contract Compact tally circuit Counter"
+Sub-query 2: "shielded token privacy ledger witness"
+Sub-query 3: "token gating access control holder balance"
+```
+
+**Why:** The original question has three independent concerns: voting mechanics, privacy/shielding, and token-based access control. Each sub-query targets one concern with specific Midnight terminology, producing focused results.
+
+### DApp Migration from Testnet to Mainnet
+
+**Before:**
+```
+Single query: "migrate DApp from testnet to mainnet with new SDK version"
+→ Mixes network config, SDK changes, and deployment
+```
+
+**After:**
+```
+Sub-query 1: "testnet mainnet network configuration endpoint"
+Sub-query 2: "SDK version migration breaking changes upgrade"
+Sub-query 3: "DApp deployment provider endpoint configuration"
+```
+
+**Why:** Network migration, SDK version changes, and deployment configuration are independent topics documented in different places. Searching each separately retrieves the relevant guidance without cross-contamination.
+
+### MerkleTree Membership with Rate Limiting
+
+**Before:**
+```
+Single query: "MerkleTree-based membership proofs and Counter-based rate limiting"
+→ Two distinct patterns in one query
+```
+
+**After:**
+```
+Sub-query 1: "MerkleTree membership proof inclusion verify"
+Sub-query 2: "Counter rate limiting increment circuit threshold"
+```
+
+**Why:** MerkleTree membership proofs and Counter-based rate limiting are completely independent patterns. A single query splits the search engine's attention between them. Two focused queries each return the best results for their pattern.
+
+### End-to-End Contract Deployment
+
+**Before:**
+```
+Single query: "write a Compact contract and deploy it from TypeScript with wallet integration"
+→ Spans three different codebases
+```
+
+**After:**
+```
+Sub-query 1 (midnight-search-compact): "contract ledger circuit export example"
+Sub-query 2 (midnight-search-typescript): "deploy contract provider TypeScript"
+Sub-query 3 (midnight-search-typescript): "wallet provider Lace connect integration"
+```
+
+**Why:** This question spans Compact (contract writing), TypeScript SDK (deployment), and wallet integration. Each sub-query targets the right tool and terminology.
+
+## Anti-Patterns
+
+### Decomposing Simple Questions
+
+**Wrong:**
+```
+User asks: "how to use Counter"
+Sub-query 1: "Counter type definition"
+Sub-query 2: "Counter increment"
+Sub-query 3: "Counter in ledger"
+```
+
+**Problem:** "Counter" is a simple topic that a single well-formed query handles well. Decomposing it wastes three tool calls for results that one query would cover.
+
+**Instead:** Use a single query: `Counter type usage increment ledger Compact`.
+
+### Creating Overlapping Sub-Queries
+
+**Wrong:**
+```
+Sub-query 1: "shielded token transfer privacy"
+Sub-query 2: "private token send shielded"
+Sub-query 3: "token privacy transfer mechanism"
+```
+
+**Problem:** These sub-queries all target the same concept with minor variations. This is multi-query, not decomposition. Decomposition splits different concerns, not synonyms.
+
+**Instead:** Use multi-query for synonym coverage of a single concept. Use decomposition when the question has genuinely distinct sub-topics.
+
+### Too Many Sub-Queries
+
+**Wrong:**
+```
+Decompose into 6 sub-queries, each targeting a minor aspect.
+```
+
+**Problem:** Each sub-query costs a tool call. Beyond 3-4 sub-queries, the overhead exceeds the benefit. Later sub-queries often target trivially small aspects that are covered by earlier results.
+
+**Instead:** Limit to 3-4 sub-queries. Combine closely related aspects into a single sub-query.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/deduplication.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/deduplication.md
@@ -1,0 +1,101 @@
+# Deduplication Examples
+
+## When to Apply
+
+When results contain near-identical content from the same or forked repos. Common when searching broad topics.
+
+## Examples
+
+### Fork-Induced Duplication
+
+**Before:**
+```
+Results:
+  1. Token contract from midnightntwrk/examples (score: 0.72)
+  2. Same token contract from user/midnight-token-demo (score: 0.68) — forked repo
+  3. Same token contract from another-user/my-midnight-fork (score: 0.61) — another fork
+```
+
+**After:**
+```
+Deduplicated:
+  1. Token contract from midnightntwrk/examples — authoritative source
+  Note: same contract also found in 2 community forks
+```
+
+**Why:** The forked copies are identical to the original. Showing all three wastes result slots and confuses the user. Keep the authoritative source, note the forks exist.
+
+### Same Content in Multiple Locations
+
+**Before:**
+```
+Results:
+  1. Counter usage in README.md of midnightntwrk/examples (score: 0.65)
+  2. Counter usage in src/counter.compact (score: 0.63) — same code, the source file
+  3. Counter usage in test/counter.test.ts (score: 0.55) — same code imported in test
+```
+
+**After:**
+```
+Deduplicated:
+  1. Counter usage in src/counter.compact — the source implementation
+  Note: same code referenced in README and test files
+```
+
+**Why:** The source file is the authoritative version. The README quotes it and the test imports it. Keeping the source file provides the most useful, complete version.
+
+### Genuinely Different Implementations
+
+**Before:**
+```
+Results:
+  1. Token transfer using direct ledger update (midnightntwrk/examples)
+  2. Token transfer using witness-based authorization (OpenZeppelin/compact-contracts)
+  3. Token transfer with privacy-preserving amounts (midnightntwrk/midnight-examples)
+```
+
+**After:**
+```
+Keep all three — these are distinct approaches:
+  1. Direct ledger update — simplest pattern
+  2. Witness-based authorization — access-controlled pattern
+  3. Privacy-preserving amounts — shielded pattern
+```
+
+**Why:** These are three genuinely different implementations of token transfer, each using a different approach. They are not duplicates — they represent distinct patterns the user should see.
+
+## Anti-Patterns
+
+### Deduplicating Different Approaches
+
+**Wrong:**
+```
+Two results both about "token transfer" → deduplicate to one
+```
+
+**Problem:** Two results about the same topic may use completely different approaches. Deduplicating them hides valuable alternatives from the user.
+
+**Instead:** Compare the actual content, not just the topic label. Deduplicate only when the code or text is substantially identical.
+
+### Keeping the Higher-Scored Duplicate Instead of the More Trusted One
+
+**Wrong:**
+```
+community/fork has score 0.73, midnightntwrk/original has score 0.68
+→ Keep the community fork because it scored higher
+```
+
+**Problem:** The higher score is likely a coincidence of indexing order or chunk size. The `midnightntwrk` version is the authoritative source that the fork copied.
+
+**Instead:** When deduplicating, keep the version from the most trusted source regardless of score.
+
+### Not Deduplicating at All
+
+**Wrong:**
+```
+Present 5 copies of the same Counter example from 5 different forks
+```
+
+**Problem:** The user sees the same code repeated 5 times, wasting their attention and making it seem like the search returned nothing diverse.
+
+**Instead:** Always check for near-identical results, especially from forked repositories. Collapse duplicates and note their existence.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/diff-aware-search.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/diff-aware-search.md
@@ -1,0 +1,102 @@
+# Diff-Aware Search Examples
+
+## When to Apply
+
+When the user is in a PR review, migration, or refactoring context and the search should be informed by what is changing.
+
+## Examples
+
+### Refactoring Counter to MerkleTree
+
+**Before:**
+```
+User's PR: replacing Counter with MerkleTree in a membership contract
+User asks: "is my MerkleTree usage correct?"
+Search: "MerkleTree usage" (generic, ignores the refactoring context)
+```
+
+**After:**
+```
+Context from diff: replacing Counter.increment() with MerkleTree.insert()
+Search: "MerkleTree insert member usage pattern" on midnight-search-compact
+Also search: "MerkleTree membership proof verify" (the pattern Counter was being used for)
+→ Results show MerkleTree patterns that match the previous Counter usage context
+```
+
+**Why:** The diff reveals what the user is trying to achieve — replacing Counter-based membership tracking with MerkleTree-based membership proofs. Searching for MerkleTree patterns that match the original Counter use case produces more relevant results.
+
+### SDK v1 to v2 Migration
+
+**Before:**
+```
+User is migrating imports from @midnight-ntwrk/compact-runtime to @midnight-ntwrk/midnight-js-contracts
+User asks: "what's the v2 equivalent of this import"
+Search: "import migration" (too generic)
+```
+
+**After:**
+```
+Context from diff: changing import paths
+Search: "midnight-js-contracts import ContractAddress DeployedContract" on midnight-search-typescript
+Also: "SDK migration v1 v2 breaking changes" on midnight-search-docs
+→ Results show the correct v2 import paths and migration guidance
+```
+
+**Why:** The diff shows the specific imports being changed. Searching for those specific type names in the new package produces the exact import patterns needed.
+
+### PR Introduces New disclose Call
+
+**Before:**
+```
+User's PR adds a disclose statement to a contract
+User asks: "did I implement disclose correctly?"
+Search: "disclose Compact" (too broad)
+```
+
+**After:**
+```
+Context from diff: new disclose call on a ledger field
+Search: "disclose ledger field public state pattern" on midnight-search-compact
+Also: "disclose privacy implications public" on midnight-search-docs
+→ Results show correct disclose patterns and privacy implications
+```
+
+**Why:** The diff reveals which specific construct the user added. Searching for disclose patterns on ledger fields and privacy implications provides verification context that directly relates to the PR changes.
+
+## Anti-Patterns
+
+### Ignoring the Diff Context
+
+**Wrong:**
+```
+User is in a PR review, asks about a specific change
+→ Search generically without considering what is changing
+```
+
+**Problem:** Generic searches miss the specific context of the changes. The user's question is about their particular modification, not the general topic.
+
+**Instead:** Read the diff or PR context to understand what is changing. Use changed file names, modified types, and affected functions as search terms.
+
+### Searching for Every Changed Symbol
+
+**Wrong:**
+```
+Diff changes 15 files, modifies 8 functions
+→ Search for all 8 function names individually
+```
+
+**Problem:** Not all changes are relevant to the user's question. Searching for every changed symbol wastes API calls and produces unfocused results.
+
+**Instead:** Focus on the symbols relevant to the user's specific question. If they ask about MerkleTree usage, search for MerkleTree patterns, not every other change in the PR.
+
+### Using Diff-Aware Search for Unrelated Questions
+
+**Wrong:**
+```
+User is in a PR context but asks: "how does the proof server work?"
+→ Search using PR diff context: "proof server MerkleTree Counter refactor"
+```
+
+**Problem:** The user's question about the proof server is unrelated to their PR changes. Injecting diff context into an unrelated question adds noise.
+
+**Instead:** Recognize when the user's question is unrelated to the current diff. Only use diff context when the question is about the changes themselves.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/entity-extraction.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/entity-extraction.md
@@ -1,0 +1,109 @@
+# Entity Extraction / Normalization Examples
+
+## When to Apply
+
+Always, as a pre-processing step before query construction.
+
+## Examples
+
+### Normalizing Type Name Casing
+
+**Before:**
+```
+User query: "how do I use the merkletree in compact"
+Detected entities: "merkletree" (type, wrong case), "compact" (language, wrong case)
+```
+
+**After:**
+```
+Normalized: "MerkleTree" (correct casing), "Compact" (correct casing)
+Search query: "MerkleTree usage Compact"
+```
+
+**Why:** The MCP search index contains `MerkleTree` with exact casing. Searching for `merkletree` may miss results due to case-sensitive indexing or reduced relevance scoring.
+
+### Extracting Package Names
+
+**Before:**
+```
+User query: "check my @midnight-ntwrk/midnight-js-contracts types"
+Detected entities: "@midnight-ntwrk/midnight-js-contracts" (package name), "types" (concept)
+```
+
+**After:**
+```
+Search query: "@midnight-ntwrk/midnight-js-contracts type definitions"
+Route to: midnight-search-typescript (TypeScript package)
+```
+
+**Why:** The package name is a precise entity that should be preserved exactly. It also signals that this is a TypeScript/SDK question, informing tool routing.
+
+### Normalizing Counter Overflow Query
+
+**Before:**
+```
+User query: "counter overflow in my token contract"
+Detected entities: "counter" (type, wrong case), "token" (domain), "contract" (construct), "overflow" (concept)
+```
+
+**After:**
+```
+Normalized: "Counter" (correct casing)
+Search query: "Counter overflow token contract limits"
+```
+
+**Why:** `Counter` is a specific Compact standard library type. Normalizing the casing ensures the search matches indexed content that uses the canonical form.
+
+### Extracting Tool and Component Names
+
+**Before:**
+```
+User query: "deploy to testnet with lace"
+Detected entities: "testnet" (network), "lace" (wallet, wrong case), "deploy" (action)
+```
+
+**After:**
+```
+Normalized: "testnet" (correct), "Lace" (correct casing for Lace wallet)
+Search query: "deploy testnet Lace wallet provider"
+```
+
+**Why:** "Lace" is the proper name of the wallet. Normalizing casing and adding the entity type ("wallet") clarifies the search intent and improves result relevance.
+
+## Anti-Patterns
+
+### Normalizing Terms That Are Already Correct
+
+**Wrong:**
+```
+"DApp" → "decentralized application"
+"DUST" → "Digital Utility Settlement Token"
+```
+
+**Problem:** DApp and DUST are the standard forms used throughout Midnight documentation and code. Expanding them introduces terms that rarely appear in the index and reduces recall.
+
+**Instead:** Keep DApp, DUST, and tDUST as-is. They are not abbreviations — they are the canonical names.
+
+### Extracting Generic Programming Terms as Midnight Entities
+
+**Wrong:**
+```
+User query: "how to define a function in Compact"
+Extracted entities: "function" (construct), "define" (action)
+```
+
+**Problem:** "function" and "define" are generic programming terms, not Midnight-specific entities. In Compact, the relevant construct is `circuit` or `witness`, not "function."
+
+**Instead:** Map generic terms to their Midnight equivalents: "function" likely means `circuit` or `witness` in Compact context.
+
+### Missing Midnight Entities That Look Like Common Words
+
+**Wrong:**
+```
+User query: "how does the witness work in my circuit"
+Extracted entities: (none — "witness" and "circuit" look like common English words)
+```
+
+**Problem:** In Midnight/Compact context, `witness` and `circuit` are specific language constructs with precise meanings. Missing them means the query loses its most important terms.
+
+**Instead:** Maintain a recognition list of Midnight terms that overlap with common words: `witness`, `circuit`, `ledger`, `export`, `field`, `pad`, `merge`.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/environmental-grounding.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/environmental-grounding.md
@@ -1,0 +1,113 @@
+# Environmental Grounding Examples
+
+## When to Apply
+
+When the user is working within a project that has Midnight dependencies or Compact source files, and the search would benefit from knowing the project's version context.
+
+## Examples
+
+### SDK Version from package.json
+
+**Before:**
+```
+package.json: "@midnight-ntwrk/compact": "^0.28.0"
+User query: "how to declare a ledger"
+Search: "ledger declaration Compact"
+```
+
+**After:**
+```
+Search: "ledger declaration Compact language_version 0.28"
+→ Bias results toward Compact 0.28.x syntax patterns
+```
+
+**Why:** Compact syntax can change between major versions. The `^0.28.0` dependency tells us the project uses 0.28.x, so results from other versions may show outdated or incompatible syntax.
+
+### Language Version from Compact Pragma
+
+**Before:**
+```
+*.compact file contains: pragma language_version 0.2.0;
+User query: "how to use disclose"
+Search: "disclose Compact"
+```
+
+**After:**
+```
+Search: "disclose Compact language_version 0.2.0"
+→ Deprioritize results showing pre-0.2.0 disclose syntax
+```
+
+**Why:** The `pragma language_version` declaration is the most reliable version signal. The `disclose` construct behavior may differ between language versions.
+
+### Local Development Network Context
+
+**Before:**
+```
+Config file has endpoint: http://localhost:9944
+User query: "how to connect to the network"
+Search: "network connection provider"
+```
+
+**After:**
+```
+Search: "devnet local network provider localhost configuration"
+→ Bias toward local development and devnet setup guides
+```
+
+**Why:** The `localhost:9944` endpoint indicates local development. The user needs devnet configuration, not testnet or mainnet deployment guides.
+
+### Detecting OpenZeppelin Dependencies
+
+**Before:**
+```
+package.json: "@openzeppelin/compact-contracts": "^1.0.0" and "@midnight-ntwrk/midnight-js-contracts": "^2.0.0"
+User query: "how to add ownership to my contract"
+Search: "ownership contract Compact"
+```
+
+**After:**
+```
+Search: "Ownable OpenZeppelin ownership contract access control"
+→ Include OpenZeppelin patterns since the project already uses their libraries
+```
+
+**Why:** The project has OpenZeppelin as a dependency. The user likely wants to use `Ownable` from `@openzeppelin/compact-contracts` rather than implementing ownership from scratch.
+
+## Anti-Patterns
+
+### Reading package.json on Every Search
+
+**Wrong:**
+```
+Every search call triggers: Read package.json → parse dependencies → extract versions
+```
+
+**Problem:** Reading `package.json` costs tokens and adds latency. The file rarely changes during a conversation session.
+
+**Instead:** Read project context once at the start of the session or when the user mentions version concerns. Cache the result mentally for subsequent searches.
+
+### Treating Version Ranges as Exact Versions
+
+**Wrong:**
+```
+package.json: "@midnight-ntwrk/compact": "^0.28.0"
+→ Restrict search to exactly version 0.28.0
+```
+
+**Problem:** `^0.28.0` means any 0.28.x version. Restricting to exactly 0.28.0 may miss results from 0.28.1 or 0.28.3 that are equally compatible.
+
+**Instead:** Treat `^0.28.0` as "0.28.x family." Include results from the entire 0.28.x range.
+
+### Ignoring Explicit User Version Context
+
+**Wrong:**
+```
+package.json shows SDK v2.0.0
+User asks: "how did this work in SDK v1?"
+→ Filter results to v2.0.0 based on environmental context
+```
+
+**Problem:** The user is explicitly asking about v1, overriding the environmental context. Applying the v2 filter excludes exactly the results the user needs.
+
+**Instead:** Environmental context is a default. When the user explicitly asks about a different version, their request takes priority.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/error-to-doc.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/error-to-doc.md
@@ -1,0 +1,119 @@
+# Error-to-Doc Search Examples
+
+## When to Apply
+
+When the user provides a compiler error, runtime error, or stack trace.
+
+## Examples
+
+### Compact Compiler Type Mismatch
+
+**Before:**
+```
+Error: "Type mismatch: expected Bytes<32>, got Field"
+Search: "Type mismatch: expected Bytes<32>, got Field" (full error message)
+→ No exact match in the index
+```
+
+**After:**
+```
+Extracted key terms: Bytes, Field, type conversion
+Search: "Bytes Field type conversion cast Compact" on midnight-search-compact
+→ Results showing how to convert between Bytes and Field types
+```
+
+**Why:** The full error message including "expected" and "got" is compiler-specific text that will not appear in documentation or examples. The key terms (the types involved and the concept of conversion) are what matches indexed content.
+
+### TypeScript Module Import Error
+
+**Before:**
+```
+Error: "Cannot find module '@midnight-ntwrk/midnight-js-contracts'"
+Search: "Cannot find module" on midnight-search-compact
+→ No results — wrong tool and wrong search terms
+```
+
+**After:**
+```
+Extracted key terms: @midnight-ntwrk/midnight-js-contracts, module, import, installation
+Search: "midnight-js-contracts import module installation" on midnight-search-typescript
+Also: "midnight-js-contracts setup installation" on midnight-search-docs
+→ Results showing correct installation and import patterns
+```
+
+**Why:** This is a JavaScript/Node.js error about a TypeScript package. Route to TypeScript search and documentation, not Compact search. Strip the generic "Cannot find module" prefix and search for the package name and setup terms.
+
+### Node.js Directory Import Error
+
+**Before:**
+```
+Error: "ERR_UNSUPPORTED_DIR_IMPORT"
+Stack trace: at node:internal/modules/esm/resolve:283
+Search: full stack trace pasted
+→ No results
+```
+
+**After:**
+```
+Extracted key terms: ERR_UNSUPPORTED_DIR_IMPORT, module resolution
+Search: "ERR_UNSUPPORTED_DIR_IMPORT module resolution" on midnight-search-docs
+→ Results from troubleshooting guides about ESM module resolution
+```
+
+**Why:** Stack trace details (line numbers, internal Node.js paths) are not indexed. The error code itself (`ERR_UNSUPPORTED_DIR_IMPORT`) is the distinctive searchable term, combined with the concept ("module resolution").
+
+### Compact Undeclared Identifier
+
+**Before:**
+```
+Error: "Undeclared identifier: myFunction at line 42 in contract.compact"
+Search: "Undeclared identifier: myFunction"
+→ No results — "myFunction" is user-specific
+```
+
+**After:**
+```
+Extracted key terms: undeclared identifier, import, module (stripped user-specific name)
+Search: "undeclared identifier import module Compact" on midnight-search-compact
+Also: "Compact import module declaration" on midnight-search-docs
+→ Results showing how to properly import and declare identifiers
+```
+
+**Why:** The specific identifier name `myFunction` is user-specific and will not appear in any indexed content. The pattern "undeclared identifier" combined with "import" and "module" matches documentation about import resolution.
+
+## Anti-Patterns
+
+### Searching for the Full Error Message with Line Numbers
+
+**Wrong:**
+```
+Search: "Type mismatch: expected Bytes<32>, got Field at line 42 in /Users/dev/project/contract.compact"
+```
+
+**Problem:** Line numbers and file paths are unique to the user's project. No indexed content will match these details. The search engine tries to match the entire string and finds nothing.
+
+**Instead:** Strip file paths, line numbers, and user-specific identifiers. Keep only the error type, involved types, and concept terms.
+
+### Searching for Just the Error Code Without Context
+
+**Wrong:**
+```
+Search: "ERR_UNSUPPORTED_DIR_IMPORT"
+→ Maybe 1 result, not enough context to be useful
+```
+
+**Problem:** Error codes alone are too narrow. They may appear in one troubleshooting page but miss related guidance about the underlying issue (module resolution configuration).
+
+**Instead:** Combine the error code with concept terms: `ERR_UNSUPPORTED_DIR_IMPORT module resolution ESM configuration`.
+
+### Using midnight-search-compact for Runtime JavaScript Errors
+
+**Wrong:**
+```
+JavaScript runtime error about module imports
+→ Search midnight-search-compact
+```
+
+**Problem:** Compact code search indexes Compact source code, not JavaScript/TypeScript runtime behavior. Runtime import errors are JavaScript ecosystem issues.
+
+**Instead:** Use `midnight-search-typescript` for SDK-related errors and `midnight-search-docs` for setup/configuration errors.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/example-mining.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/example-mining.md
@@ -1,0 +1,103 @@
+# Example Mining Examples
+
+## When to Apply
+
+When the user needs runnable, complete code examples rather than documentation or partial snippets.
+
+## Examples
+
+### Complete Token Contract
+
+**Before:**
+```
+User needs: "a complete token contract"
+Search: "token contract" on midnight-search-compact
+→ Returns fragments: a single transfer function, an import statement, a type definition
+```
+
+**After:**
+```
+Search: "token contract example ledger circuit export" on midnight-search-compact
+  filter.repository: "midnightntwrk" (trusted sources for examples)
+→ Returns complete contract implementations from official example repos
+Also check: midnight-list-examples for curated token contract examples
+```
+
+**Why:** Adding "example" and structural terms (`ledger`, `circuit`, `export`) biases results toward complete implementations. Filtering to trusted sources targets official example repositories which contain runnable code.
+
+### TypeScript Wallet Connection
+
+**Before:**
+```
+User needs: "how to connect a wallet in TypeScript"
+Search: "wallet connect" on midnight-search-typescript
+→ Returns type definitions and partial snippets
+```
+
+**After:**
+```
+Search: "wallet provider connect example implementation" on midnight-search-typescript
+  includeExamples: true
+→ Returns complete wallet connection implementations
+```
+
+**Why:** Setting `includeExamples: true` ensures example code is included in results. Adding "example" and "implementation" biases toward complete code rather than type definitions.
+
+### Voting Contract Example
+
+**Before:**
+```
+User needs: "a voting contract example"
+Search: "voting contract" on midnight-search-compact
+→ Returns 2 partial results
+```
+
+**After:**
+```
+Step 1: Check midnight-list-examples for curated voting examples
+→ Lists available example contracts with complexity ratings
+
+Step 2: midnight-search-compact query: "voting ballot tally circuit example Counter"
+  filter.repository: "midnightntwrk"
+→ Returns voting contract implementations from example repos
+```
+
+**Why:** `midnight-list-examples` provides a curated catalog of example contracts. Checking it first may directly point to a voting example. The search step uses voting-specific terms and structural keywords.
+
+## Anti-Patterns
+
+### Returning Documentation Snippets for Code Requests
+
+**Wrong:**
+```
+User asks: "show me a token contract"
+→ Return a documentation paragraph explaining what token contracts are
+```
+
+**Problem:** The user asked for code, not an explanation. Documentation snippets do not provide runnable examples.
+
+**Instead:** Route to `midnight-search-compact` with example-mining terms. If compact search does not return complete examples, try `midnight-list-examples`.
+
+### Returning Partial Implementations
+
+**Wrong:**
+```
+User asks: "show me a complete voting contract"
+→ Return a single circuit function without the ledger declaration or exports
+```
+
+**Problem:** A single function is not a complete contract. The user needs the full structure: pragma, imports, ledger, circuits, exports.
+
+**Instead:** Prefer results that include complete file content. Check for structural markers: `pragma language_version`, `ledger {`, `export circuit`, which indicate a complete contract.
+
+### Not Checking midnight-list-examples
+
+**Wrong:**
+```
+User asks for example code
+→ Go directly to midnight-search-compact without checking the curated example list
+```
+
+**Problem:** `midnight-list-examples` provides a curated catalog of example contracts with complexity ratings and descriptions. It may directly point to exactly what the user needs, saving a search step.
+
+**Instead:** Check `midnight-list-examples` first for curated examples. Use search as a complement or when the curated list does not cover the specific pattern.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/facet-extraction.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/facet-extraction.md
@@ -1,0 +1,127 @@
+# Facet Extraction Examples
+
+## When to Apply
+
+When the query implies constraints that should be used for tool selection or parameter filtering rather than as search terms.
+
+## Examples
+
+### TypeScript Type Definition Request
+
+**Before:**
+```
+User query: "show me the TypeScript types for contract deployment"
+Naive search: "TypeScript types contract deployment" on midnight-search-compact
+```
+
+**After:**
+```
+Extracted facets:
+  language: TypeScript
+  content_type: type_definitions
+
+Route to: midnight-search-typescript with includeTypes: true
+Search query: "contract deployment type definition"
+```
+
+**Why:** "TypeScript" is a routing facet, not a search term. It tells us to use `midnight-search-typescript` instead of `midnight-search-compact`. "Types" signals `includeTypes: true` rather than being a keyword.
+
+### Official Documentation Request
+
+**Before:**
+```
+User query: "what does the official docs say about token privacy"
+Naive search: "official docs token privacy" on midnight-search-compact
+```
+
+**After:**
+```
+Extracted facets:
+  source: official_docs
+  content_type: conceptual
+
+Route to: midnight-search-docs, possibly midnight-fetch-docs
+Search query: "token privacy shielded"
+```
+
+**Why:** "Official docs" is a source facet directing us to the documentation tools. Including "official" as a search keyword would not improve results — all docs results are already official.
+
+### Recent Example Request
+
+**Before:**
+```
+User query: "find me a recent example of Counter usage"
+Naive search: "recent example Counter usage"
+```
+
+**After:**
+```
+Extracted facets:
+  content_type: example
+  recency: recent
+
+Route to: midnight-search-compact with trusted sources
+Search query: "Counter usage example increment ledger"
+Apply: freshness reranking on results
+```
+
+**Why:** "Recent" is a freshness facet for result sorting, not a search keyword. "Example" signals we want code, not documentation. These facets inform tool selection and post-processing.
+
+### API Change History Request
+
+**Before:**
+```
+User query: "how did the ledger API change in the latest version"
+Naive search: "ledger API change latest version"
+```
+
+**After:**
+```
+Extracted facets:
+  recency: latest
+  content_type: changelog/migration
+
+Route to: midnight-search-docs with category: "api"
+Search query: "ledger API changes migration breaking"
+Apply: freshness reranking to boost most recent results
+```
+
+**Why:** "Latest" and "change" are temporal facets that inform freshness reranking. "API" signals the docs `category` parameter. The actual search query focuses on the content terms.
+
+## Anti-Patterns
+
+### Including Facet Terms as Literal Search Keywords
+
+**Wrong:**
+```
+Search query: "official recent TypeScript example Counter"
+```
+
+**Problem:** "Official", "recent", and "TypeScript" are not content terms — they are meta-information about what kind of result the user wants. Including them as keywords dilutes the query and may match irrelevant content that happens to contain these words.
+
+**Instead:** Extract facets to inform routing and post-processing. Keep only content terms in the search query.
+
+### Ignoring Facets Entirely
+
+**Wrong:**
+```
+User query: "show me the TypeScript types for deployment"
+→ Route to midnight-search-compact (default) with no parameters
+```
+
+**Problem:** Ignoring the TypeScript facet routes to the wrong tool. Ignoring the "types" facet misses the `includeTypes: true` parameter that would improve results.
+
+**Instead:** Always extract facets before constructing the query. Even if you are not sure about a facet, it is better to route appropriately than to ignore signals.
+
+### Extracting Contradictory Facets Without Resolving
+
+**Wrong:**
+```
+User query: "show me the latest stable Counter API"
+Extracted facets: recency=latest, stability=stable
+→ Apply both without noting the tension
+```
+
+**Problem:** "Latest" and "stable" may conflict — the latest version might not be stable. Applying both facets without resolution leads to confusing result ordering.
+
+**Instead:** Note the tension and resolve it. Ask the user to clarify, or default to stable with a note that newer versions exist.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/freshness-reranking.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/freshness-reranking.md
@@ -1,0 +1,107 @@
+# Freshness Reranking Examples
+
+## When to Apply
+
+When the query is time-sensitive — version-specific questions, migration guidance, recent changes, or when the user says "latest" or "current."
+
+## Examples
+
+### Latest Ledger Declaration Syntax
+
+**Before:**
+```
+User asks: "what's the latest syntax for declaring a ledger"
+Results:
+  1. Ledger example from 2024 (v0.1 syntax)
+  2. Ledger example from 2025 (v0.2 syntax)
+  3. Ledger documentation (current)
+→ Presented in relevance score order
+```
+
+**After:**
+```
+Reranked by freshness:
+  1. Ledger documentation (current) — most recent
+  2. Ledger example from 2025 (v0.2 syntax) — recent
+  3. Ledger example from 2024 (v0.1 syntax) — note: may use outdated syntax
+```
+
+**Why:** The user explicitly asked for "latest" — freshness is a primary signal. Older examples may show deprecated syntax.
+
+### Proven Token Standard (Freshness Less Important)
+
+**Before:**
+```
+User asks: "how does the proven token standard work"
+Results:
+  1. Experimental token implementation (last month)
+  2. Audited token standard from OpenZeppelin (6 months ago)
+  3. Token concept documentation (3 months ago)
+```
+
+**After:**
+```
+Reranked (trust over freshness):
+  1. Audited token standard from OpenZeppelin — audited, proven correct
+  2. Token concept documentation — official explanation
+  3. Experimental token implementation — newer but unaudited
+```
+
+**Why:** For a "proven" standard, correctness matters more than recency. The 6-month-old audited code is more reliable than last month's experiment. Freshness should not override trust for correctness-critical queries.
+
+### SDK Migration Between Versions
+
+**Before:**
+```
+User asks: "what changed between SDK v1 and v2"
+Results:
+  1. SDK v1 setup guide (old)
+  2. SDK v2 migration guide (recent)
+  3. SDK v1 API reference (old)
+```
+
+**After:**
+```
+Reranked by version relevance:
+  1. SDK v2 migration guide — directly addresses the migration
+  2. SDK v1 API reference — useful for comparison (the "from")
+  3. SDK v1 setup guide — less relevant to migration
+```
+
+**Why:** Migration questions need results from both versions. The migration guide is most valuable. The v1 reference provides the "before" state. The v1 setup guide is tangential.
+
+## Anti-Patterns
+
+### Always Preferring the Newest Result
+
+**Wrong:**
+```
+Sort all results by date, newest first, regardless of content quality
+```
+
+**Problem:** The newest result may be an unfinished experiment, a broken fork, or an incomplete example. Older audited code is often more correct and reliable.
+
+**Instead:** Use freshness as a tiebreaker between equally relevant and trusted results, not as the primary ranking signal.
+
+### Ignoring Freshness for Version-Sensitive Questions
+
+**Wrong:**
+```
+User asks about "current Compact syntax"
+→ Present results from all versions equally, regardless of date
+```
+
+**Problem:** Compact syntax changes between versions. Presenting old syntax as equally valid to current syntax misleads the user.
+
+**Instead:** When the query is version-sensitive, boost recent results. Note when older results may show deprecated patterns.
+
+### Treating Freshness as a Primary Signal
+
+**Wrong:**
+```
+Fresh community code (last week) ranked above audited official code (3 months ago)
+```
+
+**Problem:** Freshness is a secondary signal. A week-old community contribution does not outrank a three-month-old official audited implementation.
+
+**Instead:** Apply freshness within trust tiers. Among trusted sources, prefer fresher content. Among community sources, prefer fresher content. But do not promote untrusted fresh content above trusted older content.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/hyde.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/hyde.md
@@ -1,0 +1,118 @@
+# HyDE (Pseudo-Answer Generation) Examples
+
+## When to Apply
+
+When the query is conceptual and hard to reduce to keywords, or when you know roughly what the answer should look like but need to find real examples.
+
+## Examples
+
+### Finding Access-Gated Circuit Patterns
+
+**Before:**
+```
+User query: "how to gate access to a circuit"
+→ Hard to reduce to keywords without losing intent
+```
+
+**After:**
+```
+Hypothetical Compact snippet (not shown to user):
+  witness authorized(value: Field): Boolean;
+  circuit guarded(value: Field): [] {
+    assert authorized(value);
+    // ... protected logic
+  }
+
+Extracted search terms: "witness authorization circuit access guard assert"
+```
+
+**Why:** The hypothetical snippet contains distinctive Compact constructs (`witness`, `circuit`, `assert`) that are likely to appear in real access-control implementations. These terms produce better results than the vague original query.
+
+### Finding a Voting Contract Structure
+
+**Before:**
+```
+User query: "what does a basic voting contract look like"
+→ Too vague for keyword search
+```
+
+**After:**
+```
+Hypothetical structure (not shown to user):
+  ledger {
+    votes: Map<Bytes<32>, Counter>;
+    totalVotes: Counter;
+  }
+  export circuit cast_vote(candidate: Bytes<32>): [] {
+    votes.lookup(candidate).increment(1);
+    totalVotes.increment(1);
+  }
+
+Extracted search terms: "voting contract ledger Counter tally circuit Map cast vote"
+```
+
+**Why:** The hypothetical reveals the likely data types (`Map`, `Counter`), constructs (`ledger`, `export circuit`), and action names (`cast_vote`, `tally`) that real voting contracts would use.
+
+### Finding Private Data Storage Patterns
+
+**Before:**
+```
+User query: "how to store private data on Midnight"
+→ "Private data" is conceptual, not a searchable term
+```
+
+**After:**
+```
+Hypothetical pattern (not shown to user):
+  witness get_private_value(): Field;
+  ledger {
+    commitment: Bytes<32>;
+  }
+  circuit store(value: Field): [] {
+    commitment = persistentCommit(pad(value));
+  }
+
+Extracted search terms: "local state witness private data off-chain persistentCommit commitment"
+```
+
+**Why:** The hypothetical reveals that private data storage in Compact likely involves `witness` for off-chain data, `persistentCommit` for on-chain commitments, and the distinction between `local` and `ledger` state.
+
+## Anti-Patterns
+
+### Presenting the Hypothetical as Real
+
+**Wrong:**
+```
+"Based on my analysis, here's how to gate access to a circuit:
+  witness authorized(value: Field): Boolean;
+  ..."
+```
+
+**Problem:** The hypothetical is a search aid, not a verified answer. It may contain hallucinated API names, incorrect syntax, or wrong patterns. Presenting it as real misleads the user.
+
+**Instead:** Use the hypothetical only to extract search terms. Present only verified results from the actual search.
+
+### Using HyDE for Simple Keyword Lookups
+
+**Wrong:**
+```
+User asks: "Counter increment example"
+→ Generate a hypothetical Counter increment snippet
+→ Extract terms from it
+```
+
+**Problem:** "Counter increment example" is already a perfectly good search query. HyDE adds unnecessary complexity and latency for queries that are already keyword-rich.
+
+**Instead:** Use HyDE only when the query is conceptual and hard to reduce to keywords directly.
+
+### Searching for Hallucinated API Names
+
+**Wrong:**
+```
+Hypothetical includes: MerkleTree.verifyProof(root, leaf, proof)
+→ Search for "MerkleTree verifyProof"
+```
+
+**Problem:** `verifyProof` may not be the actual function name in Compact's standard library. Searching for hallucinated names produces zero results. The real function could be `member` or `verify`.
+
+**Instead:** Extract general structural terms (`MerkleTree proof verify member`) rather than specific method names from the hypothetical.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/intent-classification.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/intent-classification.md
@@ -1,0 +1,130 @@
+# Intent Classification Examples
+
+## When to Apply
+
+Always, before selecting a tool. Classify the search intent to determine which MCP tool and parameters to use.
+
+## Examples
+
+### Code Example Intent
+
+**Before:**
+```
+User query: "how do I declare a ledger with a Counter"
+Unclassified → default to midnight-search-docs
+```
+
+**After:**
+```
+Intent: code_example
+→ Route to: midnight-search-compact
+Query: "ledger Counter declaration example"
+```
+
+**Why:** The user wants to see implementation code, not read about the concept. `midnight-search-compact` returns real Compact code patterns, which is what "how do I" + specific construct signals.
+
+### Conceptual Intent
+
+**Before:**
+```
+User query: "what is the transaction model in Midnight"
+Unclassified → default to midnight-search-compact
+```
+
+**After:**
+```
+Intent: conceptual
+→ Route to: midnight-search-docs
+Query: "transaction model architecture Midnight"
+```
+
+**Why:** "What is" + architectural concept signals the user wants an explanation, not code. Documentation provides conceptual overviews that code indexes do not.
+
+### API Reference Intent
+
+**Before:**
+```
+User query: "what's the type signature of ContractAddress"
+Unclassified → search all tools
+```
+
+**After:**
+```
+Intent: api_reference
+→ Route to: midnight-search-typescript with includeTypes: true
+Query: "ContractAddress type definition"
+```
+
+**Why:** Type signatures live in TypeScript definitions. Setting `includeTypes: true` ensures type definition files are included in results.
+
+### Troubleshooting Intent
+
+**Before:**
+```
+User query: "I'm getting ERR_UNSUPPORTED_DIR_IMPORT when importing midnight-js-contracts"
+Unclassified → search midnight-search-compact
+```
+
+**After:**
+```
+Intent: troubleshooting
+→ Route to: midnight-search-docs with category: "guides"
+→ Also consider: midnight-search-typescript for import patterns
+Query: "ERR_UNSUPPORTED_DIR_IMPORT module resolution import"
+```
+
+**Why:** Runtime import errors are JavaScript/Node.js issues. Documentation guides cover common setup problems. TypeScript search shows correct import patterns.
+
+### Specific Page Intent
+
+**Before:**
+```
+User query: "show me the getting started page"
+→ Search for "getting started" across all tools
+```
+
+**After:**
+```
+Intent: specific_page
+→ Route to: midnight-fetch-docs with path: "/devnet/getting-started"
+```
+
+**Why:** The user knows exactly which page they want. Fetching directly is faster and more complete than searching for snippets.
+
+## Anti-Patterns
+
+### Defaulting to Docs for Code Questions
+
+**Wrong:**
+```
+User asks: "show me a Counter example"
+→ Route to midnight-search-docs
+```
+
+**Problem:** Documentation may describe Counter conceptually but rarely contains complete, runnable code examples. The compact code index has real implementations.
+
+**Instead:** Classify as `code_example` and route to `midnight-search-compact`.
+
+### Using Compact Search for TypeScript/SDK Questions
+
+**Wrong:**
+```
+User asks: "how to set up the MidnightProvider"
+→ Route to midnight-search-compact
+```
+
+**Problem:** `MidnightProvider` is a TypeScript SDK type. The Compact code index does not contain TypeScript SDK implementations.
+
+**Instead:** Classify as `code_example` with TypeScript context and route to `midnight-search-typescript`.
+
+### Classifying Everything as code_example
+
+**Wrong:**
+```
+User asks: "what is the role of the proof server in Midnight's architecture?"
+→ Classify as code_example → midnight-search-compact
+```
+
+**Problem:** This is a conceptual/architectural question. Code search returns implementation details, not architectural explanations.
+
+**Instead:** Classify as `conceptual` and route to `midnight-search-docs`.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/multi-query.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/multi-query.md
@@ -1,0 +1,97 @@
+# Multi-Query Generation Examples
+
+## When to Apply
+
+When a single query is unlikely to capture all relevant results — ambiguous terms, multiple synonyms, or broad topics.
+
+## Examples
+
+### Covering Token Transfer Synonyms
+
+**Before:**
+```
+Single query: "token transfer"
+```
+
+**After:**
+```
+Query 1: "token transfer circuit"
+Query 2: "shielded send DUST"
+Query 3: "DUST transfer ledger"
+```
+
+**Why:** "Token transfer" might appear as "shielded send" or "DUST transfer" in different codebases. Three queries with distinct terminology cover all naming conventions.
+
+### Searching for Access Control Patterns
+
+**Before:**
+```
+Single query: "access control"
+```
+
+**After:**
+```
+Query 1: "access control owner witness authorization"
+Query 2: "OpenZeppelin Ownable Compact module"
+Query 3: "circuit guard restrict caller"
+```
+
+**Why:** Access control is implemented differently across the ecosystem — Midnight Foundation uses `witness`-based patterns, OpenZeppelin provides `Ownable` modules, and some contracts use custom circuit guards.
+
+### Cross-Domain Proof Server Research
+
+**Before:**
+```
+Single query: "how does the proof server work"
+```
+
+**After:**
+```
+Query 1 (midnight-search-docs): "proof server architecture overview"
+Query 2 (midnight-search-compact): "Zero Knowledge Proof (ZKP) proof generation circuit"
+Query 3 (midnight-search-typescript): "proof server API endpoint client"
+```
+
+**Why:** The proof server spans documentation (architecture), Compact code (proof generation), and TypeScript (API integration). Each query targets the tool and terminology appropriate for that domain.
+
+## Anti-Patterns
+
+### Generating Minor Rephrases
+
+**Wrong:**
+```
+Query 1: "token transfer pattern"
+Query 2: "pattern for token transfers"
+Query 3: "transferring tokens pattern"
+```
+
+**Problem:** These are syntactic variations of the same query. Vector-based search returns nearly identical results for all three, wasting API calls.
+
+**Instead:** Each query should use genuinely different terminology: `token transfer circuit`, `shielded send DUST`, `DUST transfer ledger`.
+
+### Generating Too Many Queries
+
+**Wrong:**
+```
+Query 1: "Counter increment"
+Query 2: "Counter add value"
+Query 3: "Counter update state"
+Query 4: "Counter modify ledger"
+Query 5: "Counter change number"
+```
+
+**Problem:** Beyond 3 queries, returns diminish rapidly. Each additional query costs a tool call and adds token overhead without meaningful new results.
+
+**Instead:** Limit to 2-3 queries maximum. Pick the most semantically distinct variants.
+
+### Using Multi-Query for Simple Lookups
+
+**Wrong:**
+```
+User asks: "what is the Counter type?"
+Generating 3 queries for this.
+```
+
+**Problem:** Simple, specific lookups work well with a single query. Multi-query adds latency and token cost without benefit when the search term is already precise.
+
+**Instead:** Use a single query: `Counter type Compact`. Reserve multi-query for ambiguous or broad topics.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/parameter-optimization.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/parameter-optimization.md
@@ -1,0 +1,117 @@
+# Parameter Optimization Examples
+
+## When to Apply
+
+After tool selection, before making the call. Configure tool-specific parameters to improve result quality.
+
+## Examples
+
+### Looking Up a Single Type Definition
+
+**Before:**
+```
+midnight-search-typescript
+  query: "ContractAddress"
+  (default parameters)
+```
+
+**After:**
+```
+midnight-search-typescript
+  query: "ContractAddress type definition"
+  includeTypes: true
+  includeExamples: false
+  limit: 5
+```
+
+**Why:** The user wants a type definition, not usage examples. Setting `includeTypes: true` ensures type declaration files are searched. Setting `includeExamples: false` reduces noise from example code. A limit of 5 is sufficient for a single type lookup.
+
+### Broad Exploration of Token Patterns
+
+**Before:**
+```
+midnight-search-compact
+  query: "token pattern"
+  (default limit: 10)
+```
+
+**After:**
+```
+midnight-search-compact
+  query: "token pattern shielded transfer mint"
+  limit: 20
+```
+
+**Why:** Broad exploration benefits from more results. The default limit of 10 may miss valuable patterns beyond the first page. Increasing to 20 provides better coverage of different token implementations across repositories.
+
+### Finding a Deployment Tutorial
+
+**Before:**
+```
+midnight-search-docs
+  query: "deploy contract"
+  (no category filter)
+```
+
+**After:**
+```
+midnight-search-docs
+  query: "deploy contract tutorial setup"
+  category: "guides"
+  limit: 10
+```
+
+**Why:** Setting `category: "guides"` filters to tutorials and how-to content, excluding API reference pages and conceptual overviews that mention deployment in passing.
+
+### Extracting a Specific Section from a Doc Page
+
+**Before:**
+```
+midnight-fetch-docs
+  path: "/compact/standard-library"
+  (returns entire page — may be very long)
+```
+
+**After:**
+```
+midnight-fetch-docs
+  path: "/compact/standard-library"
+  extractSection: "Functions"
+```
+
+**Why:** The standard library reference page is long. Using `extractSection` returns only the "Functions" heading and its content, reducing token consumption while getting exactly the information needed.
+
+## Anti-Patterns
+
+### Using Default Parameters for Every Search
+
+**Wrong:**
+```
+Every call: midnight-search-compact query: "..." (no other parameters)
+```
+
+**Problem:** Default parameters are a compromise. Specific tasks benefit from tailored parameters — higher limits for exploration, type filters for API lookups, category filters for docs.
+
+**Instead:** Set parameters based on the task: adjust `limit`, set `category` for docs, set `includeTypes`/`includeExamples` for TypeScript.
+
+### Setting Excessively High Limits
+
+**Wrong:**
+```
+midnight-search-compact query: "Counter" limit: 50
+```
+
+**Problem:** Most useful results are in the first 10-15. Results beyond 20 are almost always irrelevant or duplicative. High limits waste tokens processing low-quality results.
+
+**Instead:** Use `limit: 10` for targeted lookups, `limit: 15-20` for broad exploration. Never exceed 20.
+
+### Setting category on midnight-search-compact
+
+**Wrong:**
+```
+midnight-search-compact query: "Counter" category: "guides"
+```
+
+**Problem:** The `category` parameter only exists on `midnight-search-docs`. Passing it to `midnight-search-compact` has no effect or may cause an error.
+
+**Instead:** Check which parameters belong to which tool. `category` is for docs, `filter.repository` is for compact, `includeTypes` is for TypeScript.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/query-refinement.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/query-refinement.md
@@ -1,0 +1,112 @@
+# Query Refinement Examples
+
+## When to Apply
+
+When results are too broad (many results, none specific enough) or too narrow (few or no results).
+
+## Examples
+
+### Too Broad — Narrowing State Management
+
+**Before:**
+```
+Query: "state management"
+→ 50+ results about everything: Counter, Map, ledger, configuration, SDK state
+None specific enough to answer the actual question about Counter state patterns
+```
+
+**After:**
+```
+Refined query: "Counter Map ledger state Compact circuit"
+→ 8 focused results about Compact state types and patterns
+```
+
+**Why:** "State management" is too generic. Adding Compact-specific type names (`Counter`, `Map`) and constructs (`ledger`, `circuit`) narrows results to the relevant domain.
+
+### Too Narrow — Broadening MerkleTree Query
+
+**Before:**
+```
+Query: "MerkleTree<Bytes<32>, 16> insert"
+→ 0 results — the exact generic parameters are too specific
+```
+
+**After:**
+```
+Refined query: "MerkleTree insert member"
+→ 6 results showing MerkleTree insertion patterns with various type parameters
+```
+
+**Why:** The exact generic signature `MerkleTree<Bytes<32>, 16>` is too specific for the search index. Removing the type parameters while keeping the operation names matches more broadly.
+
+### Wrong Tool — Switching from Compact to TypeScript
+
+**Before:**
+```
+Query: "Provider setup configuration" on midnight-search-compact
+→ Results about Compact code, none about TypeScript Provider setup
+```
+
+**After:**
+```
+Switch tool: midnight-search-typescript
+Refined query: "MidnightProvider setup configuration connect"
+→ Results showing TypeScript Provider initialization patterns
+```
+
+**Why:** The `Provider` and `MidnightProvider` types are TypeScript SDK concepts, not Compact constructs. The wrong tool was selected. Switching to `midnight-search-typescript` and using the correct type name fixes the problem.
+
+### Wrong Results — Rethinking the Approach
+
+**Before:**
+```
+Query: "privacy" on midnight-search-compact
+→ Results about various privacy-related code, none about the user's specific question on disclose behavior
+```
+
+**After:**
+```
+Rethought approach:
+Query: "disclose public ledger state visibility" on midnight-search-compact
+→ Results specifically about the disclose construct and state visibility
+```
+
+**Why:** "Privacy" is too abstract. The user's actual question is about the `disclose` construct. Using the specific construct name and related terms produces targeted results.
+
+## Anti-Patterns
+
+### Adding Random Terms to Narrow a Broad Search
+
+**Wrong:**
+```
+"state management" → "state management blue fast important"
+```
+
+**Problem:** Random adjectives do not narrow the search meaningfully. They may match nothing or match irrelevant content.
+
+**Instead:** Add terms that relate to what was missing from the results. If results were too broad about state, add the specific state type (`Counter`, `Map`) or construct (`ledger`).
+
+### Removing All Specific Terms When Broadening
+
+**Wrong:**
+```
+"MerkleTree<Bytes<32>, 16> insert" → "data structure"
+```
+
+**Problem:** Removing all specific terms broadens the search too far. "Data structure" matches everything and returns no useful results for MerkleTree.
+
+**Instead:** Remove the overly specific parts (generic type parameters) while keeping the core concept: `MerkleTree insert`.
+
+### Refining More Than Twice Without Rethinking
+
+**Wrong:**
+```
+Round 1: "Counter decrement" → no results
+Round 2: "Counter subtract" → no results
+Round 3: "Counter minus" → no results
+Round 4: "Counter reduce" → no results
+```
+
+**Problem:** Four refinement attempts on the same concept suggests the information does not exist in the index with any of these terms. Continuing to try synonyms is unproductive.
+
+**Instead:** After 2 failed refinements, rethink the approach entirely. Try a step-back query (`Counter operations`), switch tools (`midnight-search-docs`), or inform the user that the feature may not exist.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/query-rewriting.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/query-rewriting.md
@@ -1,0 +1,100 @@
+# Query Rewriting Examples
+
+## When to Apply
+
+Always, as a first pass before calling any MCP search tool.
+
+## Examples
+
+### Finding a Token Minting Pattern
+
+**Before:**
+```
+how do I make a token that only the owner can mint
+```
+
+**After:**
+```
+mint access control owner witness shielded token
+```
+
+**Why:** Stripped filler words ("how do I make"), replaced natural language with Compact-specific terms (`witness`, `shielded`), and added the construct name (`access control`).
+
+### Searching for Zero Knowledge Proof Costs
+
+**Before:**
+```
+ZKP costs for merkle proofs
+```
+
+**After:**
+```
+Zero Knowledge Proof (ZKP) circuit cost MerkleTree
+```
+
+**Why:** Expanded "ZKP" (genuinely written both ways in docs) and normalized `merkle proofs` to the Compact type name `MerkleTree`.
+
+### Looking Up Compact State Management
+
+**Before:**
+```
+what is the best way to handle state in Compact
+```
+
+**After:**
+```
+Compact ledger state management Counter Map Set
+```
+
+**Why:** Stripped filler ("what is the best way to"), added specific state types (`Counter`, `Map`, `Set`) and the core construct (`ledger`).
+
+### Fixing Typos and Terminology
+
+**Before:**
+```
+midnite compact smart contract deploy
+```
+
+**After:**
+```
+Midnight Compact contract deployment
+```
+
+**Why:** Fixed the typo "midnite" to "Midnight" and normalized to standard terminology.
+
+## Anti-Patterns
+
+### Expanding Terms That Are Already Standard
+
+**Wrong:**
+```
+"DApp" → "decentralized application"
+"DUST" → "Digital Utility Settlement Token"
+"tDUST" → "test Digital Utility Settlement Token"
+```
+
+**Problem:** DUST, tDUST, and DApp are standard forms in Midnight documentation and code. Expanding them produces terms that do not appear in the index, reducing search recall.
+
+**Instead:** Keep DUST, tDUST, and DApp as-is. Only expand shorthand that genuinely appears in both forms (e.g., ZKP).
+
+### Passing Raw Natural Language to MCP Tools
+
+**Wrong:**
+```
+midnight-search-compact query: "how do I create a contract that stores a list of approved addresses?"
+```
+
+**Problem:** Natural language queries produce poor results against code indexes. The search engine matches keywords, not intent.
+
+**Instead:** Extract the key concepts and rewrite: `approved addresses access control list Set Map ledger`
+
+### Over-Expanding Into Generic Terms
+
+**Wrong:**
+```
+"token transfer" → "cryptocurrency digital asset movement blockchain transaction"
+```
+
+**Problem:** Generic programming and blockchain terms dilute the query. The MCP index contains Midnight-specific content — generic terms match too broadly or not at all.
+
+**Instead:** Use Midnight-specific terms: `token transfer shielded circuit DUST`

--- a/plugins/midnight-mcp/skills/mcp-search/examples/relevance-reranking.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/relevance-reranking.md
@@ -1,0 +1,106 @@
+# Relevance Reranking Examples
+
+## When to Apply
+
+Always, as a first pass on results from any MCP search tool.
+
+## Examples
+
+### Filtering Tangential Results for Shielded Transfer
+
+**Before:**
+```
+Query: "token transfer shielded"
+Results:
+  1. Shielded transfer circuit implementation (score: 0.72) — full transfer circuit
+  2. Generic Counter example mentioning "transfer" in a comment (score: 0.41) — irrelevant
+  3. Test file importing the transfer module (score: 0.38) — marginally relevant
+```
+
+**After:**
+```
+Reranked:
+  1. Shielded transfer circuit implementation — directly answers the question
+  2. Test file importing the transfer module — shows usage context
+  Dropped: Generic Counter example — mentions "transfer" but is about Counter operations
+```
+
+**Why:** The Counter example matched the keyword "transfer" but is about Counter increment/decrement, not token transfers. Reranking by intent (not just keyword match) correctly identifies it as irrelevant.
+
+### Correcting Misleading Relevance Scores
+
+**Before:**
+```
+Query: "deploy contract provider"
+Results:
+  1. Deployment guide for Midnight DApps (score: 0.71) — comprehensive tutorial
+  2. Provider type definition in SDK (score: 0.52) — partial match
+  3. Indexer configuration mentioning "provider" (score: 0.25) — wrong context
+```
+
+**After:**
+```
+Reranked:
+  1. Deployment guide — directly addresses the question
+  2. Provider type definition — useful supplementary information
+  Dropped: Indexer configuration — "provider" here means indexer provider, not deployment provider
+```
+
+**Why:** The indexer result scored 0.25 and uses "provider" in a different context. Relevance reranking identifies this as a false positive from keyword overlap.
+
+### High Score But Wrong Context
+
+**Before:**
+```
+Query: "witness function parameter types"
+Results:
+  1. Documentation page about witness construct (score: 0.68) — explains concept
+  2. Compact code with witness accepting Field parameter (score: 0.65) — code example
+  3. TypeScript test file with "witness" variable name (score: 0.55) — wrong domain
+```
+
+**After:**
+```
+Reranked:
+  1. Compact code with witness accepting Field parameter — shows exactly what was asked
+  2. Documentation page about witness construct — provides context
+  Dropped: TypeScript test file — "witness" is a variable name, not a Compact construct
+```
+
+**Why:** The TypeScript result scored well because it contained the word "witness," but it uses "witness" as a generic variable name, not the Compact language construct.
+
+## Anti-Patterns
+
+### Accepting Results Based on relevanceScore Alone
+
+**Wrong:**
+```
+Score > 0.5 → include
+Score < 0.5 → exclude
+```
+
+**Problem:** `relevanceScore` measures keyword/vector similarity, not semantic relevance to the question. A result about "Counter transfer" may score high for a "token transfer" query despite being about transferring Counter ownership, not token transfers.
+
+**Instead:** Use `relevanceScore` as a first filter, then manually assess each remaining result against the original intent.
+
+### Dropping Results Below an Arbitrary Threshold
+
+**Wrong:**
+```
+Drop all results with score < 0.4 without reading them
+```
+
+**Problem:** Some legitimate results score low due to terminology mismatch. A result about `shielded send` may score low for a "token transfer" query but be exactly what the user needs.
+
+**Instead:** Read low-scoring results briefly before dropping them. A quick check of the title or first line reveals whether the low score is a false negative.
+
+### Reranking by Result Length
+
+**Wrong:**
+```
+Prefer longer results because they seem more comprehensive
+```
+
+**Problem:** Length does not correlate with relevance. A 50-line file that happens to contain boilerplate may be less useful than a 10-line snippet that shows exactly the right pattern.
+
+**Instead:** Rank by how directly the result answers the question, regardless of length.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/retrieve-read-retrieve.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/retrieve-read-retrieve.md
@@ -1,0 +1,101 @@
+# Retrieve-Read-Retrieve Examples
+
+## When to Apply
+
+When initial results partially answer the question but leave gaps, or when reading results reveals a dimension that the original query missed.
+
+## Examples
+
+### Token Transfer Missing Witness Implementation
+
+**Before:**
+```
+First search: "token transfer" on midnight-search-compact
+→ Returns the transfer circuit but not the witness implementation
+Gap: how the off-chain witness authorizes the transfer is not shown
+```
+
+**After:**
+```
+Follow-up search: "token transfer witness TypeScript authorization" on midnight-search-typescript
+→ Returns the TypeScript-side witness implementation that pairs with the circuit
+Combined: circuit (from first search) + witness (from follow-up) = complete pattern
+```
+
+**Why:** Reading the initial results revealed that the circuit calls a witness function, but the witness implementation lives in TypeScript. The follow-up targets that specific gap.
+
+### MerkleTree Usage Missing Capacity Limits
+
+**Before:**
+```
+First search: "MerkleTree usage example" on midnight-search-compact
+→ Returns insertion and membership check examples
+Gap: no information about depth limits or maximum capacity
+```
+
+**After:**
+```
+Follow-up search: "MerkleTree depth limit capacity maximum" on midnight-search-docs
+→ Returns documentation about MerkleTree depth constraints
+Combined: usage examples + capacity limits = complete understanding
+```
+
+**Why:** The code examples show how to use MerkleTree but not its limitations. The follow-up targets documentation that covers depth and capacity constraints.
+
+### Deployment Returns Docs But No Code
+
+**Before:**
+```
+First search: "deploy contract Midnight" on midnight-search-docs
+→ Returns conceptual deployment documentation but no runnable code
+Gap: actual TypeScript deployment code is missing
+```
+
+**After:**
+```
+Follow-up search: "deploy contract provider code example" on midnight-search-typescript
+→ Returns TypeScript deployment implementations
+Combined: conceptual overview + runnable code = actionable answer
+```
+
+**Why:** Documentation explains the deployment concepts but does not include TypeScript code. The follow-up targets the TypeScript index for actual implementation code.
+
+## Anti-Patterns
+
+### Repeating the Same Query
+
+**Wrong:**
+```
+First search: "Counter overflow" → 2 results, neither addresses overflow
+Follow-up: "Counter overflow" → same 2 results
+```
+
+**Problem:** Repeating the same query against the same tool always returns the same results. The follow-up must target different content or use a different tool.
+
+**Instead:** Reformulate the follow-up: try different terms (`Counter limit maximum value`), a different tool (`midnight-search-docs` instead of `midnight-search-compact`), or a step-back query.
+
+### Doing Follow-Up Searches When Results Are Sufficient
+
+**Wrong:**
+```
+First search returns 5 highly relevant results that fully answer the question
+→ Do a follow-up "just to be thorough"
+```
+
+**Problem:** The follow-up wastes an API call and tokens when the initial results already provide a complete answer. More results do not mean a better answer.
+
+**Instead:** Assess result sufficiency before deciding on a follow-up. If the initial results cover the question, stop.
+
+### More Than Two Total Search Rounds
+
+**Wrong:**
+```
+Round 1: initial search → gaps found
+Round 2: follow-up → still gaps
+Round 3: another follow-up → still gaps
+Round 4: yet another follow-up
+```
+
+**Problem:** If two rounds of searching do not produce the information, it is likely not in the index. Additional rounds produce diminishing returns and consume excessive API calls.
+
+**Instead:** Limit to two total rounds (initial + one follow-up). If the information is still missing, inform the user and suggest alternative approaches (checking source code directly, asking on community channels).

--- a/plugins/midnight-mcp/skills/mcp-search/examples/source-routing.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/source-routing.md
@@ -1,0 +1,112 @@
+# Source Routing Examples
+
+## When to Apply
+
+After intent classification, to select the specific MCP tool based on the detected entities and context.
+
+## Examples
+
+### Compact Type Entities Detected
+
+**Before:**
+```
+User query mentions: Counter, MerkleTree, circuit, witness
+→ No routing decision made
+```
+
+**After:**
+```
+Detected entities: Counter (Compact type), MerkleTree (Compact type), circuit (Compact construct), witness (Compact construct)
+→ Route to: midnight-search-compact
+Query: "Counter MerkleTree circuit witness usage"
+```
+
+**Why:** All detected entities are Compact language constructs. These exist in the Compact code index, not in TypeScript SDK or documentation search.
+
+### TypeScript SDK Entities Detected
+
+**Before:**
+```
+User query mentions: @midnight-ntwrk/midnight-js-contracts, Provider, ContractAddress
+→ No routing decision made
+```
+
+**After:**
+```
+Detected entities: @midnight-ntwrk/midnight-js-contracts (npm package), Provider (TypeScript type), ContractAddress (TypeScript type)
+→ Route to: midnight-search-typescript
+Query: "midnight-js-contracts Provider ContractAddress"
+```
+
+**Why:** npm package names and TypeScript SDK types signal a TypeScript question. The TypeScript index contains SDK code and type definitions.
+
+### Conceptual Keywords Detected
+
+**Before:**
+```
+User query: "overview of how Midnight achieves data protection"
+→ Default to midnight-search-compact
+```
+
+**After:**
+```
+Detected signals: "overview", "how...achieves", conceptual framing
+→ Route to: midnight-search-docs
+Query: "Midnight data protection privacy architecture"
+```
+
+**Why:** Conceptual framing words ("overview", "how does X work", "architecture of") indicate the user wants explanations, not code. Documentation provides this.
+
+### Known Documentation Path
+
+**Before:**
+```
+User query: "show me the compact language reference page"
+→ Search for "compact language reference" across tools
+```
+
+**After:**
+```
+Known path: /compact/reference
+→ Route to: midnight-fetch-docs with path: "/compact/reference"
+```
+
+**Why:** When the user requests a specific documentation page, fetching it directly is faster and returns complete content instead of search snippets.
+
+## Anti-Patterns
+
+### Routing Based on Keywords Alone
+
+**Wrong:**
+```
+User mentions "TypeScript" in: "how does Compact generate TypeScript types?"
+→ Route to midnight-search-typescript
+```
+
+**Problem:** The question is about Compact's type generation feature, not about TypeScript SDK usage. The word "TypeScript" is part of the question, not a routing signal.
+
+**Instead:** Check entity types, not just keyword presence. The core entity here is Compact's type generation — route to `midnight-search-compact` or `midnight-search-docs`.
+
+### Always Routing to the Same Tool
+
+**Wrong:**
+```
+All queries → midnight-search-compact (because the user is a developer)
+```
+
+**Problem:** Compact code search is only one of four tools. SDK questions need TypeScript search, conceptual questions need docs search, known pages need fetch.
+
+**Instead:** Classify intent and extract entities before routing. Different questions need different tools.
+
+### Routing to Fetch Without Knowing the Path
+
+**Wrong:**
+```
+User asks: "what does the docs say about tokens?"
+→ Route to midnight-fetch-docs with path: "/token"
+→ 404 — the actual path is "/token/overview"
+```
+
+**Problem:** `midnight-fetch-docs` requires an exact path. Guessing the path leads to errors.
+
+**Instead:** Use `midnight-search-docs` first to discover the correct page path, then use `midnight-fetch-docs` to get the full content if needed.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/step-back-queries.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/step-back-queries.md
@@ -1,0 +1,109 @@
+# Step-Back Queries Examples
+
+## When to Apply
+
+When the specific question is too narrow to return results, or when background context would improve understanding of specific results.
+
+## Examples
+
+### Counter Decrement Support
+
+**Before:**
+```
+Specific query: "does Counter support decrement"
+→ Few or no results
+```
+
+**After:**
+```
+Step-back query: "Counter type operations increment value"
+Specific query: "Counter decrement subtract"
+```
+
+**Why:** "Counter decrement" is too narrow — the index may not contain that exact phrase. Stepping back to "Counter type operations" retrieves the full Counter API documentation, which reveals whether decrement exists.
+
+### MerkleTree Overflow at Depth 32
+
+**Before:**
+```
+Specific query: "MerkleTree overflow at depth 32"
+→ No results
+```
+
+**After:**
+```
+Step-back query: "MerkleTree depth capacity limits"
+Specific query: "MerkleTree depth 32 maximum"
+```
+
+**Why:** The exact phrasing "overflow at depth 32" may not appear anywhere. The step-back query finds documentation about MerkleTree depth limits in general, which will cover the capacity question.
+
+### Concurrent Counter Modification
+
+**Before:**
+```
+Specific query: "what happens when two transactions modify the same Counter"
+→ Few results
+```
+
+**After:**
+```
+Step-back query: "Compact concurrency ledger contention transaction conflict"
+Specific query: "Counter concurrent modification race"
+```
+
+**Why:** The specific question is about a nuanced scenario. The step-back query retrieves Compact's general concurrency model, providing context for understanding how Counter modifications interact.
+
+### Witness Parameter Validation
+
+**Before:**
+```
+Specific query: "how to validate witness parameters at circuit boundaries"
+→ No results
+```
+
+**After:**
+```
+Step-back query: "witness function circuit parameter Compact"
+Specific query: "witness validation assert circuit boundary"
+```
+
+**Why:** "Circuit boundaries" is an abstract concept. Stepping back to general witness/circuit documentation reveals how parameter validation is actually structured in Compact.
+
+## Anti-Patterns
+
+### Stepping Back Too Far
+
+**Wrong:**
+```
+Original: "MerkleTree insert"
+Step-back: "Compact programming"
+```
+
+**Problem:** "Compact programming" is so broad it returns everything and nothing useful. The step-back query should still be within the relevant domain — one level of abstraction up, not five.
+
+**Instead:** Step back to `MerkleTree operations` or `MerkleTree type usage Compact`.
+
+### Using Step-Back When the Original Query Works
+
+**Wrong:**
+```
+Original: "Counter increment" → returns 8 relevant results
+Step-back: "Counter type operations" → returns similar results
+```
+
+**Problem:** The original query already returns good results. The step-back search adds latency and token cost without new information.
+
+**Instead:** Only use step-back when the original query returns few or no results, or when you specifically need broader context.
+
+### Returning Only Step-Back Results
+
+**Wrong:**
+```
+Step-back: "ledger state types" → returns overview docs
+→ Present these results without trying the specific query
+```
+
+**Problem:** Step-back results provide context but may not answer the specific question. The user asked about a particular scenario, not for a general overview.
+
+**Instead:** Always run both the step-back and the specific query. Use step-back results for context, specific results for the direct answer.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/symbol-aware-search.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/symbol-aware-search.md
@@ -1,0 +1,119 @@
+# Symbol-Aware Search Examples
+
+## When to Apply
+
+When the query targets a specific named symbol — a type, function, module, circuit, or constructor.
+
+## Examples
+
+### Detecting MerkleTree from Natural Language
+
+**Before:**
+```
+User asks: "how to use merkle trees"
+Search: "merkle trees usage"
+→ Poor results — index uses "MerkleTree" not "merkle trees"
+```
+
+**After:**
+```
+Detected symbol: MerkleTree (Compact standard library type)
+Search: "MerkleTree insert member proof"
+→ Results with exact MerkleTree API usage
+```
+
+**Why:** The search index contains the exact symbol name `MerkleTree`. Using the normalized form matches indexed content directly.
+
+### Detecting Standard Library Functions
+
+**Before:**
+```
+User asks: "what's the hash function in Compact"
+Search: "hash function Compact"
+→ Broad results about hashing concepts
+```
+
+**After:**
+```
+Detected symbols: persistentHash, persistentCommit (Compact stdlib functions)
+Search: "persistentHash persistentCommit usage"
+→ Results showing actual stdlib hash function usage
+```
+
+**Why:** Compact has specific named hash functions (`persistentHash`, `persistentCommit`). Using the exact function names targets real implementations instead of generic hashing discussions.
+
+### Detecting TypeScript SDK Symbol
+
+**Before:**
+```
+User asks: "how to check contract address"
+Search: "check contract address"
+→ Mixed results about addresses generally
+```
+
+**After:**
+```
+Detected symbol: ContractAddress (TypeScript SDK type)
+Route to: midnight-search-typescript
+Search: "ContractAddress type deployed contract"
+→ Results showing ContractAddress TypeScript type usage
+```
+
+**Why:** `ContractAddress` is a specific TypeScript SDK type. Using the exact type name and routing to the TypeScript search tool produces focused results.
+
+### Detecting Optional Type
+
+**Before:**
+```
+User mentions: "the optional type in Compact"
+Search: "optional type Compact"
+→ Results about optional parameters generally
+```
+
+**After:**
+```
+Detected symbol: Optional (Compact standard library type)
+Search: "Optional value unwrap Compact type"
+→ Results showing Optional type usage with unwrap patterns
+```
+
+**Why:** `Optional` is a specific Compact type with methods like unwrap. Using the exact type name distinguishes it from the generic concept of "optional."
+
+## Anti-Patterns
+
+### Paraphrasing Symbol Names
+
+**Wrong:**
+```
+User asks about MerkleTree
+Search: "tree data structure hash verification"
+```
+
+**Problem:** Paraphrasing `MerkleTree` as "tree data structure" loses the specific symbol name. The index contains `MerkleTree`, not "tree data structure." Paraphrased terms match too broadly.
+
+**Instead:** Use exact symbol names: `MerkleTree`, `Counter`, `persistentHash`. These are the terms that appear in indexed code.
+
+### Searching for a Symbol Without Context
+
+**Wrong:**
+```
+Search: "Map"
+→ Matches everything — too generic
+```
+
+**Problem:** `Map` is both a Compact type and a common programming term. Without context, the search returns results from many unrelated domains.
+
+**Instead:** Add context: `Map Compact ledger state key value` to narrow to Compact-specific Map usage.
+
+### Assuming a Symbol Exists Without Verification
+
+**Wrong:**
+```
+User asks: "how to use MerkleTree.verifyProof()"
+Search: "MerkleTree verifyProof"
+→ No results — function name may not exist
+```
+
+**Problem:** The user may have assumed a function name that does not exist in Compact's standard library. Searching for a non-existent name wastes a call.
+
+**Instead:** Cross-reference with `compact-core:compact-standard-library` to verify the function exists. The actual function may be `member` rather than `verifyProof`.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/trust-aware-reranking.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/trust-aware-reranking.md
@@ -1,0 +1,101 @@
+# Trust-Aware Reranking Examples
+
+## When to Apply
+
+When result reliability matters — production code, security-sensitive patterns, or when results come from mixed sources.
+
+## Examples
+
+### Preferring Official Token Transfer Implementation
+
+**Before:**
+```
+Results:
+  1. Token transfer from community/midnight-demo (score: 0.73)
+  2. Token transfer from midnightntwrk/examples (score: 0.68)
+→ Presented in score order
+```
+
+**After:**
+```
+Reranked by trust:
+  1. Token transfer from midnightntwrk/examples — official Foundation code
+  2. Token transfer from community/midnight-demo — community implementation (note: verify independently)
+```
+
+**Why:** The `midnightntwrk` version is maintained by the Midnight Foundation. Despite the slightly lower relevance score, it is the more reliable source for production use.
+
+### Preferring Audited Access Control
+
+**Before:**
+```
+Results:
+  1. Custom access control from user/my-compact-project (score: 0.65)
+  2. Ownable module from OpenZeppelin/compact-contracts (score: 0.60)
+→ Presented in score order
+```
+
+**After:**
+```
+Reranked by trust:
+  1. Ownable module from OpenZeppelin/compact-contracts — audited library
+  2. Custom access control from user/my-compact-project — unaudited (note: may contain security issues)
+```
+
+**Why:** OpenZeppelin's `Ownable` module is professionally audited. The community implementation may work but has not been reviewed for security vulnerabilities.
+
+### TypeScript Results with Mixed Sources
+
+**Before:**
+```
+midnight-search-typescript results (no server-side filter):
+  1. Provider setup from community/midnight-starter (score: 0.71)
+  2. Provider setup from midnightntwrk/midnight-js (score: 0.66)
+  3. Provider wrapper from user/my-dapp (score: 0.58)
+```
+
+**After:**
+```
+Reranked by trust:
+  1. Provider setup from midnightntwrk/midnight-js — official SDK code
+  2. Provider setup from community/midnight-starter — community, check against official
+  3. Provider wrapper from user/my-dapp — personal project, lowest trust
+```
+
+**Why:** `midnight-search-typescript` has no server-side `filter.repository`. Client-side trust-aware reranking is the only way to prioritize official sources in TypeScript search results.
+
+## Anti-Patterns
+
+### Rejecting All Community Code
+
+**Wrong:**
+```
+Source is not midnightntwrk, OpenZeppelin, or LFDT-Minokawa → discard
+```
+
+**Problem:** Community code may be the only available implementation of a niche pattern. Rejecting it entirely means returning no results when the user needs something that official repos do not cover.
+
+**Instead:** Rank community code lower, but include it with a note about verification. Some patterns only exist in community projects.
+
+### Trusting All midnightntwrk Code Equally
+
+**Wrong:**
+```
+Source is midnightntwrk → fully trust, no further checks
+```
+
+**Problem:** The `midnightntwrk` organization has many repositories. Some contain outdated examples from earlier SDK versions, experimental code, or deprecated patterns. Trust the organization but verify currency.
+
+**Instead:** Apply trust ranking for source quality, then check recency. An official but outdated example from SDK v1 should not be presented as current guidance for SDK v2.
+
+### Applying Trust Reranking When Broad Results Are Requested
+
+**Wrong:**
+```
+User asks: "show me all the different voting implementations out there"
+→ Filter to trusted sources only
+```
+
+**Problem:** The user explicitly wants breadth and diversity. Applying trust filtering contradicts their request and limits the result set unnecessarily.
+
+**Instead:** When the user asks for broad or diverse results, present all sources with trust labels rather than filtering.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/trusted-source-filtering.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/trusted-source-filtering.md
@@ -1,0 +1,115 @@
+# Trusted-Source Filtering Examples
+
+## When to Apply
+
+When result reliability matters more than breadth — production code, security-sensitive patterns, official examples.
+
+## Examples
+
+### Production Token Transfer Pattern
+
+**Before:**
+```
+User needs: production-ready token transfer pattern
+Search: midnight-search-compact query: "token transfer shielded"
+→ Results include community forks, experimental code, and official examples
+```
+
+**After:**
+```
+Search: midnight-search-compact
+  query: "token transfer shielded"
+  filter.repository: "midnightntwrk" (or "OpenZeppelin")
+→ Results restricted to official Foundation and audited sources
+```
+
+**Why:** For production code, community implementations may contain bugs or use deprecated patterns. Restricting to `midnightntwrk` and `OpenZeppelin` ensures results come from maintained, reviewed sources.
+
+### Broad Exploration Without Filtering
+
+**Before:**
+```
+User wants: "show me how anyone has implemented voting in Compact"
+→ Apply trusted-source filter by default
+```
+
+**After:**
+```
+Search: midnight-search-compact
+  query: "voting ballot tally circuit"
+  (no filter.repository — broad search)
+→ Results include Foundation, community, and experimental implementations
+```
+
+**Why:** The user explicitly wants to see diverse implementations. Filtering to trusted-only would miss creative community approaches that may be useful for inspiration.
+
+### TypeScript SDK Trust-Aware Reranking
+
+**Before:**
+```
+User needs: reliable SDK integration pattern
+Search: midnight-search-typescript query: "contract deployment provider"
+  filter.repository: "midnightntwrk" ← WRONG: parameter does not exist on this tool
+```
+
+**After:**
+```
+Search: midnight-search-typescript query: "contract deployment provider"
+  (no filter parameter — not supported on this tool)
+→ After retrieval: apply trust-aware reranking to boost midnightntwrk results
+```
+
+**Why:** `midnight-search-typescript` does not support `filter.repository`. Trust filtering for TypeScript results must be done client-side by checking `source.repository` in the response and reranking results from trusted organizations higher.
+
+### Audited Code Request
+
+**Before:**
+```
+User asks: "find me audited access control code"
+Search: midnight-search-compact query: "access control audited"
+```
+
+**After:**
+```
+Search: midnight-search-compact
+  query: "access control Ownable owner"
+  filter.repository: "OpenZeppelin"
+→ Results restricted to OpenZeppelin's audited libraries
+```
+
+**Why:** "Audited" is a trust facet, not a search keyword. OpenZeppelin provides audited Compact libraries. Filtering to their repos and using their module names (`Ownable`) directly targets what the user needs.
+
+## Anti-Patterns
+
+### Passing filter.repository to midnight-search-typescript
+
+**Wrong:**
+```
+midnight-search-typescript with filter.repository: "midnightntwrk"
+```
+
+**Problem:** The `filter.repository` parameter does not exist on `midnight-search-typescript`. The call may fail or the parameter will be silently ignored.
+
+**Instead:** For TypeScript results, retrieve without filtering, then apply trust-aware reranking client-side by checking `source.repository` in each result.
+
+### Always Filtering to Trusted-Only
+
+**Wrong:**
+```
+Every search: filter.repository: "midnightntwrk"
+```
+
+**Problem:** This misses useful community examples, creative implementations, and third-party libraries that may be the only source for niche patterns. Some valid patterns appear only in community code.
+
+**Instead:** Use trusted-source filtering when reliability is critical (production code, security). Use broad search when exploring or when the pattern is niche.
+
+### Treating All midnightntwrk Code as Equally Current
+
+**Wrong:**
+```
+Result from midnightntwrk/old-examples-repo → trust it fully
+```
+
+**Problem:** Not all `midnightntwrk` repositories are actively maintained. Some contain outdated examples from earlier SDK or language versions. The trust hierarchy ranks source quality, not currency.
+
+**Instead:** Apply trust ranking for source quality, then apply freshness reranking for currency. A trusted but outdated result may need verification against current versions.

--- a/plugins/midnight-mcp/skills/mcp-search/examples/version-aware-search.md
+++ b/plugins/midnight-mcp/skills/mcp-search/examples/version-aware-search.md
@@ -1,0 +1,104 @@
+# Version-Aware Search Examples
+
+## When to Apply
+
+When the user's project targets a specific Compact language version or SDK version, and results from other versions could be misleading or incorrect.
+
+## Examples
+
+### Compact Language Version from Pragma
+
+**Before:**
+```
+Project has: pragma language_version 0.2.0;
+User asks: "how to declare a witness"
+Search: "witness declaration Compact"
+→ Returns results from multiple language versions, some with outdated syntax
+```
+
+**After:**
+```
+Search: "witness declaration Compact language_version 0.2.0"
+→ Bias toward results matching 0.2.0 syntax
+After retrieval: deprioritize results showing pre-0.2.0 witness syntax
+```
+
+**Why:** Witness declaration syntax may have changed between language versions. Including the version in the query and filtering results by version prevents the user from seeing outdated syntax.
+
+### SDK Version from package.json
+
+**Before:**
+```
+package.json: "@midnight-ntwrk/midnight-js-contracts": "^2.0.0"
+User asks: "how to deploy a contract"
+Search: "deploy contract provider" on midnight-search-typescript
+→ Returns results mixing SDK v1 and v2 patterns
+```
+
+**After:**
+```
+Search: "deploy contract provider v2" on midnight-search-typescript
+After retrieval: deprioritize results with v1 import paths
+  v1: import from "@midnight-ntwrk/compact-runtime" → deprioritize
+  v2: import from "@midnight-ntwrk/midnight-js-contracts" → boost
+```
+
+**Why:** SDK v1 and v2 have different import paths and API patterns. Showing v1 patterns to a v2 user leads to import errors and API mismatches.
+
+### Feature Availability by Version
+
+**Before:**
+```
+User asks: "does Compact support generics"
+Search: "generics Compact type parameters"
+→ Results from mixed versions, unclear which version added the feature
+```
+
+**After:**
+```
+Search: "generics Compact type parameters language_version"
+After retrieval: check version context of each result
+→ Note to user: "Generic support depends on the Compact language version. Results show generics in language_version 0.2.0+. Check your pragma language_version to confirm availability."
+```
+
+**Why:** Feature availability is version-dependent. Without version context, the user might try to use a feature not available in their project's language version.
+
+## Anti-Patterns
+
+### Ignoring Version Context
+
+**Wrong:**
+```
+Project uses Compact 0.28.x and SDK v2
+→ Search without any version context
+→ Present v1 patterns alongside v2 patterns
+```
+
+**Problem:** Mixing version results is confusing and may lead to incompatible code. Import paths, API signatures, and syntax change between major versions.
+
+**Instead:** Always check environmental context for version information. Include version terms in queries and filter results by version compatibility.
+
+### Being Overly Strict About Versions
+
+**Wrong:**
+```
+Project uses Compact 0.28.0
+→ Reject all results from 0.27.x and 0.28.1+
+```
+
+**Problem:** Minor version differences rarely change core patterns. A Counter usage pattern from 0.27.0 is almost certainly valid in 0.28.0. Being too strict eliminates useful results.
+
+**Instead:** Be strict about major version differences (v1 vs v2 SDK, 0.1.x vs 0.2.x language). Be lenient about patch versions within the same minor version.
+
+### Not Checking Environmental Context
+
+**Wrong:**
+```
+User asks about version-sensitive syntax
+→ Search without checking package.json or pragma language_version
+→ Present results from all versions
+```
+
+**Problem:** Without environmental context, you cannot filter results by version. The user may implement patterns from the wrong version.
+
+**Instead:** When version matters, check environmental context first. Read `package.json` and `*.compact` pragmas to determine the target version before searching.

--- a/plugins/midnight-mcp/skills/mcp-search/references/code-search.md
+++ b/plugins/midnight-mcp/skills/mcp-search/references/code-search.md
@@ -1,0 +1,45 @@
+# Code-Specific Search
+
+Techniques specifically for searching code patterns in Compact and TypeScript.
+
+## Symbol-Aware Search
+
+**When to apply:** When the query targets a specific named symbol — a type, function, module, circuit, or constructor.
+
+Detect symbol names in the query. Compact symbols include: `Counter`, `MerkleTree`, `Map`, `Set`, `Bytes`, `Uint`, `Field`, `Boolean`, `Void`, `Optional`, `Vector`, `persistentHash`, `persistentCommit`, `pad`, `merge`, `assert`. TypeScript symbols include: `ContractAddress`, `DeployedContract`, `MidnightProvider`, `WalletProvider`, `Transaction`, `NodeApiClient`.
+
+Use exact symbol names in queries — do not paraphrase (`Counter` not "counter variable", `MerkleTree` not "tree data structure"). For stdlib functions, cross-reference with `compact-core:compact-standard-library`.
+
+**Examples:** `examples/symbol-aware-search.md`
+
+## Error-to-Doc Search
+
+**When to apply:** When the user provides a compiler error, runtime error, or stack trace.
+
+Extract the distinctive parts of the error message — error codes, specific function names mentioned, type mismatch details. Strip the file-specific context (line numbers, file paths) that will not match in the index. Rewrite into a search query using the error's key terms. For Compact compiler errors, include both the error text and the likely cause terms. For TypeScript runtime errors, include the package name and error type.
+
+**Examples:** `examples/error-to-doc.md`
+
+## Example Mining
+
+**When to apply:** When the user needs runnable, complete code examples rather than documentation or partial snippets.
+
+Bias search queries toward finding complete implementations. Add terms like `example`, `contract`, `circuit export` for Compact code. For TypeScript, add `example`, `implementation`, `deploy`. Prefer results that include full file content over single-function snippets. Check `source.repository` — official example repos (`midnightntwrk/examples`, `midnightntwrk/midnight-examples`) are the richest source. The MCP tool `midnight-list-examples` (from `mcp-overview`) can also list available example contracts with complexity ratings.
+
+**Examples:** `examples/example-mining.md`
+
+## Version-Aware Search
+
+**When to apply:** When the user's project targets a specific Compact language version or SDK version, and results from other versions could be misleading or incorrect.
+
+Determine the target version from environmental grounding (Context Gathering cluster) or user context. Include version-specific terms in the query where relevant. After retrieval, check `source.repository` metadata for version indicators. Deprioritize results from significantly different versions. Be especially careful with import paths, API signatures, and syntax that changes between versions.
+
+**Examples:** `examples/version-aware-search.md`
+
+## Diff-Aware Search
+
+**When to apply:** When the user is in a PR review, migration, or refactoring context and the search should be informed by what is changing.
+
+Identify the files being changed (from git diff, open PR, or user description). Use the changed file paths, modified function names, and affected types as search context. For migrations, search for the specific constructs being migrated. For PR reviews, search for patterns that the PR is trying to implement to verify correctness.
+
+**Examples:** `examples/diff-aware-search.md`

--- a/plugins/midnight-mcp/skills/mcp-search/references/context-gathering.md
+++ b/plugins/midnight-mcp/skills/mcp-search/references/context-gathering.md
@@ -1,0 +1,55 @@
+# Context Gathering
+
+Techniques for enriching queries with information already available from the conversation or project environment.
+
+## Conversation Grounding
+
+**When to apply:** When prior conversation turns contain entity names, versions, file paths, contract names, or other specifics that the current query lacks.
+
+Scan recent conversation turns for Midnight-specific entities: contract names, type names, version numbers, file paths, package names. Inject the most relevant entities into the search query as additional terms. Do not add entities that would narrow the search inappropriately.
+
+**Examples:** `examples/conversation-grounding.md`
+
+## Environmental Grounding
+
+**When to apply:** When the user is working within a project that has Midnight dependencies or Compact source files, and the search would benefit from knowing the project's version context.
+
+Check these project files:
+- `package.json` — look for `@midnight-ntwrk/*` dependencies and their version ranges
+- `*.compact` files — look for `pragma language_version` declarations
+- Configuration files — look for network targets (devnet, testnet, mainnet), endpoint URLs
+- `node_modules/@midnight-ntwrk/*/package.json` — look for actual installed versions if `package.json` has ranges
+
+Inject the discovered version and network context as implicit constraints. For example, if the project uses `@midnight-ntwrk/midnight-js-contracts` version `2.x`, bias search results toward SDK v2 patterns.
+
+**Examples:** `examples/environmental-grounding.md`
+
+## Entity Extraction / Normalization
+
+**When to apply:** Always, as a pre-processing step before query construction.
+
+Scan the user's query for Midnight-specific entities:
+- Package names: `@midnight-ntwrk/compact`, `@midnight-ntwrk/midnight-js-contracts`, etc.
+- Type names: `Counter`, `MerkleTree`, `Map`, `Set`, `Bytes`, `Uint`, `Field`
+- Construct names: `circuit`, `witness`, `ledger`, `export`, `import`, `disclose`
+- Version strings: `0.28.0`, `v2`, `language_version 0.2.0`
+- Tool/component names: proof server, indexer, node, Compact CLI, Lace wallet
+
+Normalize detected entities: fix casing (`merkletree` to `MerkleTree`), resolve abbreviations only where written both ways, keep standard forms as-is.
+
+**Examples:** `examples/entity-extraction.md`
+
+## Facet Extraction
+
+**When to apply:** When the query implies constraints that should be used for tool selection or parameter filtering rather than as search terms.
+
+Extract implicit facets:
+- Language/domain: Compact code vs TypeScript SDK vs documentation
+- Version: specific version mentioned or implied
+- Source trust level: user asks for "official" or "audited" — use trusted sources
+- Content type: tutorial vs reference vs example code
+- Recency: "latest", "current", "new" — freshness matters
+
+Use extracted facets to inform tool selection (Tool Routing cluster) and result filtering (Result Refinement cluster). Do not include facets as literal search terms.
+
+**Examples:** `examples/facet-extraction.md`

--- a/plugins/midnight-mcp/skills/mcp-search/references/iterative-search.md
+++ b/plugins/midnight-mcp/skills/mcp-search/references/iterative-search.md
@@ -1,0 +1,42 @@
+# Iterative Search
+
+Techniques for refining when initial results are insufficient. These techniques trigger a second (or third) search pass.
+
+## Retrieve-Read-Retrieve
+
+**When to apply:** When initial results partially answer the question but leave gaps, or when reading results reveals that the question has a dimension that the original query missed.
+
+Read the initial results carefully. Identify what aspects of the question remain unanswered. Formulate a targeted follow-up query that specifically addresses the gap. Do NOT repeat the original query — the follow-up must target different content. Limit to one follow-up pass; if two rounds do not produce answers, the information may not be in the index.
+
+**Examples:** `examples/retrieve-read-retrieve.md`
+
+## Query Refinement
+
+**When to apply:** When results are too broad (many results, none specific enough) or too narrow (few or no results).
+
+- Too broad — add specificity: more Midnight-specific terms, type names, construct names
+- Too narrow — remove constraints: fewer terms, more general concepts, drop version-specific terms
+- Wrong results entirely — rethink the query approach, possibly switch tools or use a different technique from the Query Expansion cluster
+
+**Examples:** `examples/query-refinement.md`
+
+## Confidence Assessment
+
+**When to apply:** After every search, before presenting results to the user.
+
+Assess the result set:
+- **High confidence**: multiple results from trusted sources agree, covering the full question. Present results.
+- **Medium confidence**: some relevant results but gaps, or results from lower-trust sources. Note the gaps, consider a follow-up search.
+- **Low confidence**: few relevant results, conflicting information, or results that do not directly address the question. Do a follow-up search, try a different technique, or flag the uncertainty to the user.
+
+This is about search sufficiency, not result trustworthiness (which belongs to `compact-core:verify-correctness`).
+
+**Examples:** `examples/confidence-assessment.md`
+
+## Contradiction Detection
+
+**When to apply:** When multiple search results provide conflicting information about the same topic.
+
+When results disagree (different function signatures, different behaviors described, different recommendations), do NOT silently pick one. Flag both results to the user with their sources. Note which source is more authoritative (trust hierarchy) and more recent (freshness). If the contradiction might be due to version differences, note the versions. Let the user or the verification skill resolve the conflict.
+
+**Examples:** `examples/contradiction-detection.md`

--- a/plugins/midnight-mcp/skills/mcp-search/references/query-expansion.md
+++ b/plugins/midnight-mcp/skills/mcp-search/references/query-expansion.md
@@ -1,0 +1,43 @@
+# Query Expansion
+
+Techniques for turning raw intent into better search input. Apply these before calling MCP search tools.
+
+## Query Rewriting
+
+**When to apply:** Always, as a first pass on any search query.
+
+Rewrite natural language into keyword-rich queries using Midnight-specific terms. Expand shorthand only where genuinely written both ways (e.g., "ZKP" becomes "Zero Knowledge Proof (ZKP)"). Do NOT expand DUST, tDUST, DApp, or other terms that are standard as-is. Fix obvious typos. Strip filler words ("how do I", "what is the best way to").
+
+**Examples:** `examples/query-rewriting.md`
+
+## Multi-Query Generation
+
+**When to apply:** When a single query is unlikely to capture all relevant results — ambiguous terms, multiple synonyms, broad topics.
+
+Generate 2-3 semantically different queries from the same intent. Each query should target different terminology that might appear in the indexed content. Run all queries against the same tool. Combine and deduplicate results.
+
+**Examples:** `examples/multi-query.md`
+
+## Step-Back Queries
+
+**When to apply:** When the specific question is too narrow to return results, or when background context would improve understanding of specific results.
+
+Generate a more abstract version of the question. Search for the abstract version first or alongside the specific query. The step-back result provides context; the specific query provides the direct answer.
+
+**Examples:** `examples/step-back-queries.md`
+
+## HyDE (Pseudo-Answer Generation)
+
+**When to apply:** When the query is conceptual and hard to reduce to keywords, or when you know roughly what the answer should look like but need to find real examples.
+
+Generate a short hypothetical answer — a Compact code snippet or documentation paragraph that would answer the question if it existed. Extract the distinctive terms and structure from that hypothetical. Use those terms as the search query. Do NOT present the hypothetical answer to the user — it is a search aid only.
+
+**Examples:** `examples/hyde.md`
+
+## Decomposition
+
+**When to apply:** When the question involves multiple independent concerns that should be searched separately.
+
+Identify the distinct sub-questions. Search each independently. Combine results. This is better than a single broad query because each sub-question gets targeted results rather than diluted matches.
+
+**Examples:** `examples/decomposition.md`

--- a/plugins/midnight-mcp/skills/mcp-search/references/result-refinement.md
+++ b/plugins/midnight-mcp/skills/mcp-search/references/result-refinement.md
@@ -1,0 +1,57 @@
+# Result Refinement
+
+Techniques for processing results after retrieval. All techniques operate on the result set returned by MCP tools — they are client-side reasoning performed on the response.
+
+## Relevance Reranking
+
+**When to apply:** Always, as a first pass on results.
+
+Re-evaluate each result against the original intent, not just the search query. A result may match query keywords but not address the actual question. Check `relevanceScore` in the response — scores below 0.3 are often tangentially related. Mentally reorder results by how directly they answer the question. Discard results that are clearly irrelevant even if their score is moderate.
+
+**Examples:** `examples/relevance-reranking.md`
+
+## Trust-Aware Reranking
+
+**When to apply:** When result reliability matters — production code, security-sensitive patterns, or when results come from mixed sources.
+
+Check `source.repository` in each result. Apply this trust hierarchy:
+- Highest: `midnightntwrk` official repos (compiler, SDK, examples)
+- High: `OpenZeppelin` audited libraries
+- Medium: `LFDT-Minokawa` infrastructure
+- Lower: community and third-party code
+
+Boost results from higher-trust sources. When two results provide similar information, prefer the higher-trust source. This is especially important for `midnight-search-typescript` results where server-side filtering is unavailable.
+
+**Examples:** `examples/trust-aware-reranking.md`
+
+## Freshness Reranking
+
+**When to apply:** When the query is time-sensitive — version-specific questions, migration guidance, recent changes, or when the user says "latest" or "current."
+
+Check date metadata in results where available. Prefer results from more recent sources when recency matters. Be cautious: in a blockchain context, older audited code may be more reliable than newer unaudited code. Freshness should boost, not override, trust rankings.
+
+**Examples:** `examples/freshness-reranking.md`
+
+## Deduplication
+
+**When to apply:** When results contain near-identical content from the same or forked repos. Common when searching broad topics.
+
+Identify results that contain substantially the same code or text. Keep the result from the most authoritative source. Collapse duplicates into a single entry, noting that alternatives exist. Watch for fork-induced duplication — the same contract may appear in multiple repos.
+
+**Examples:** `examples/deduplication.md`
+
+## Coverage Balancing
+
+**When to apply:** When the query has multiple facets or sub-topics, and results cluster around only one facet.
+
+Check whether the results cover the different parts of the question. If 8 of 10 results address facet A and 0 address facet B, the result set is imbalanced. Consider a follow-up search targeted at the underrepresented facet. When presenting results, organize by facet rather than by score.
+
+**Examples:** `examples/coverage-balancing.md`
+
+## Answerability Scoring
+
+**When to apply:** As a final filter before using results.
+
+For each result, assess: "does this actually answer the user's question, or does it just mention the same terms?" A result that contains the relevant code pattern is answerable. A result that mentions the pattern name in passing is not. Prefer results that provide complete, actionable information over those that provide fragments or tangential mentions.
+
+**Examples:** `examples/answerability-scoring.md`

--- a/plugins/midnight-mcp/skills/mcp-search/references/server-enhanced.md
+++ b/plugins/midnight-mcp/skills/mcp-search/references/server-enhanced.md
@@ -1,0 +1,87 @@
+# Server-Enhanced Search
+
+Techniques that require MCP server changes to implement. Each technique is tracked as a GitHub issue on `devrelaicom/compact-playground`. Until server-side support is added, the LLM cannot apply these techniques directly — they are documented here for context and to explain current limitations.
+
+## Hybrid Search
+
+**What it does:** Combines keyword/BM25 matching with vector similarity search using reciprocal rank fusion. A single query benefits from both exact term matching and semantic similarity.
+
+**What it would enable:** Better results from single queries that mix exact terms (type names like `Counter`, `MerkleTree`) with semantic concepts ("how to manage state"). Currently the LLM compensates with multi-query generation, which doubles API calls.
+
+**Current limitation:** The MCP server uses a single retrieval strategy. Queries that need both keyword precision and semantic recall require the LLM to issue separate queries.
+
+**Server-side implementation:** Add a `hybrid` boolean parameter to search endpoints (default: `true`). Implement reciprocal rank fusion to combine BM25 and vector results. Optionally expose a `hybridWeight` parameter for tuning.
+
+**Plugin changes once implemented:** Update `references/tool-routing.md` parameter optimization section to include `hybrid` parameter guidance.
+
+## Field-Aware Retrieval
+
+**What it does:** Weights different document fields (title, headings, code blocks, body text) differently in scoring.
+
+**What it would enable:** A query for `MerkleTree` would rank a document titled "MerkleTree Operations" higher than one that mentions MerkleTree once in the body. Currently all fields are weighted equally, requiring the LLM to perform client-side relevance reranking.
+
+**Current limitation:** All text fields are scored equally. Title and heading matches — which are stronger relevance signals — receive the same weight as body text mentions.
+
+**Server-side implementation:** Implement field-based scoring with default weights: title (3x), headings (2x), code blocks (1.5x), body (1x). Optionally expose a `fieldWeights` parameter.
+
+**Plugin changes once implemented:** Update `references/tool-routing.md` parameter optimization section to include field weight guidance.
+
+## Extended Metadata Filtering
+
+**What it does:** Adds server-side filters for date range, language version, document type, and source author beyond the current `filter.repository` and `filter.isPublic` parameters.
+
+**What it would enable:** The LLM could filter results server-side by version, date, and content type instead of performing client-side post-filtering. This reduces token consumption from irrelevant results.
+
+**Current limitation:** `midnight-search-compact` supports `filter.repository` and `filter.isPublic`. `midnight-search-typescript` and `midnight-search-docs` have no repository-level filtering. No tool supports date, version, or content type filtering.
+
+**Server-side implementation:** Extend the `filter` parameter schema to include `dateRange`, `languageVersion`, `docType`, and `author` fields. Apply filtering server-side before scoring.
+
+**Plugin changes once implemented:** Update `references/tool-routing.md` and `examples/parameter-optimization.md` with new filter parameters.
+
+## Diversity-Aware Retrieval
+
+**What it does:** Limits the number of results returned from any single document, ensuring the result set covers different sources.
+
+**What it would enable:** Broad queries would return results from multiple documents instead of multiple chunks from the same large document. Currently the LLM deduplicates client-side, wasting tokens on results that will be discarded.
+
+**Current limitation:** The server may return multiple chunks from the same document. A search for "state management" might return 5 chunks from the same tutorial, missing relevant content from other sources.
+
+**Server-side implementation:** Add a `maxPerDocument` integer parameter (default: 3). After scoring, enforce the per-document limit and backfill with next-highest results from other documents.
+
+**Plugin changes once implemented:** Update `references/result-refinement.md` to note that server-side deduplication reduces the need for client-side deduplication techniques.
+
+## Parent-Child Retrieval
+
+**What it does:** Returns the surrounding section or parent document alongside the matching chunk when requested.
+
+**What it would enable:** The LLM would get sufficient context from a single search call instead of needing follow-up calls to read surrounding content. A matched function would come with its parent class or module.
+
+**Current limitation:** Results are individual chunks without surrounding context. The LLM often needs the full function, full section, or full file to understand a code pattern, requiring additional tool calls.
+
+**Server-side implementation:** Add an `includeParent` boolean parameter (default: `false`). Return the parent section (heading-delimited) or containing file alongside the matching chunk in a `parentContent` response field.
+
+**Plugin changes once implemented:** Update `references/tool-routing.md` parameter guidance and `references/result-refinement.md` result interpretation guidance.
+
+## Passage Compression
+
+**What it does:** Extracts and returns only the most relevant span from long chunks, reducing token consumption while preserving the answer.
+
+**What it would enable:** Results would contain only the relevant portion plus minimal surrounding context, significantly reducing token consumption. Currently full chunks are returned even if only a small span is relevant.
+
+**Current limitation:** Full chunks are returned regardless of how much of the chunk is relevant. A 200-line file chunk is returned when only 5 lines contain the answer.
+
+**Server-side implementation:** Add a `compress` boolean parameter (default: `false`). Use extractive summarization or span detection to return the relevant portion plus N lines of surrounding context. Include position metadata (start/end offsets).
+
+**Plugin changes once implemented:** Update `references/tool-routing.md` parameter guidance and result interpretation guidance across references.
+
+## Graph-Assisted Retrieval
+
+**What it does:** Uses links between documents, code symbols, repositories, issues, and examples to retrieve related content that does not share keywords with the query.
+
+**What it would enable:** A search for a Compact function would also surface the related TypeScript SDK bindings, the documentation page that explains it, and the example contract that uses it — even if those do not share keywords.
+
+**Current limitation:** Documents are retrieved independently based on text similarity. Related content that uses different terminology is not surfaced. The LLM compensates with cross-tool orchestration, but this requires knowing which tools to call and what terms to use.
+
+**Server-side implementation:** Build a link graph across indexed content: doc-to-code, code-to-test, function-to-usage, package-to-docs. Add a `followLinks` boolean parameter (default: `false`). Return directly linked content (1 hop) in a `relatedContent` response field with relationship labels.
+
+**Plugin changes once implemented:** Update `references/tool-routing.md` with graph-aware search patterns and `examples/cross-tool-orchestration.md` with graph-assisted examples.

--- a/plugins/midnight-mcp/skills/mcp-search/references/tool-routing.md
+++ b/plugins/midnight-mcp/skills/mcp-search/references/tool-routing.md
@@ -1,0 +1,70 @@
+# Tool Routing
+
+Techniques for selecting and configuring MCP tools before executing a search.
+
+## Intent Classification
+
+**When to apply:** Always, before selecting a tool.
+
+Classify the search intent into one of these categories:
+
+- `code_example` — user wants to see how something is implemented. Route to `midnight-search-compact` or `midnight-search-typescript`.
+- `conceptual` — user wants to understand how something works. Route to `midnight-search-docs`.
+- `api_reference` — user wants exact API signatures or type definitions. Route to `midnight-search-typescript` with `includeTypes: true`.
+- `troubleshooting` — user has an error or problem. Route to `midnight-search-docs` with `category: "guides"`, possibly `midnight-search-compact` for error patterns.
+- `migration` — user is upgrading versions. Route to `midnight-search-docs`, `midnight-fetch-docs` for release notes.
+- `specific_page` — user knows which doc page they need. Route to `midnight-fetch-docs` directly.
+
+**Examples:** `examples/intent-classification.md`
+
+## Source Routing
+
+**When to apply:** After intent classification, to select the specific tool.
+
+Map the classified intent and detected entities to the correct MCP tool:
+
+- Compact language questions — `midnight-search-compact`
+- TypeScript/SDK questions — `midnight-search-typescript`
+- Conceptual/architectural questions — `midnight-search-docs`
+- Known doc page — `midnight-fetch-docs` with the page path
+- Mixed — use cross-tool orchestration (technique 5)
+
+Decision factors: entity types in the query (Compact types indicate compact search, npm packages indicate TypeScript search), language context from prior turns, facets extracted from the query.
+
+**Examples:** `examples/source-routing.md`
+
+## Trusted-Source Filtering
+
+**When to apply:** When result reliability matters more than breadth — production code, security-sensitive patterns, official examples.
+
+- For `midnight-search-compact`: set `filter.repository` to restrict to trusted organizations. Supported prefixes: `midnightntwrk`, `OpenZeppelin`, `LFDT-Minokawa`.
+- For `midnight-search-typescript`: no server-side filter available. Apply trust-aware reranking from the Result Refinement cluster after retrieval.
+- For `midnight-search-docs`: all results are from official docs — no additional filtering needed.
+- For `midnight-fetch-docs`: fetches directly from docs.midnight.network — inherently trusted.
+
+**Examples:** `examples/trusted-source-filtering.md`
+
+## Parameter Optimization
+
+**When to apply:** After tool selection, before making the call.
+
+Set tool-specific parameters to improve result quality:
+
+- `midnight-search-compact`: `limit` (default 10, increase to 15-20 for broad searches), `filter.repository` (for trusted sources), `filter.isPublic` (for public-only code)
+- `midnight-search-typescript`: `limit`, `includeExamples` (true for usage patterns, false for type-only lookups), `includeTypes` (true for type definitions, false for implementation code)
+- `midnight-search-docs`: `limit`, `category` — set `"guides"` for tutorials/howtos, `"api"` for API references, `"concepts"` for architecture/theory, omit or use `"all"` for broad search
+- `midnight-fetch-docs`: `path` (required), `extractSection` (use when you only need one heading from a large page)
+
+**Examples:** `examples/parameter-optimization.md`
+
+## Cross-Tool Orchestration
+
+**When to apply:** When a single tool cannot provide complete coverage — typically for comprehensive research, or when code examples need conceptual context.
+
+- **Compact + Docs** (most common): search compact for implementation patterns, search docs for conceptual explanation. Useful for answering "how and why" questions.
+- **TypeScript + Compact**: search TypeScript for SDK integration, search compact for the contract side. Useful for end-to-end DApp questions.
+- **Search + Fetch**: use search to discover the relevant page, then fetch for full content. Useful when search snippets are insufficient.
+
+Limit to 2-3 tool calls per question. Additional calls rarely add value beyond the first 2-3.
+
+**Examples:** `examples/cross-tool-orchestration.md`


### PR DESCRIPTION
## Summary

- Created comprehensive search technique library with 7 technique references and example files
- Added search workflow guidance, trusted source registry, and query expansion patterns
- Created 7 GitHub issues on compact-playground for missing example coverage

## Plan

Implemented from `docs/superpowers/plans/2026-03-19-mcp-search-technique-library.md`

## Spec

Designed in `docs/superpowers/specs/2026-03-19-mcp-search-technique-library-design.md`

## Changes

- 38 new files created
- 7 GitHub issues created on devrelaicom/compact-playground

Generated with [Claude Code](https://claude.com/claude-code)