### PR TITLE
fix(midnight-mcp): update stale cross-references after mcp-format ext…

### DIFF
--- a/plugins/midnight-mcp/skills/mcp-compile/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-compile/SKILL.md
@@ -60,6 +60,7 @@ When hitting rate limits: fix all reported errors before recompiling rather than
 |-------|----------------|
 | Local CLI compilation, artifacts, ZKIR, keys | `compact-core:compact-compilation` |
 | Compact standard library reference | `compact-core:compact-standard-library` |
-| Analysis, visualization, formatting, diffing | `mcp-analyze` |
+| Analysis, visualization, diffing | `mcp-analyze` |
+| Compact code formatting via MCP | `mcp-format` |
 | Tool routing and category overview | `mcp-overview` |
 | Verification methodology using compilation | `compact-core:verify-correctness` |

--- a/plugins/midnight-mcp/skills/mcp-overview/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-overview/SKILL.md
@@ -93,7 +93,9 @@ Different tool categories have different cost profiles. Follow these limits to a
 | Topic | Skill / Plugin |
 |-------|----------------|
 | Search tool details and query optimization | `mcp-search` |
-| Analysis and compilation tool details | `mcp-analyze` |
+| Analysis, visualization, diffing tool details | `mcp-analyze` |
+| MCP-hosted compilation workflows and error recovery | `mcp-compile` |
+| Compact code formatting via MCP | `mcp-format` |
 | Simulation lifecycle | `mcp-simulate` |
 | Repository and version tools | `mcp-repository` |
 | Health and diagnostics | `mcp-health` |


### PR DESCRIPTION
…raction

mcp-compile and mcp-overview still attributed formatting to mcp-analyze. Split those rows to correctly reference mcp-format and mcp-compile as separate skills.