### PR TITLE
chore(midnight-mcp): normalize skill names and switch to GitHub install

### DIFF
--- a/plugins/midnight-mcp/.mcp.json
+++ b/plugins/midnight-mcp/.mcp.json
@@ -3,7 +3,7 @@
     "command": "npx",
     "args": [
       "-y",
-      "midnight-mcp@latest"
+      "github:devrelaicom/midnight-mcp"
     ]
   }
 }

--- a/plugins/midnight-mcp/commands/search.md
+++ b/plugins/midnight-mcp/commands/search.md
@@ -1,4 +1,5 @@
 ---
+name: midnight-mcp:search
 description: Search Midnight code, documentation, and SDK patterns with technique-aware query optimization, preset modes, and interactive guided search
 allowed-tools: AskUserQuestion, Read, Glob, Grep, mcp__midnight__midnight-search-compact, mcp__midnight__midnight-search-typescript, mcp__midnight__midnight-search-docs, mcp__midnight__midnight-fetch-docs, mcp__midnight__midnight-list-examples
 argument-hint: "[<query>] [--compact | --typescript | --docs | --all] [--quick | --thorough | --debug | --examples | --migration] [--trusted-only] [--rewrite] [--multi-query] [--step-back] [--hyde] [--decompose] [--rerank] [--dedupe] [--iterative] [--version-aware] [--env]"

--- a/plugins/midnight-mcp/commands/simulate.md
+++ b/plugins/midnight-mcp/commands/simulate.md
@@ -1,4 +1,5 @@
 ---
+name: midnight-mcp:simulate
 description: Simulate Compact contracts interactively — deploy, call circuits, inspect state, and verify behavior with preset testing modes and witness/caller control
 allowed-tools: AskUserQuestion, Read, Glob, Grep, mcp__midnight__midnight-simulate-deploy, mcp__midnight__midnight-simulate-call, mcp__midnight__midnight-simulate-state, mcp__midnight__midnight-simulate-delete, mcp__midnight__midnight-compile-contract
 argument-hint: "[<code-or-file>] [--explore | --test-sequence | --regression | --assertions] [--caller <address>] [--cleanup] [--version <ver>] [--witness <name>=<value>] [--compile-first]"

--- a/plugins/midnight-mcp/skills/mcp-analyze/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-analyze/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mcp-analyze
+name: midnight-mcp:mcp-analyze
 description: This skill should be used when the user asks about analyzing a Compact contract, visualizing a contract, proving a contract, MCP analyze, contract analysis pipelines, midnight-analyze-contract, midnight-visualize-contract, midnight-prove-contract, midnight-diff-contracts, semantic contract diff, or circuit visualization.
 ---
 
@@ -7,8 +7,8 @@ description: This skill should be used when the user asks about analyzing a Comp
 
 Four tools for analyzing, visualizing, proving, and diffing Compact contracts. All tools produce deterministic results — call each tool once per contract and reuse the result.
 
-For compilation tools (`midnight-compile-contract`, `midnight-compile-archive`), see the `mcp-compile` skill.
-For formatting tools (`midnight-format-contract`), see the `mcp-format` skill.
+For compilation tools (`midnight-compile-contract`, `midnight-compile-archive`), see the `midnight-mcp:mcp-compile` skill.
+For formatting tools (`midnight-format-contract`), see the `midnight-mcp:mcp-format` skill.
 
 ## midnight-analyze-contract
 
@@ -114,9 +114,9 @@ All tools produce deterministic output for the same input. Call each tool once p
 
 | Topic | Skill / Plugin |
 |-------|----------------|
-| MCP-hosted compilation workflows and error recovery | `mcp-compile` |
-| MCP-hosted formatting and code style | `mcp-format` |
-| Tool routing and category overview | `mcp-overview` |
+| MCP-hosted compilation workflows and error recovery | `midnight-mcp:mcp-compile` |
+| MCP-hosted formatting and code style | `midnight-mcp:mcp-format` |
+| Tool routing and category overview | `midnight-mcp:mcp-overview` |
 | Local compilation with Compact CLI | `compact-core:compact-compilation` |
 | Verification methodology using compilation | `midnight-verify:verify-correctness` |
 | Compact standard library for resolving compile errors | `compact-core:compact-standard-library` |

--- a/plugins/midnight-mcp/skills/mcp-analyze/examples/tool-invocations.md
+++ b/plugins/midnight-mcp/skills/mcp-analyze/examples/tool-invocations.md
@@ -38,4 +38,4 @@
 }
 ```
 
-For compilation tool invocations (`midnight-compile-contract`, `midnight-compile-archive`), see the `mcp-compile` skill.
+For compilation tool invocations (`midnight-compile-contract`, `midnight-compile-archive`), see the `midnight-mcp:mcp-compile` skill.

--- a/plugins/midnight-mcp/skills/mcp-compile/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-compile/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mcp-compile
+name: midnight-mcp:mcp-compile
 version: 1.0.0
 description: This skill should be used when the user asks about compiling Compact code via MCP, hosted compilation, midnight-compile-contract, midnight-compile-archive, MCP compile, snippet compilation, multi-version compilation, compile errors from MCP, code auto-wrapping, testing backwards compatibility across Compact versions, OpenZeppelin library linking in MCP compilation, interpreting hosted compiler responses, quick validation, check if code compiles, full ZK compilation via MCP, circuit metrics, k-values, or TypeScript bindings from MCP.
 ---
@@ -60,7 +60,7 @@ When hitting rate limits: fix all reported errors before recompiling rather than
 |-------|----------------|
 | Local CLI compilation, artifacts, ZKIR, keys | `compact-core:compact-compilation` |
 | Compact standard library reference | `compact-core:compact-standard-library` |
-| Analysis, visualization, diffing | `mcp-analyze` |
-| Compact code formatting via MCP | `mcp-format` |
-| Tool routing and category overview | `mcp-overview` |
+| Analysis, visualization, diffing | `midnight-mcp:mcp-analyze` |
+| Compact code formatting via MCP | `midnight-mcp:mcp-format` |
+| Tool routing and category overview | `midnight-mcp:mcp-overview` |
 | Verification methodology using compilation | `midnight-verify:verify-correctness` |

--- a/plugins/midnight-mcp/skills/mcp-format/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-format/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mcp-format
+name: midnight-mcp:mcp-format
 description: This skill should be used when the user asks about formatting Compact code, midnight-format-contract, Compact code style, code formatting via MCP, presenting Compact code, cleaning up Compact code, or formatting with a specific compiler version. This skill should also be used proactively whenever the LLM is about to present Compact code to the user.
 ---
 
@@ -100,7 +100,7 @@ Use `versions` array to format with multiple compiler versions. Compare the `for
 - If the code is from a known-good source (user file, search result) → try formatting
   - Success → present formatted
   - Parse error → present unformatted, note the syntax issues
-- If the code failed compilation → do not attempt formatting. Fix the code first via `mcp-compile`, then format.
+- If the code failed compilation → do not attempt formatting. Fix the code first via `midnight-mcp:mcp-compile`, then format.
 
 **Version not available:** The requested compiler version is not installed on the playground. Fall back to omitting the `version` parameter (uses default/latest version) or inform the user.
 
@@ -124,6 +124,6 @@ Use `versions` array to format with multiple compiler versions. Compare the `for
 | Topic | Skill / Plugin |
 |-------|----------------|
 | Local formatting (in-place, CI, pre-commit) | `midnight-tooling:compact-cli` |
-| MCP-hosted compilation | `mcp-compile` |
-| Analysis, visualization, diffing | `mcp-analyze` |
-| Tool routing and category overview | `mcp-overview` |
+| MCP-hosted compilation | `midnight-mcp:mcp-compile` |
+| Analysis, visualization, diffing | `midnight-mcp:mcp-analyze` |
+| Tool routing and category overview | `midnight-mcp:mcp-overview` |

--- a/plugins/midnight-mcp/skills/mcp-health/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-health/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mcp-health
+name: midnight-mcp:mcp-health
 description: Diagnose and manage the Midnight MCP server. Use when the user asks is the MCP server running, MCP server down, what compilers are available, OpenZeppelin libraries, update MCP, upgrade MCP server, or asks about health check, MCP status, MCP version, MCP troubleshooting, rate limiting, cache stats, midnight-health-check, midnight-get-status, midnight-check-version, midnight-get-update-instructions, midnight-list-compiler-versions, or midnight-list-libraries.
 ---
 
@@ -106,7 +106,7 @@ The MCP server enforces rate limits to prevent abuse. If you encounter rate limi
 
 1. Run `midnight-get-status` to check current rate limit status
 2. Wait for the reset window (shown in the status response)
-3. Reduce call frequency — follow the call frequency guidance in `mcp-overview`
+3. Reduce call frequency — follow the call frequency guidance in `midnight-mcp:mcp-overview`
 4. Use compound tools (`midnight-upgrade-check`, `midnight-get-repo-context`) to reduce the number of individual calls
 
 ### Graceful Degradation
@@ -134,7 +134,7 @@ If `midnight-check-version` shows that the installed version is behind the lates
 
 | Topic | Skill / Plugin |
 |-------|----------------|
-| Tool routing and category overview | `mcp-overview` |
+| Tool routing and category overview | `midnight-mcp:mcp-overview` |
 | Local Compact CLI as fallback for compilation | `compact-core:compact-compilation` |
 | Compact standard library as fallback for library listing | `compact-core:compact-standard-library` |
 | Verification methodology | `midnight-verify:verify-correctness` |

--- a/plugins/midnight-mcp/skills/mcp-overview/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-overview/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mcp-overview
+name: midnight-mcp:mcp-overview
 description: Use when the user asks about listing available tools, what the MCP server can do, compound tools, saving tokens, call frequency, rate limiting, which MCP tool to use for a task, tool categories, tool routing, suggesting the right tool, MCP overview, midnight tool routing, available MCP capabilities, or how to choose between midnight MCP tools.
 ---
 
@@ -92,13 +92,13 @@ Different tool categories have different cost profiles. Follow these limits to a
 
 | Topic | Skill / Plugin |
 |-------|----------------|
-| Search tool details and query optimization | `mcp-search` |
-| Analysis, visualization, diffing tool details | `mcp-analyze` |
-| MCP-hosted compilation workflows and error recovery | `mcp-compile` |
-| Compact code formatting via MCP | `mcp-format` |
-| Simulation lifecycle | `mcp-simulate` |
-| Repository and version tools | `mcp-repository` |
-| Health and diagnostics | `mcp-health` |
+| Search tool details and query optimization | `midnight-mcp:mcp-search` |
+| Analysis, visualization, diffing tool details | `midnight-mcp:mcp-analyze` |
+| MCP-hosted compilation workflows and error recovery | `midnight-mcp:mcp-compile` |
+| Compact code formatting via MCP | `midnight-mcp:mcp-format` |
+| Simulation lifecycle | `midnight-mcp:mcp-simulate` |
+| Repository and version tools | `midnight-mcp:mcp-repository` |
+| Health and diagnostics | `midnight-mcp:mcp-health` |
 | Compact compilation with local CLI | `compact-core:compact-compilation` |
 | Verification methodology using MCP tools | `midnight-verify:verify-correctness` |
 | Compact standard library reference | `compact-core:compact-standard-library` |

--- a/plugins/midnight-mcp/skills/mcp-repository/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-repository/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mcp-repository
+name: midnight-mcp:mcp-repository
 description: Use when the user asks to show me what changed between versions, how do I upgrade from version X to Y, what example contracts are available, or asks about browsing repo content, listing examples, checking updates, breaking changes, comparing syntax, upgrade checks, midnight-get-file, midnight-list-examples, midnight-get-latest-updates, midnight-check-breaking-changes, midnight-get-file-at-version, midnight-compare-syntax, midnight-upgrade-check, or midnight-get-repo-context.
 ---
 
@@ -155,7 +155,7 @@ Combines version checking, breaking change detection, and migration guidance int
 
 1. `midnight-check-breaking-changes` — What breaks between the two versions
 2. Migration guidance — Step-by-step instructions for the upgrade
-3. Version context via `midnight-check-version` (from `mcp-health`) — What version is installed vs. what is available
+3. Version context via `midnight-check-version` (from `midnight-mcp:mcp-health`) — What version is installed vs. what is available
 
 ### midnight-get-repo-context
 
@@ -178,7 +178,7 @@ Combines version information, syntax reference, and example listings into a sing
 
 1. `midnight-compare-syntax` — Syntax reference for the target version
 2. `midnight-list-examples` — Relevant examples for the component
-3. Version context via `midnight-check-version` (from `mcp-health`) — Current version information
+3. Version context via `midnight-check-version` (from `midnight-mcp:mcp-health`) — Current version information
 
 ### When to Use Compound vs. Individual Tools
 
@@ -196,7 +196,7 @@ Always prefer compound tools when they cover your needs. Use individual tools on
 
 | Topic | Skill / Plugin |
 |-------|----------------|
-| Tool routing and category overview | `mcp-overview` |
+| Tool routing and category overview | `midnight-mcp:mcp-overview` |
 | Compact compilation for verifying retrieved code | `compact-core:compact-compilation` |
 | Verification methodology using repository content | `midnight-verify:verify-correctness` |
 | Compact standard library reference | `compact-core:compact-standard-library` |

--- a/plugins/midnight-mcp/skills/mcp-search/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-search/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mcp-search
+name: midnight-mcp:mcp-search
 version: 1.0.0
 description: This skill should be used when the user asks about searching Midnight code, searching Compact examples, searching TypeScript SDK code, finding Midnight documentation, fetching docs pages, using MCP search tools (midnight-search-compact, midnight-search-typescript, midnight-search-docs, midnight-fetch-docs), the /midnight-mcp:search command, optimizing search queries, search techniques like query rewriting or multi-query generation, improving search result quality, or reranking search results.
 ---
@@ -8,7 +8,7 @@ description: This skill should be used when the user asks about searching Midnig
 
 Search techniques and tool guidance for the four Midnight MCP search tools. This skill provides a technique library organized as cluster references with per-technique example files. Load only what you need for the current task.
 
-**Not this skill:** If the user asks what MCP tools are available, how tools are categorized, or for a general overview of Midnight tooling, use `mcp-overview` instead. This skill is for *executing* searches, not describing the tools.
+**Not this skill:** If the user asks what MCP tools are available, how tools are categorized, or for a general overview of Midnight tooling, use `midnight-mcp:mcp-overview` instead. This skill is for *executing* searches, not describing the tools.
 
 ## Search Tools
 
@@ -59,7 +59,7 @@ Users can invoke `/midnight-mcp:search` for technique-aware search with preset m
 
 | Topic | Skill / Plugin |
 |-------|----------------|
-| Tool routing and category overview | `mcp-overview` |
+| Tool routing and category overview | `midnight-mcp:mcp-overview` |
 | Verification methodology using search results | `midnight-verify:verify-correctness` |
 | Compact standard library reference | `compact-core:compact-standard-library` |
 | Compact compilation for verifying search results | `compact-core:compact-compilation` |

--- a/plugins/midnight-mcp/skills/mcp-search/references/code-search.md
+++ b/plugins/midnight-mcp/skills/mcp-search/references/code-search.md
@@ -24,7 +24,7 @@ Extract the distinctive parts of the error message — error codes, specific fun
 
 **When to apply:** When the user needs runnable, complete code examples rather than documentation or partial snippets.
 
-Bias search queries toward finding complete implementations. Add terms like `example`, `contract`, `circuit export` for Compact code. For TypeScript, add `example`, `implementation`, `deploy`. Prefer results that include full file content over single-function snippets. Check `source.repository` — official example repos (`midnightntwrk/examples`, `midnightntwrk/midnight-examples`) are the richest source. The MCP tool `midnight-list-examples` (from `mcp-overview`) can also list available example contracts with complexity ratings.
+Bias search queries toward finding complete implementations. Add terms like `example`, `contract`, `circuit export` for Compact code. For TypeScript, add `example`, `implementation`, `deploy`. Prefer results that include full file content over single-function snippets. Check `source.repository` — official example repos (`midnightntwrk/examples`, `midnightntwrk/midnight-examples`) are the richest source. The MCP tool `midnight-list-examples` (from `midnight-mcp:mcp-overview`) can also list available example contracts with complexity ratings.
 
 **Examples:** `examples/example-mining.md`
 

--- a/plugins/midnight-mcp/skills/mcp-simulate/SKILL.md
+++ b/plugins/midnight-mcp/skills/mcp-simulate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mcp-simulate
+name: midnight-mcp:mcp-simulate
 description: This skill should be used when the user asks about simulating a Compact contract, deploying a contract in simulation, calling a circuit in simulation, testing contract behavior, reading simulation state, managing simulation sessions, MCP simulation, midnight-simulate-deploy, midnight-simulate-call, midnight-simulate-state, midnight-simulate-delete, contract simulation lifecycle, testing contract assertions, witness mocking, multi-user contract testing, caller context simulation, interactive contract testing, or simulation error recovery.
 ---
 
@@ -14,7 +14,7 @@ Evaluate these conditions before continuing. If any match, stop loading this ski
 | Condition | Use Instead |
 |-----------|-------------|
 | CI/CD pipeline testing (headless, reproducible) | OZ simulator locally via `@openzeppelin/compact-simulator` |
-| Need ZK proof generation | `mcp-compile` (full compilation) |
+| Need ZK proof generation | `midnight-mcp:mcp-compile` (full compilation) |
 | Need to test against live on-chain state | Local devnet via `midnight-tooling:devnet` |
 | Bulk/automated test suites (hundreds of calls) | OZ simulator locally |
 
@@ -102,7 +102,7 @@ Users can invoke `/midnight-mcp:simulate` to run simulations with preset testing
 | `--cleanup` | Auto-delete session when done |
 | `--version <ver>` | Compiler version for deploy |
 | `--witness <name>=<value>` | Provide witness override (repeatable) |
-| `--compile-first` | Run through `mcp-compile` (skipZk) before deploying |
+| `--compile-first` | Run through `midnight-mcp:mcp-compile` (skipZk) before deploying |
 
 No flags with code/file: `--explore`. No flags, no code: interactive mode.
 
@@ -110,8 +110,8 @@ No flags with code/file: `--explore`. No flags, no code: interactive mode.
 
 | Topic | Skill / Plugin |
 |-------|---------------|
-| Tool routing and category overview | `mcp-overview` |
-| Compilation workflows and compiler errors | `mcp-compile` |
+| Tool routing and category overview | `midnight-mcp:mcp-overview` |
+| Compilation workflows and compiler errors | `midnight-mcp:mcp-compile` |
 | Local CLI compilation and artifacts | `compact-core:compact-compilation` |
 | Verification methodology | `midnight-verify:verify-correctness` |
 | Compact standard library for understanding circuit behavior | `compact-core:compact-standard-library` |

--- a/plugins/midnight-mcp/skills/mcp-simulate/examples/deployment-errors.md
+++ b/plugins/midnight-mcp/skills/mcp-simulate/examples/deployment-errors.md
@@ -2,7 +2,7 @@
 
 ## When This Error Occurs
 
-Contract code fails compilation during `midnight-simulate-deploy`. The simulator cannot create a session because the code doesn't compile. Deploy errors ARE compiler errors — the same error messages and fixes apply as in `mcp-compile`.
+Contract code fails compilation during `midnight-simulate-deploy`. The simulator cannot create a session because the code doesn't compile. Deploy errors ARE compiler errors — the same error messages and fixes apply as in `midnight-mcp:mcp-compile`.
 
 ## Examples
 
@@ -127,6 +127,6 @@ Modifying code in response to a deployment error without reading the compiler er
 
 Redeploying the same code hoping for a different result. Compilation is deterministic — the same code always produces the same errors.
 
-### Ignoring mcp-compile cross-references
+### Ignoring midnight-mcp:mcp-compile cross-references
 
-Not cross-referencing `mcp-compile` error examples when deploy fails. Deploy errors ARE compiler errors — `mcp-compile` has detailed guidance for every error category.
+Not cross-referencing `midnight-mcp:mcp-compile` error examples when deploy fails. Deploy errors ARE compiler errors — `midnight-mcp:mcp-compile` has detailed guidance for every error category.

--- a/plugins/midnight-mcp/skills/mcp-simulate/references/deploy-workflows.md
+++ b/plugins/midnight-mcp/skills/mcp-simulate/references/deploy-workflows.md
@@ -6,7 +6,7 @@ Starting any simulation. This is always the first step — every session begins 
 
 ## The Deploy-Compile Pipeline
 
-Deploy compiles the contract before initializing the simulator. This takes ~1-5s (with skipZk). If compilation fails, the deploy fails with compiler errors — load `references/error-recovery.md` for diagnosis, and cross-reference `mcp-compile` error recovery for detailed compiler error guidance.
+Deploy compiles the contract before initializing the simulator. This takes ~1-5s (with skipZk). If compilation fails, the deploy fails with compiler errors — load `references/error-recovery.md` for diagnosis, and cross-reference `midnight-mcp:mcp-compile` error recovery for detailed compiler error guidance.
 
 ## Parameters
 
@@ -77,7 +77,7 @@ Action: Load references/error-recovery.md to diagnose. This is a compiler error 
 
 ## Version Selection
 
-Same version semantics as `mcp-compile`:
+Same version semantics as `midnight-mcp:mcp-compile`:
 - `"detect"` — resolves from `pragma language_version` in the source
 - Specific version string (e.g., `"0.14.0"`) — uses that version
 - Omit — uses the latest available version

--- a/plugins/midnight-mcp/skills/mcp-simulate/references/error-recovery.md
+++ b/plugins/midnight-mcp/skills/mcp-simulate/references/error-recovery.md
@@ -33,4 +33,4 @@ Match the error pattern, then load the corresponding example file.
 
 ## Cross-Reference
 
-Deploy compilation errors use the same compiler as `mcp-compile`. For detailed compiler error guidance, see `mcp-compile` error recovery reference.
+Deploy compilation errors use the same compiler as `midnight-mcp:mcp-compile`. For detailed compiler error guidance, see `midnight-mcp:mcp-compile` error recovery reference.

--- a/plugins/midnight-mcp/skills/mcp-simulate/references/session-management.md
+++ b/plugins/midnight-mcp/skills/mcp-simulate/references/session-management.md
@@ -51,4 +51,4 @@ Always call `midnight-simulate-delete` when done. Abandoned sessions consume res
 
 Deploy is the most expensive operation (compilation). Plan your testing so you deploy once and make multiple calls, rather than redeploying for each test case.
 
-If you need to test different code versions, use `mcp-compile` multi-version first to identify which version compiles, then deploy the working version for simulation.
+If you need to test different code versions, use `midnight-mcp:mcp-compile` multi-version first to identify which version compiles, then deploy the working version for simulation.

--- a/plugins/midnight-mcp/skills/mcp-simulate/references/testing-patterns.md
+++ b/plugins/midnight-mcp/skills/mcp-simulate/references/testing-patterns.md
@@ -72,7 +72,7 @@ Keep regression sequences simple and focused on critical invariants.
 
 ## The Compile-Then-Simulate Pattern
 
-Before deploying, run the code through `mcp-compile` (skipZk) to catch compilation errors cheaply. Then deploy for simulation.
+Before deploying, run the code through `midnight-mcp:mcp-compile` (skipZk) to catch compilation errors cheaply. Then deploy for simulation.
 
 ```
 1. midnight-compile-contract({ code: "<contract>", skipZk: true })


### PR DESCRIPTION
Update all skill names to fully-qualified format (midnight-mcp:*) and fix cross-references throughout. Add missing name fields to commands. Switch MCP server install from npm registry to github:devrelaicom/midnight-mcp.