### PR TITLE
feat(verify): add ZKIR verification to midnight-verify plugin

### DIFF
--- a/docs/superpowers/plans/2026-03-28-zkir-verification.md
+++ b/docs/superpowers/plans/2026-03-28-zkir-verification.md
@@ -1,0 +1,1707 @@
+# ZKIR Verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add ZKIR-level verification to the midnight-verify plugin — a new `zkir-checker` agent with checker and inspection skills, a domain routing skill, a regression sweep skill, and a fixture library mirroring the ZKIR reference document's oracle traces.
+
+**Architecture:** New `zkir-checker` agent (opus) dispatched by the existing verifier orchestrator. Four new skills: `verify-zkir` (domain routing), `verify-by-zkir-checker` (WASM checker method), `verify-by-zkir-inspection` (compiled circuit analysis), `zkir-regression` (sweep). Fixtures live in the checker skill's directory tree. Existing hub/compact/execution skills gain ZKIR-aware routing and verdict qualifiers.
+
+**Tech Stack:** `@midnight-ntwrk/zkir-v2` (WASM checker), `@midnight-ntwrk/compact-runtime`, Compact CLI, hand-crafted `.zkir` JSON circuits.
+
+**Spec:** `docs/superpowers/specs/2026-03-28-zkir-verification-design.md`
+
+---
+
+### Task 1: Create the `zkir-checker` agent
+
+**Files:**
+- Create: `plugins/midnight-verify/agents/zkir-checker.md`
+
+- [ ] **Step 1: Create the agent file**
+
+```markdown
+---
+name: zkir-checker
+description: >-
+  Use this agent to verify ZKIR-level claims by running circuits through the
+  @midnight-ntwrk/zkir-v2 WASM checker or inspecting compiled circuit structure.
+  Compiles Compact to extract .zkir, constructs proof data, invokes the checker,
+  and analyzes circuit properties. Dispatched by the verifier orchestrator agent.
+
+  Example 1: Claim "add wraps modulo r" — loads a fixture circuit that adds
+  (r-1) + 1, runs through the checker, confirms the result wraps to 0.
+
+  Example 2: Claim "constrain_bits enforces 8-bit range" — loads fixture circuits
+  for values 0, 255, and 256, runs all three, confirms accept/accept/reject.
+
+  Example 3: Claim "counter increment compiles to fewer than 20 instructions" —
+  compiles a counter contract, extracts .zkir, counts instructions.
+
+  Example 4: Claim "this circuit uses persistent_hash for authority" — compiles
+  a guarded counter, extracts .zkir, searches for persistent_hash opcode in
+  instruction list.
+skills: midnight-verify:verify-by-zkir-checker, midnight-verify:verify-by-zkir-inspection
+model: opus
+color: red
+---
+
+You are a ZKIR circuit verifier for Midnight.
+
+## Your Job
+
+Based on the claim you receive, load the appropriate skill:
+
+- **Checker claims** (opcode behavior, constraint semantics, field arithmetic, proof data validity) → load `midnight-verify:verify-by-zkir-checker` and follow it step by step
+- **Inspection claims** (compiled circuit structure, instruction counts, opcode usage, transcript encoding) → load `midnight-verify:verify-by-zkir-inspection` and follow it step by step
+- **Both** (claims about structure AND behavior) → load both skills, perform inspection first to understand the circuit, then run checker to verify behavior
+
+## Important
+
+- You do NOT classify claims or synthesize verdicts — the verifier orchestrator does that.
+- You may compile Compact contracts when needed — use `compact compile --skip-zk` the same way the contract-writer does.
+- You may hand-craft `.zkir` JSON directly for IR-level claims not reachable from Compact, or for trivially small circuits.
+- Check the fixture library first (`${CLAUDE_SKILL_DIR}/fixtures/` in the checker skill) before writing anything from scratch.
+- You may load compact-core skills as hints for writing Compact test contracts, but test results and checker verdicts are your evidence, not skill content.
+```
+
+Write this to `plugins/midnight-verify/agents/zkir-checker.md`.
+
+- [ ] **Step 2: Verify the file was created**
+
+Run: `cat plugins/midnight-verify/agents/zkir-checker.md | head -5`
+Expected: The frontmatter starting with `---` and `name: zkir-checker`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/midnight-verify/agents/zkir-checker.md
+git commit -m "feat(verify): add zkir-checker agent for ZKIR-level verification
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Create the `verify-zkir` domain routing skill
+
+**Files:**
+- Create: `plugins/midnight-verify/skills/verify-zkir/SKILL.md`
+
+- [ ] **Step 1: Create the skill directory and file**
+
+```markdown
+---
+name: midnight-verify:verify-zkir
+description: >-
+  ZKIR claim classification and method routing. Determines what kind of ZKIR
+  claim is being verified and which verification method applies: WASM checker
+  (accept/reject testing), circuit inspection (compiled structure analysis),
+  or source investigation. Handles claims about opcode semantics, constraint
+  behavior, field arithmetic, transcript protocol, and compiled circuit
+  properties. Loaded by the verifier agent alongside the hub skill.
+version: 0.4.0
+---
+
+# ZKIR Claim Classification
+
+This skill classifies ZKIR-related claims and determines which verification method to use. The verifier (orchestrator) agent loads this alongside the hub skill (`verify-correctness`).
+
+## Claim Type → Method Routing
+
+When you receive a ZKIR-related claim, classify it using this table to determine which agent(s) to dispatch:
+
+### Claims About ZKIR Behavior
+
+| Claim Type | Example | Dispatch |
+|---|---|---|
+| Opcode semantics | "add wraps modulo r", "mul by zero produces zero" | **zkir-checker** (checker method) |
+| Constraint behavior | "assert requires boolean input", "constrain_eq fails on unequal values" | **zkir-checker** (checker method) |
+| Field arithmetic | "there are no negative numbers, -1 is r-1", "(r-1) + 1 = 0" | **zkir-checker** (checker method) |
+| Transcript protocol | "publicTranscript encodes ledger ops as field elements", "popeq bridges public_input" | **zkir-checker** (checker method) |
+| Cryptographic opcodes | "persistent_hash produces two field elements", "ec_mul_generator derives public key" | **zkir-checker** (checker method) |
+| Proof data validity | "extra private transcript outputs cause rejection", "tampered public transcript is detected" | **zkir-checker** (checker method) |
+| Type encoding | "encode converts a curve point to two field elements", "decode is the inverse of encode" | **zkir-checker** (checker method) |
+
+### Claims About Compiled Circuit Structure
+
+| Claim Type | Example | Dispatch |
+|---|---|---|
+| Instruction count | "this contract produces N instructions" | **zkir-checker** (inspection method) |
+| Opcode usage | "guard counter uses persistent_hash for authority" | **zkir-checker** (inspection method) |
+| Transcript encoding | "increment circuit uses 3 transcript ops", "disclosure compiles to declare_pub_input" | **zkir-checker** (inspection method) |
+| I/O shape | "this pure circuit has no private_input instructions" | **zkir-checker** (inspection method) |
+| ZKIR version format | "compiled output uses v2 format with implicit variable numbering" | **zkir-checker** (inspection method) |
+
+### Claims About ZKIR Internals
+
+| Claim Type | Example | Dispatch |
+|---|---|---|
+| ZKIR version differences | "v3 uses named variables, v2 uses integer indices" | **source-investigator** |
+| Compiler internals | "zkir-passes.ss handles v2 serialization" | **source-investigator** |
+| Checker implementation | "the WASM checker enforces transcript integrity" | **source-investigator** |
+
+### Cross-Domain Claims
+
+| Claim Type | Example | Dispatch |
+|---|---|---|
+| Compact → ZKIR mapping | "this Compact disclosure compiles to these ZKIR constraints" | **zkir-checker** (both methods) + **contract-writer** (concurrent) |
+| Behavior + structure | "the guard circuit uses persistent_hash AND correctly rejects wrong keys" | **zkir-checker** (both methods) |
+| ZKIR + runtime agreement | "the checker and JS runtime agree on this circuit's behavior" | **zkir-checker** (checker) + **contract-writer** (concurrent) |
+
+### Routing Rules
+
+**When in doubt:**
+- Observable checker behavior (accept/reject with specific inputs) → **zkir-checker** (checker method)
+- Compiled output properties (structure, counts, patterns) → **zkir-checker** (inspection method)
+- Compiler/toolchain internals (how the compiler works, not what it produces) → **source-investigator**
+
+**When multiple methods apply, dispatch concurrently.** Checker and inspection are independent and can run in parallel within the same agent.
+
+## Hints from the ZKIR Reference
+
+The zkir-checker agent has access to a fixture library with pre-crafted test circuits. The ZKIR reference document (Compact compiler v0.29.0) documents 26 opcodes across 8 categories:
+
+- **Arithmetic:** add, mul, neg
+- **Constraints:** assert, constrain_bits, constrain_eq, constrain_to_boolean
+- **Control Flow:** cond_select, copy
+- **Type Encoding:** decode, encode, reconstitute_field
+- **Division:** div_mod_power_of_two
+- **Cryptographic:** ec_mul, ec_mul_generator, hash_to_curve, persistent_hash, transient_hash
+- **I/O:** impact, output, private_input, public_input
+- **Comparison:** less_than, test_eq
+
+These categories map directly to the fixture library's directory structure. When a claim is about a specific opcode, mention the category to help the zkir-checker find relevant fixtures.
+```
+
+Write this to `plugins/midnight-verify/skills/verify-zkir/SKILL.md`.
+
+- [ ] **Step 2: Verify the file was created**
+
+Run: `head -10 plugins/midnight-verify/skills/verify-zkir/SKILL.md`
+Expected: Frontmatter with `name: midnight-verify:verify-zkir`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-zkir/SKILL.md
+git commit -m "feat(verify): add verify-zkir domain routing skill for ZKIR claims
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Create the `verify-by-zkir-checker` skill
+
+**Files:**
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/SKILL.md`
+
+- [ ] **Step 1: Create the skill directory and file**
+
+```markdown
+---
+name: midnight-verify:verify-by-zkir-checker
+description: >-
+  Verification by running ZKIR circuits through the @midnight-ntwrk/zkir-v2
+  WASM checker. Constructs or loads .zkir circuits, builds proof data, invokes
+  the checker, and interprets accept/reject results. Covers workspace setup
+  (lazy init), three circuit source paths (fixtures, compiled from Compact,
+  hand-crafted), proof data construction, positive and negative testing, and
+  result interpretation. Loaded by the zkir-checker agent.
+version: 0.4.0
+---
+
+# Verify by ZKIR Checker
+
+You are verifying a ZKIR claim by running a circuit through the `@midnight-ntwrk/zkir-v2` WASM checker. The checker is a deterministic oracle: given a circuit and proof data, it returns accept or reject. Follow these steps in order.
+
+## Critical Rule
+
+**A checker ACCEPT proves constraints are satisfied for those specific inputs. It does NOT prove the circuit is correct for all inputs.** When the claim is universal (e.g., "add always wraps"), note that your test covers specific cases, not all possible inputs.
+
+## Step 1: Set Up the Workspace
+
+The workspace lives at `.midnight-expert/verify/zkir-workspace/` relative to the project root.
+
+**First time (workspace does not exist):**
+
+```bash
+mkdir -p .midnight-expert/verify/zkir-workspace
+cd .midnight-expert/verify/zkir-workspace
+npm init -y
+npm install @midnight-ntwrk/zkir-v2 @midnight-ntwrk/compact-runtime
+```
+
+**Subsequent times (workspace exists):**
+
+Run a quick integrity check:
+
+```bash
+cd .midnight-expert/verify/zkir-workspace
+npm ls @midnight-ntwrk/zkir-v2
+```
+
+If `npm ls` reports errors, run `npm install` to repair.
+
+**Create the job directory:**
+
+```bash
+JOB_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+mkdir -p .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID
+```
+
+**Discover the checker API (first time only):**
+
+On the very first use of this workspace, inspect the WASM package to understand its API:
+
+```bash
+ls node_modules/@midnight-ntwrk/zkir-v2/
+cat node_modules/@midnight-ntwrk/zkir-v2/package.json | head -20
+```
+
+Look at the TypeScript types or JS exports to find the checker function. Document what you find in `.midnight-expert/verify/zkir-workspace/CHECKER-API.md` so subsequent jobs can reference it.
+
+## Step 2: Determine Circuit Source
+
+Choose the circuit source in this order of preference:
+
+### Option A: Fixture Match (preferred)
+
+Check `${CLAUDE_SKILL_DIR}/fixtures/test-cases/` for an existing test case that covers the claim. Read `${CLAUDE_SKILL_DIR}/fixtures/test-cases/manifest.json` to search by opcode, category, or description.
+
+If a matching fixture exists:
+1. Copy the test case JSON to the job directory
+2. Copy the referenced `.zkir` circuit to the job directory
+3. Skip to Step 5
+
+### Option B: Compile from Compact (default)
+
+Write a minimal `.compact` contract that exercises the claim, compile it, and extract the `.zkir`:
+
+1. Get the current language version: `compact compile --language-version`
+2. Write the contract to the job directory: `jobs/$JOB_ID/test-claim.compact`
+3. Compile: `compact compile jobs/$JOB_ID/test-claim.compact --skip-zk`
+4. Locate the `.zkir` JSON in the build output directory
+5. Proceed to Step 3 to construct proof data
+
+You may load compact-core skills as hints for writing correct Compact code. The compiled output is your evidence, not the skill content.
+
+### Option C: Hand-Craft `.zkir` JSON (IR-level only)
+
+Only use this when:
+- The claim is about IR-level behavior not reachable from Compact (e.g., specific variable numbering, meta-instruction behavior)
+- The circuit is trivially small (2-5 instructions)
+
+Check `${CLAUDE_SKILL_DIR}/fixtures/templates/` for parameterizable patterns:
+- `pure-circuit.json` — minimal: load_imm → op → constrain_eq → output
+- `witness-circuit.json` — circuit with private_input
+- `transcript-circuit.json` — circuit with publicTranscript
+
+A hand-crafted v2 `.zkir` circuit follows this structure:
+
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "<hex_value>" },
+    { "op": "<opcode>", ... },
+    { "op": "output", "var": <index> }
+  ]
+}
+```
+
+Key rules for hand-crafting:
+- Variables are implicit sequential integers (0, 1, 2, ...). Each instruction that produces output gets the next index.
+- Immediates are hex strings without `0x` prefix: `"01"`, `"FF"`, `"0302"`.
+- `load_imm` creates a variable with a literal value.
+- Input operands reference previous variable indices or hex immediates.
+
+## Step 3: Construct Proof Data
+
+Build a test case JSON that bundles the circuit with its inputs:
+
+```json
+{
+  "description": "what this test verifies",
+  "circuit": "path/to/circuit.zkir",
+  "inputs": {
+    "input": { "value": [], "alignment": [] },
+    "output": { "value": [], "alignment": [] },
+    "publicTranscript": [],
+    "privateTranscriptOutputs": []
+  },
+  "expect": "accept"
+}
+```
+
+**For pure circuits** (no state, no witnesses): `input` contains function arguments, `output` contains return values. `publicTranscript` and `privateTranscriptOutputs` are empty.
+
+**For circuits with witnesses:** `privateTranscriptOutputs` contains the witness values the circuit's `private_input` instructions will read, as an array of `AlignedValue` objects.
+
+**For circuits with transcript:** `publicTranscript` contains the VM operations array. See the ZKIR reference's Section 4.5 for the encoding format.
+
+## Step 4: Design Positive and Negative Tests
+
+**Positive test:** "This should accept" — construct valid proof data that satisfies all constraints.
+
+**Negative test:** "This should reject" — deliberately violate a constraint:
+- Wrong output value → `"Failed equality constraint: XX != YY"`
+- Non-boolean to assert → `"Expected boolean, found: XX"`
+- Boolean 0 to assert → `"Failed direct assertion"`
+- Value too large for constrain_bits → `"Bit bound failed: XX is not N-bit"`
+- Missing witness → `"Ran out of private transcript outputs"`
+- Extra witness → `"Transcripts not fully consumed"`
+- Tampered public transcript → `"Public transcript input mismatch for input N"`
+
+A rejection in a negative test **confirms** the claim (the constraint is enforced). A rejection in a positive test **refutes** the claim (the expected behavior doesn't hold).
+
+## Step 5: Run the Checker
+
+Write a runner script in the job directory. The exact API depends on what you discovered in Step 1 — reference `CHECKER-API.md` in the workspace.
+
+General pattern:
+
+```javascript
+// jobs/$JOB_ID/run-checker.mjs
+import { /* checker function */ } from '@midnight-ntwrk/zkir-v2';
+import { readFileSync } from 'fs';
+
+const circuit = JSON.parse(readFileSync('./circuit.zkir', 'utf8'));
+const inputs = JSON.parse(readFileSync('./inputs.json', 'utf8'));
+
+try {
+  const result = /* invoke checker with circuit and inputs */;
+  console.log(JSON.stringify({ verdict: 'ACCEPTED', outputs: result }));
+} catch (e) {
+  console.log(JSON.stringify({ verdict: 'REJECTED', error: e.message }));
+}
+```
+
+Run it:
+
+```bash
+cd .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID
+node run-checker.mjs
+```
+
+Capture stdout and stderr. If the script throws due to a bug in your test setup (not a checker rejection), fix and retry once.
+
+## Step 6: Interpret and Report
+
+**Report format:**
+
+```
+### ZKIR Checker Report
+
+**Claim:** [verbatim]
+
+**Circuit source:** [fixture / compiled from Compact / hand-crafted]
+
+**Circuit:**
+\`\`\`json
+[.zkir JSON — or Compact source if compiled, with note about where .zkir was extracted]
+\`\`\`
+
+**Proof data:**
+\`\`\`json
+[inputs summary — full JSON for small circuits, key fields for large ones]
+\`\`\`
+
+**Checker output:**
+\`\`\`
+[raw stdout from runner]
+\`\`\`
+
+**Interpretation:** [Confirmed / Refuted / Inconclusive] — [explanation of what the checker result means for the claim]
+```
+
+## Step 7: Clean Up
+
+```bash
+rm -rf .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID
+```
+
+Do NOT remove the base workspace — it's shared across jobs.
+```
+
+Write this to `plugins/midnight-verify/skills/verify-by-zkir-checker/SKILL.md`.
+
+- [ ] **Step 2: Verify the file was created**
+
+Run: `head -10 plugins/midnight-verify/skills/verify-by-zkir-checker/SKILL.md`
+Expected: Frontmatter with `name: midnight-verify:verify-by-zkir-checker`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-by-zkir-checker/SKILL.md
+git commit -m "feat(verify): add verify-by-zkir-checker skill for WASM checker verification
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Create the `verify-by-zkir-inspection` skill
+
+**Files:**
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-inspection/SKILL.md`
+
+- [ ] **Step 1: Create the skill directory and file**
+
+```markdown
+---
+name: midnight-verify:verify-by-zkir-inspection
+description: >-
+  Verification by compiling Compact to ZKIR and analyzing the compiled circuit
+  structure. Extracts .zkir JSON from compilation output, parses instruction
+  arrays, counts opcodes, traces data flow, and checks transcript encoding.
+  Does not run the WASM checker — for constraint behavior, use
+  verify-by-zkir-checker instead. Loaded by the zkir-checker agent.
+version: 0.4.0
+---
+
+# Verify by ZKIR Inspection
+
+You are verifying a claim about compiled circuit structure by compiling Compact code and analyzing the resulting `.zkir` JSON. Follow these steps in order.
+
+## Critical Rule
+
+**Inspection proves what the compiler emits for specific source. It does NOT prove the circuit is correct.** Proving constraint correctness requires running the checker — use `verify-by-zkir-checker` for that. If the claim spans both structure and behavior, perform inspection first, then hand off to the checker.
+
+## Step 1: Set Up and Compile
+
+Uses the same workspace as the checker method: `.midnight-expert/verify/zkir-workspace/`. Does not require the WASM checker — only the Compact CLI and JSON parsing.
+
+Create a job directory:
+
+```bash
+JOB_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+mkdir -p .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID
+```
+
+Write a minimal `.compact` contract targeting the claim. Only include what's needed to test the specific structural property.
+
+Get the current language version and compile:
+
+```bash
+compact compile --language-version
+compact compile .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID/test-claim.compact --skip-zk
+```
+
+Capture the compiler output. Note the compiler version — ZKIR output may change between versions.
+
+## Step 2: Locate and Parse the `.zkir`
+
+After compilation, find the `.zkir` JSON in the build output directory. The typical structure is:
+
+```
+test-claim/build/zkir/<circuit-name>.zkir
+```
+
+Read the `.zkir` JSON and extract the top-level fields:
+
+```bash
+# Quick overview
+node -e "
+const zkir = JSON.parse(require('fs').readFileSync('<path-to-zkir>', 'utf8'));
+console.log(JSON.stringify({
+  version: zkir.version,
+  do_communications_commitment: zkir.do_communications_commitment,
+  num_inputs: zkir.num_inputs,
+  instruction_count: zkir.instructions.length,
+  opcodes: [...new Set(zkir.instructions.map(i => i.op))].sort()
+}, null, 2));
+"
+```
+
+## Step 3: Analyze Based on the Claim
+
+Perform targeted analysis based on what the claim asserts:
+
+| Claim type | Analysis approach |
+|---|---|
+| Instruction count | `zkir.instructions.length` |
+| Opcode usage | `zkir.instructions.filter(i => i.op === '<opcode>')` — count and list indices |
+| Opcode presence/absence | Check if opcode appears: `zkir.instructions.some(i => i.op === '<opcode>')` |
+| Transcript encoding | Look for `declare_pub_input` and `pi_skip` instructions (v2), count groups |
+| I/O shape | Count `output`, `public_input`, `private_input` instructions |
+| Constraint structure | Trace data flow: find constraint instructions, follow their input variable references back through the DAG to see what feeds into them |
+| ZKIR version format | Check `zkir.version.major` — 2 for v2, 3 for v3 |
+| Variable numbering | In v2, check that instructions reference sequential integer indices. In v3, look for named variables like `%v.0`, `%v.1` |
+
+For complex structural claims, write a small Node.js script in the job directory to perform the analysis and output structured JSON.
+
+## Step 4: Report
+
+```
+### ZKIR Inspection Report
+
+**Claim:** [verbatim]
+
+**Compact source:**
+\`\`\`compact
+[the contract you compiled]
+\`\`\`
+
+**Compiler version:** [output of compact compile --language-version]
+
+**ZKIR version:** v2 / v3
+
+**Analysis:**
+- Total instructions: N
+- [other relevant metrics based on claim type]
+
+**Key findings:**
+[specific instructions, indices, and patterns that address the claim]
+
+**Interpretation:** [Confirmed / Refuted / Inconclusive] — [explanation]
+```
+
+## Step 5: Clean Up
+
+```bash
+rm -rf .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID
+```
+```
+
+Write this to `plugins/midnight-verify/skills/verify-by-zkir-inspection/SKILL.md`.
+
+- [ ] **Step 2: Verify the file was created**
+
+Run: `head -10 plugins/midnight-verify/skills/verify-by-zkir-inspection/SKILL.md`
+Expected: Frontmatter with `name: midnight-verify:verify-by-zkir-inspection`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-by-zkir-inspection/SKILL.md
+git commit -m "feat(verify): add verify-by-zkir-inspection skill for circuit structure analysis
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Create the `zkir-regression` skill
+
+**Files:**
+- Create: `plugins/midnight-verify/skills/zkir-regression/SKILL.md`
+
+- [ ] **Step 1: Create the skill directory and file**
+
+```markdown
+---
+name: midnight-verify:zkir-regression
+description: >-
+  Run the ZKIR test fixture library against the current toolchain to detect
+  behavioral changes. Supports full sweep (all opcodes) and targeted sweep
+  (single category). Produces a pass/fail report. Invocable as
+  /midnight-verify:zkir-regression or loadable by agents as a sense-check
+  when they suspect toolchain issues.
+version: 0.4.0
+argument-hint: "[category: arithmetic|constraints|comparison|control-flow|type-encoding|division|cryptographic|io|transcript]"
+---
+
+# ZKIR Regression Sweep
+
+Run the ZKIR fixture library against the current toolchain to detect behavioral changes. Use this when:
+- A new compiler version or checker version is released
+- An agent suspects unexpected behavior from the toolchain
+- You want to validate the fixture library itself after adding new test cases
+
+## Step 1: Determine Mode
+
+If `$ARGUMENTS` is empty → **full sweep** (all categories).
+
+If `$ARGUMENTS` contains a category name → **targeted sweep** (that category only).
+
+Valid categories: `arithmetic`, `constraints`, `comparison`, `control-flow`, `type-encoding`, `division`, `cryptographic`, `io`, `transcript`.
+
+## Step 2: Set Up the Workspace
+
+Ensure `.midnight-expert/verify/zkir-workspace/` is initialized with `@midnight-ntwrk/zkir-v2` installed. Follow the same workspace setup as `verify-by-zkir-checker` Step 1.
+
+## Step 3: Load the Fixture Manifest
+
+Read the manifest from the checker skill's fixtures directory:
+
+```bash
+FIXTURES_DIR="${CLAUDE_SKILL_DIR}/../verify-by-zkir-checker/fixtures"
+```
+
+If the directory does not exist, report an error:
+> "Fixture library not found at expected path. The verify-by-zkir-checker skill may not be installed or the fixtures have not been created yet."
+
+Read `$FIXTURES_DIR/test-cases/manifest.json`. For targeted sweeps, filter `test_cases` by the requested category.
+
+## Step 4: Record Toolchain Versions
+
+```bash
+compact compile --language-version
+node -e "console.log(require('@midnight-ntwrk/zkir-v2/package.json').version)"
+```
+
+Record both for the report header.
+
+## Step 5: Run Each Test Case
+
+For each test case in the (filtered) manifest:
+
+1. Copy the circuit `.zkir` from `$FIXTURES_DIR/circuits/<path>` to a temporary job directory
+2. Copy the test case JSON from `$FIXTURES_DIR/test-cases/<path>` to the job directory
+3. Run the checker (same invocation as `verify-by-zkir-checker` Step 5)
+4. Compare the checker result to the `expect` field:
+   - If `expect: "accept"` and checker accepted → **PASS**
+   - If `expect: "reject"` and checker rejected → **PASS**
+   - Otherwise → **FAIL** — record the expected vs actual result and error message
+5. Clean up the job directory
+
+Do NOT stop on first failure — run all test cases and collect all results.
+
+## Step 6: Report
+
+```markdown
+## ZKIR Regression Report
+
+**Toolchain:** compact compiler vX.Y.Z, @midnight-ntwrk/zkir-v2@A.B.C
+**Fixture version:** [from manifest.json]
+**Mode:** [full sweep / targeted: <category>]
+**Ran:** N test cases
+
+### Results
+
+| Category | Passed | Failed | Total |
+|---|---|---|---|
+| arithmetic | N | N | N |
+| constraints | N | N | N |
+| comparison | N | N | N |
+| control-flow | N | N | N |
+| type-encoding | N | N | N |
+| division | N | N | N |
+| cryptographic | N | N | N |
+| io | N | N | N |
+| transcript | N | N | N |
+| **Total** | **N** | **N** | **N** |
+
+### Failures
+
+[For each failure:]
+
+**<test-id>:** Expected <expect>, got <actual>: "<error message>"
+- Circuit: <circuit path>
+- Interpretation: [what this failure suggests about toolchain changes]
+```
+
+If there are zero failures, end with:
+> All N test cases passed. Toolchain behavior matches fixture expectations.
+
+## Adding New Fixtures
+
+To add a new test case to the library:
+
+1. Create the `.zkir` circuit in `$FIXTURES_DIR/circuits/<category>/<name>.zkir`
+2. Create the test case JSON in `$FIXTURES_DIR/test-cases/<category>/<name>.json` with the circuit reference, proof data, and expected result
+3. Add an entry to `$FIXTURES_DIR/test-cases/manifest.json`
+4. Run a targeted sweep on the category to verify the new test passes
+```
+
+Write this to `plugins/midnight-verify/skills/zkir-regression/SKILL.md`.
+
+- [ ] **Step 2: Verify the file was created**
+
+Run: `head -10 plugins/midnight-verify/skills/zkir-regression/SKILL.md`
+Expected: Frontmatter with `name: midnight-verify:zkir-regression`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/zkir-regression/SKILL.md
+git commit -m "feat(verify): add zkir-regression skill for fixture library sweep
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Create fixture templates
+
+**Files:**
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/templates/pure-circuit.json`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/templates/witness-circuit.json`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/templates/transcript-circuit.json`
+
+- [ ] **Step 1: Create the templates directory and pure-circuit template**
+
+```json
+{
+  "_comment": "Template: pure circuit with no state or witnesses. Load two immediates, apply an operation, constrain the result, output it.",
+  "_usage": "Replace IMMEDIATE_A, IMMEDIATE_B, OPERATION, and EXPECTED_RESULT. Variable indices: 0=imm_a, 1=imm_b, 2=op_result, 3=expected.",
+  "circuit": {
+    "version": { "major": 2, "minor": 0 },
+    "do_communications_commitment": false,
+    "num_inputs": 0,
+    "instructions": [
+      { "op": "load_imm", "imm": "IMMEDIATE_A" },
+      { "op": "load_imm", "imm": "IMMEDIATE_B" },
+      { "op": "OPERATION", "a": 0, "b": 1 },
+      { "op": "load_imm", "imm": "EXPECTED_RESULT" },
+      { "op": "constrain_eq", "a": 2, "b": 3 },
+      { "op": "output", "var": 2 }
+    ]
+  },
+  "inputs": {
+    "input": { "value": [], "alignment": [] },
+    "output": { "value": ["EXPECTED_RESULT_BYTES"], "alignment": [{ "tag": "atom", "value": { "tag": "field" } }] },
+    "publicTranscript": [],
+    "privateTranscriptOutputs": []
+  },
+  "expect": "accept"
+}
+```
+
+Write to `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/templates/pure-circuit.json`.
+
+- [ ] **Step 2: Create the witness-circuit template**
+
+```json
+{
+  "_comment": "Template: circuit with a private witness input. The circuit reads a private value and constrains it.",
+  "_usage": "Replace WITNESS_TYPE, PUBLIC_VALUE, and constraint logic. Variable 0=private_input result.",
+  "circuit": {
+    "version": { "major": 2, "minor": 0 },
+    "do_communications_commitment": false,
+    "num_inputs": 0,
+    "instructions": [
+      { "op": "private_input", "type": "WITNESS_TYPE", "guard": null },
+      { "op": "load_imm", "imm": "PUBLIC_VALUE" },
+      { "op": "constrain_eq", "a": 0, "b": 1 }
+    ]
+  },
+  "inputs": {
+    "input": { "value": [], "alignment": [] },
+    "output": { "value": [], "alignment": [] },
+    "publicTranscript": [],
+    "privateTranscriptOutputs": [
+      { "value": ["WITNESS_VALUE_BYTES"], "alignment": [{ "tag": "atom", "value": { "tag": "field" } }] }
+    ]
+  },
+  "expect": "accept"
+}
+```
+
+Write to `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/templates/witness-circuit.json`.
+
+- [ ] **Step 3: Create the transcript-circuit template**
+
+```json
+{
+  "_comment": "Template: circuit with public transcript (ledger interaction). Uses declare_pub_input and pi_skip for transcript encoding.",
+  "_usage": "Replace transcript operations. This template shows a minimal idx+addi+ins pattern (read, increment, write).",
+  "circuit": {
+    "version": { "major": 2, "minor": 0 },
+    "do_communications_commitment": true,
+    "num_inputs": 0,
+    "instructions": [
+      { "op": "load_imm", "imm": "OPCODE_HEX" },
+      { "op": "declare_pub_input", "var": 0 },
+      { "op": "load_imm", "imm": "OPERAND_HEX" },
+      { "op": "declare_pub_input", "var": 2 },
+      { "op": "pi_skip", "guard": 0, "count": 2 }
+    ]
+  },
+  "inputs": {
+    "input": { "value": [], "alignment": [] },
+    "output": { "value": [], "alignment": [] },
+    "publicTranscript": ["TRANSCRIPT_OPERATIONS"],
+    "privateTranscriptOutputs": []
+  },
+  "expect": "accept"
+}
+```
+
+Write to `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/templates/transcript-circuit.json`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/templates/
+git commit -m "feat(verify): add ZKIR fixture templates (pure, witness, transcript circuits)
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Create initial fixture circuits and test cases — arithmetic
+
+**Files:**
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/arithmetic/add-basic.zkir`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/arithmetic/add-wrong.zkir`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/arithmetic/mul-basic.zkir`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/arithmetic/mul-by-zero.zkir`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/arithmetic/neg-basic.zkir`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/test-cases/arithmetic/add-basic.json`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/test-cases/arithmetic/add-wrong.json`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/test-cases/arithmetic/mul-basic.json`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/test-cases/arithmetic/mul-by-zero.json`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/test-cases/arithmetic/neg-basic.json`
+
+This task creates fixture circuits and test cases for the arithmetic category based on the ZKIR reference PDF's oracle traces. Each circuit is a minimal hand-crafted `.zkir` JSON. Each test case bundles the circuit with proof data and expected verdict.
+
+- [ ] **Step 1: Create add-basic circuit (3 + 4 = 7, expect accept)**
+
+`circuits/arithmetic/add-basic.zkir`:
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "03" },
+    { "op": "load_imm", "imm": "04" },
+    { "op": "add", "a": 0, "b": 1 },
+    { "op": "load_imm", "imm": "07" },
+    { "op": "constrain_eq", "a": 2, "b": 3 },
+    { "op": "output", "var": 2 }
+  ]
+}
+```
+
+`test-cases/arithmetic/add-basic.json`:
+```json
+{
+  "description": "add: 3 + 4 = 7",
+  "circuit": "circuits/arithmetic/add-basic.zkir",
+  "inputs": {
+    "input": { "value": [], "alignment": [] },
+    "output": { "value": [7], "alignment": [{ "tag": "atom", "value": { "tag": "field" } }] },
+    "publicTranscript": [],
+    "privateTranscriptOutputs": []
+  },
+  "expect": "accept"
+}
+```
+
+- [ ] **Step 2: Create add-wrong circuit (3 + 4 != 8, expect reject)**
+
+`circuits/arithmetic/add-wrong.zkir`:
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "03" },
+    { "op": "load_imm", "imm": "04" },
+    { "op": "add", "a": 0, "b": 1 },
+    { "op": "load_imm", "imm": "08" },
+    { "op": "constrain_eq", "a": 2, "b": 3 },
+    { "op": "output", "var": 2 }
+  ]
+}
+```
+
+`test-cases/arithmetic/add-wrong.json`:
+```json
+{
+  "description": "add: 3 + 4 != 8 (wrong expected value)",
+  "circuit": "circuits/arithmetic/add-wrong.zkir",
+  "inputs": {
+    "input": { "value": [], "alignment": [] },
+    "output": { "value": [7], "alignment": [{ "tag": "atom", "value": { "tag": "field" } }] },
+    "publicTranscript": [],
+    "privateTranscriptOutputs": []
+  },
+  "expect": "reject"
+}
+```
+
+- [ ] **Step 3: Create mul-basic circuit (3 * 5 = 15, expect accept)**
+
+`circuits/arithmetic/mul-basic.zkir`:
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "03" },
+    { "op": "load_imm", "imm": "05" },
+    { "op": "mul", "a": 0, "b": 1 },
+    { "op": "load_imm", "imm": "0F" },
+    { "op": "constrain_eq", "a": 2, "b": 3 },
+    { "op": "output", "var": 2 }
+  ]
+}
+```
+
+`test-cases/arithmetic/mul-basic.json`:
+```json
+{
+  "description": "mul: 3 * 5 = 15",
+  "circuit": "circuits/arithmetic/mul-basic.zkir",
+  "inputs": {
+    "input": { "value": [], "alignment": [] },
+    "output": { "value": [15], "alignment": [{ "tag": "atom", "value": { "tag": "field" } }] },
+    "publicTranscript": [],
+    "privateTranscriptOutputs": []
+  },
+  "expect": "accept"
+}
+```
+
+- [ ] **Step 4: Create mul-by-zero circuit (42 * 0 = 0, expect accept)**
+
+`circuits/arithmetic/mul-by-zero.zkir`:
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "2A" },
+    { "op": "load_imm", "imm": "00" },
+    { "op": "mul", "a": 0, "b": 1 },
+    { "op": "load_imm", "imm": "00" },
+    { "op": "constrain_eq", "a": 2, "b": 3 },
+    { "op": "output", "var": 2 }
+  ]
+}
+```
+
+`test-cases/arithmetic/mul-by-zero.json`:
+```json
+{
+  "description": "mul: 42 * 0 = 0",
+  "circuit": "circuits/arithmetic/mul-by-zero.zkir",
+  "inputs": {
+    "input": { "value": [], "alignment": [] },
+    "output": { "value": [0], "alignment": [{ "tag": "atom", "value": { "tag": "field" } }] },
+    "publicTranscript": [],
+    "privateTranscriptOutputs": []
+  },
+  "expect": "accept"
+}
+```
+
+- [ ] **Step 5: Create neg-basic circuit (x + neg(x) = 0, expect accept)**
+
+`circuits/arithmetic/neg-basic.zkir`:
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "2A" },
+    { "op": "neg", "a": 0 },
+    { "op": "add", "a": 0, "b": 1 },
+    { "op": "load_imm", "imm": "00" },
+    { "op": "constrain_eq", "a": 2, "b": 3 },
+    { "op": "output", "var": 2 }
+  ]
+}
+```
+
+`test-cases/arithmetic/neg-basic.json`:
+```json
+{
+  "description": "neg: x + neg(x) = 0 (additive inverse)",
+  "circuit": "circuits/arithmetic/neg-basic.zkir",
+  "inputs": {
+    "input": { "value": [], "alignment": [] },
+    "output": { "value": [0], "alignment": [{ "tag": "atom", "value": { "tag": "field" } }] },
+    "publicTranscript": [],
+    "privateTranscriptOutputs": []
+  },
+  "expect": "accept"
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/arithmetic/
+git add plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/test-cases/arithmetic/
+git commit -m "feat(verify): add arithmetic ZKIR fixture circuits and test cases
+
+Covers add (basic + wrong), mul (basic + zero), neg (additive inverse).
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Create initial fixture circuits and test cases — constraints
+
+**Files:**
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/constraints/assert-true.zkir`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/constraints/assert-false.zkir`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/constraints/assert-two.zkir`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/constraints/cb-8bit-zero.zkir`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/constraints/cb-8bit-255.zkir`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/constraints/cb-8bit-256.zkir`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/constraints/ceq-equal.zkir`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/constraints/ceq-unequal.zkir`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/constraints/ctb-zero.zkir`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/constraints/ctb-one.zkir`
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/constraints/ctb-two.zkir`
+- Create: corresponding test-case JSON files in `test-cases/constraints/`
+
+This task mirrors the ZKIR reference's constraint oracle traces. Each circuit follows the same minimal pattern: `load_imm` → constraint instruction → (optional output).
+
+- [ ] **Step 1: Create assert circuits**
+
+`circuits/constraints/assert-true.zkir` — assert with input 1 (boolean true, accept):
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "01" },
+    { "op": "assert", "cond": 0 }
+  ]
+}
+```
+
+`circuits/constraints/assert-false.zkir` — assert with input 0 (boolean false, reject: "Failed direct assertion"):
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "00" },
+    { "op": "assert", "cond": 0 }
+  ]
+}
+```
+
+`circuits/constraints/assert-two.zkir` — assert with input 2 (not boolean, reject: "Expected boolean, found: 02"):
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "02" },
+    { "op": "assert", "cond": 0 }
+  ]
+}
+```
+
+Create corresponding test-case JSON files in `test-cases/constraints/` with appropriate `expect` values (accept, reject, reject).
+
+- [ ] **Step 2: Create constrain_bits circuits**
+
+`circuits/constraints/cb-8bit-zero.zkir` — constrain_bits: 0 fits in 8 bits (accept):
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "00" },
+    { "op": "constrain_bits", "var": 0, "bits": 8 }
+  ]
+}
+```
+
+`circuits/constraints/cb-8bit-255.zkir` — constrain_bits: 255 fits in 8 bits (accept):
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "FF" },
+    { "op": "constrain_bits", "var": 0, "bits": 8 }
+  ]
+}
+```
+
+`circuits/constraints/cb-8bit-256.zkir` — constrain_bits: 256 doesn't fit in 8 bits (reject: "Bit bound failed: 0001 is not 8-bit"):
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "0100" },
+    { "op": "constrain_bits", "var": 0, "bits": 8 }
+  ]
+}
+```
+
+Create corresponding test-case JSON files.
+
+- [ ] **Step 3: Create constrain_eq and constrain_to_boolean circuits**
+
+`circuits/constraints/ceq-equal.zkir` — equal values (accept):
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "2A" },
+    { "op": "load_imm", "imm": "2A" },
+    { "op": "constrain_eq", "a": 0, "b": 1 }
+  ]
+}
+```
+
+`circuits/constraints/ceq-unequal.zkir` — unequal values (reject):
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "2A" },
+    { "op": "load_imm", "imm": "2B" },
+    { "op": "constrain_eq", "a": 0, "b": 1 }
+  ]
+}
+```
+
+`circuits/constraints/ctb-zero.zkir` — constrain_to_boolean: 0 is boolean (accept):
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "00" },
+    { "op": "constrain_to_boolean", "var": 0 }
+  ]
+}
+```
+
+`circuits/constraints/ctb-one.zkir` — constrain_to_boolean: 1 is boolean (accept):
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "01" },
+    { "op": "constrain_to_boolean", "var": 0 }
+  ]
+}
+```
+
+`circuits/constraints/ctb-two.zkir` — constrain_to_boolean: 2 is not boolean (reject):
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "02" },
+    { "op": "constrain_to_boolean", "var": 0 }
+  ]
+}
+```
+
+Create corresponding test-case JSON files for all.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/constraints/
+git add plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/test-cases/constraints/
+git commit -m "feat(verify): add constraint ZKIR fixture circuits and test cases
+
+Covers assert (true/false/non-boolean), constrain_bits (0/255/256 in 8-bit),
+constrain_eq (equal/unequal), constrain_to_boolean (0/1/2).
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Create initial fixture circuits and test cases — comparison, control flow, division
+
+**Files:**
+- Create: circuits and test cases for `comparison/` (test_eq, less_than)
+- Create: circuits and test cases for `control-flow/` (cond_select, copy)
+- Create: circuits and test cases for `division/` (div_mod_power_of_two)
+
+- [ ] **Step 1: Create comparison circuits**
+
+`test_eq` — equal values produce 1, unequal produce 0. Both are accept tests (test_eq doesn't fail, it produces a boolean result):
+
+`circuits/comparison/teq-equal.zkir`:
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "2A" },
+    { "op": "load_imm", "imm": "2A" },
+    { "op": "test_eq", "a": 0, "b": 1 },
+    { "op": "load_imm", "imm": "01" },
+    { "op": "constrain_eq", "a": 2, "b": 3 },
+    { "op": "output", "var": 2 }
+  ]
+}
+```
+
+`circuits/comparison/teq-unequal.zkir`:
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "2A" },
+    { "op": "load_imm", "imm": "2B" },
+    { "op": "test_eq", "a": 0, "b": 1 },
+    { "op": "constrain_to_boolean", "var": 2 },
+    { "op": "output", "var": 2 }
+  ]
+}
+```
+
+`less_than` — 3 < 10 is true (8-bit), 10 < 3 is false:
+
+`circuits/comparison/lt-true.zkir`:
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "03" },
+    { "op": "load_imm", "imm": "0A" },
+    { "op": "less_than", "a": 0, "b": 1, "bits": 8 },
+    { "op": "load_imm", "imm": "01" },
+    { "op": "constrain_eq", "a": 2, "b": 3 },
+    { "op": "output", "var": 2 }
+  ]
+}
+```
+
+`circuits/comparison/lt-false.zkir`:
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "0A" },
+    { "op": "load_imm", "imm": "03" },
+    { "op": "less_than", "a": 0, "b": 1, "bits": 8 },
+    { "op": "load_imm", "imm": "00" },
+    { "op": "constrain_eq", "a": 2, "b": 3 },
+    { "op": "output", "var": 2 }
+  ]
+}
+```
+
+Create corresponding test-case JSON files (all expect accept).
+
+- [ ] **Step 2: Create control flow circuits**
+
+`cond_select` — bit=1 selects first, bit=0 selects second:
+
+`circuits/control-flow/csel-true.zkir`:
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "01" },
+    { "op": "load_imm", "imm": "AA" },
+    { "op": "load_imm", "imm": "BB" },
+    { "op": "cond_select", "bit": 0, "a": 1, "b": 2 },
+    { "op": "load_imm", "imm": "AA" },
+    { "op": "constrain_eq", "a": 3, "b": 4 },
+    { "op": "output", "var": 3 }
+  ]
+}
+```
+
+`circuits/control-flow/csel-false.zkir`:
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "00" },
+    { "op": "load_imm", "imm": "AA" },
+    { "op": "load_imm", "imm": "BB" },
+    { "op": "cond_select", "bit": 0, "a": 1, "b": 2 },
+    { "op": "load_imm", "imm": "BB" },
+    { "op": "constrain_eq", "a": 3, "b": 4 },
+    { "op": "output", "var": 3 }
+  ]
+}
+```
+
+`copy` — copied value equals original:
+
+`circuits/control-flow/copy-basic.zkir`:
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "2A" },
+    { "op": "copy", "var": 0 },
+    { "op": "constrain_eq", "a": 0, "b": 1 },
+    { "op": "output", "var": 1 }
+  ]
+}
+```
+
+Create corresponding test-case JSON files.
+
+- [ ] **Step 3: Create division circuit**
+
+`div_mod_power_of_two` — 11 divmod 2^3 = (1, 3):
+
+`circuits/division/divmod-basic.zkir`:
+```json
+{
+  "version": { "major": 2, "minor": 0 },
+  "do_communications_commitment": false,
+  "num_inputs": 0,
+  "instructions": [
+    { "op": "load_imm", "imm": "0B" },
+    { "op": "div_mod_power_of_two", "var": 0, "bits": 3 },
+    { "op": "load_imm", "imm": "01" },
+    { "op": "constrain_eq", "a": 1, "b": 3 },
+    { "op": "load_imm", "imm": "03" },
+    { "op": "constrain_eq", "a": 2, "b": 5 },
+    { "op": "output", "var": 1 },
+    { "op": "output", "var": 2 }
+  ]
+}
+```
+
+Create corresponding test-case JSON.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/comparison/
+git add plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/control-flow/
+git add plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/division/
+git add plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/test-cases/comparison/
+git add plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/test-cases/control-flow/
+git add plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/test-cases/division/
+git commit -m "feat(verify): add comparison, control flow, division ZKIR fixtures
+
+Covers test_eq, less_than, cond_select, copy, div_mod_power_of_two.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Create the fixture manifest
+
+**Files:**
+- Create: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/test-cases/manifest.json`
+
+- [ ] **Step 1: Create the manifest indexing all test cases from Tasks 7-9**
+
+Build `manifest.json` with entries for every test case created so far. Each entry has: `id`, `category`, `opcode`, `file` (relative path within `test-cases/`), `zkir_version`, `expect`.
+
+```json
+{
+  "version": "0.1.0",
+  "generated_for": "compact-compiler-v0.29.0",
+  "checker_package": "@midnight-ntwrk/zkir-v2@2.1.0",
+  "test_cases": [
+    { "id": "add-basic", "category": "arithmetic", "opcode": "add", "file": "arithmetic/add-basic.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "add-wrong", "category": "arithmetic", "opcode": "add", "file": "arithmetic/add-wrong.json", "zkir_version": "v2", "expect": "reject" },
+    { "id": "mul-basic", "category": "arithmetic", "opcode": "mul", "file": "arithmetic/mul-basic.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "mul-by-zero", "category": "arithmetic", "opcode": "mul", "file": "arithmetic/mul-by-zero.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "neg-basic", "category": "arithmetic", "opcode": "neg", "file": "arithmetic/neg-basic.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "assert-true", "category": "constraints", "opcode": "assert", "file": "constraints/assert-true.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "assert-false", "category": "constraints", "opcode": "assert", "file": "constraints/assert-false.json", "zkir_version": "v2", "expect": "reject" },
+    { "id": "assert-two", "category": "constraints", "opcode": "assert", "file": "constraints/assert-two.json", "zkir_version": "v2", "expect": "reject" },
+    { "id": "cb-8bit-zero", "category": "constraints", "opcode": "constrain_bits", "file": "constraints/cb-8bit-zero.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "cb-8bit-255", "category": "constraints", "opcode": "constrain_bits", "file": "constraints/cb-8bit-255.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "cb-8bit-256", "category": "constraints", "opcode": "constrain_bits", "file": "constraints/cb-8bit-256.json", "zkir_version": "v2", "expect": "reject" },
+    { "id": "ceq-equal", "category": "constraints", "opcode": "constrain_eq", "file": "constraints/ceq-equal.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "ceq-unequal", "category": "constraints", "opcode": "constrain_eq", "file": "constraints/ceq-unequal.json", "zkir_version": "v2", "expect": "reject" },
+    { "id": "ctb-zero", "category": "constraints", "opcode": "constrain_to_boolean", "file": "constraints/ctb-zero.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "ctb-one", "category": "constraints", "opcode": "constrain_to_boolean", "file": "constraints/ctb-one.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "ctb-two", "category": "constraints", "opcode": "constrain_to_boolean", "file": "constraints/ctb-two.json", "zkir_version": "v2", "expect": "reject" },
+    { "id": "teq-equal", "category": "comparison", "opcode": "test_eq", "file": "comparison/teq-equal.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "teq-unequal", "category": "comparison", "opcode": "test_eq", "file": "comparison/teq-unequal.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "lt-true", "category": "comparison", "opcode": "less_than", "file": "comparison/lt-true.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "lt-false", "category": "comparison", "opcode": "less_than", "file": "comparison/lt-false.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "csel-true", "category": "control-flow", "opcode": "cond_select", "file": "control-flow/csel-true.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "csel-false", "category": "control-flow", "opcode": "cond_select", "file": "control-flow/csel-false.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "copy-basic", "category": "control-flow", "opcode": "copy", "file": "control-flow/copy-basic.json", "zkir_version": "v2", "expect": "accept" },
+    { "id": "divmod-basic", "category": "division", "opcode": "div_mod_power_of_two", "file": "division/divmod-basic.json", "zkir_version": "v2", "expect": "accept" }
+  ]
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/test-cases/manifest.json
+git commit -m "feat(verify): add ZKIR fixture manifest indexing all test cases
+
+24 test cases across 5 categories (arithmetic, constraints, comparison,
+control-flow, division).
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Future: Expand fixture library (cryptographic, io, transcript, type-encoding)
+
+Tasks 7-9 create 24 fixtures covering the simpler opcode categories. The remaining categories — cryptographic (ec_mul, ec_mul_generator, hash_to_curve, persistent_hash, transient_hash), I/O (private_input, public_input, output, impact), transcript (full counter/guarded_counter circuits), and type-encoding (encode, decode, reconstitute_field) — require more complex circuit construction:
+
+- **Cryptographic:** Multi-output instructions (two field elements for point coordinates), curve point alignment metadata
+- **I/O:** Witness data in `privateTranscriptOutputs`, guarded inputs
+- **Transcript:** Full `declare_pub_input`/`pi_skip` encoding, `publicTranscript` VM operations
+- **Type encoding:** v3-only opcodes (encode/decode), `reconstitute_field` with bit-width parameters
+
+These should be added iteratively after the initial fixture set is validated against the WASM checker and the checker API is documented in `CHECKER-API.md`. Target: mirror the ZKIR reference's 68 v2 oracle traces. Update `manifest.json` as new fixtures are added.
+
+---
+
+### Task 11: Update `verify-correctness` hub skill
+
+**Files:**
+- Modify: `plugins/midnight-verify/skills/verify-correctness/SKILL.md`
+
+- [ ] **Step 1: Add ZKIR domain to classification table**
+
+In the `### 1. Classify the Domain` section, add a new row to the table after the SDK/TypeScript row:
+
+```markdown
+| **ZKIR** | ZKIR opcodes, circuit constraints, field elements, proof data, `.zkir` files, transcript protocol, checker behavior, circuit structure | Load `midnight-verify:verify-zkir` |
+```
+
+And update the Cross-domain row to include ZKIR:
+
+```markdown
+| **Cross-domain** | Spans Compact and SDK, Compact and ZKIR, or protocol/architecture | Load applicable domain skills |
+```
+
+- [ ] **Step 2: Add ZKIR dispatch instructions**
+
+In the `### 3. Dispatch Sub-Agents` section, add after the package/version check entry:
+
+```markdown
+- **ZKIR checker verification needed** → dispatch `midnight-verify:zkir-checker` agent with the claim and whether to use the checker method, inspection method, or both
+- **ZKIR regression sweep needed** → dispatch `midnight-verify:zkir-checker` agent and instruct it to load the `midnight-verify:zkir-regression` skill
+```
+
+- [ ] **Step 3: Add ZKIR verdict qualifiers**
+
+In the `### 4. Synthesize the Verdict` section, add these rows to the verdict table:
+
+```markdown
+| **Confirmed** | (zkir-checked) | WASM checker accepted the circuit with expected inputs |
+| **Confirmed** | (zkir-checked + tested) | Both WASM checker and Compact JS runtime agree |
+| **Confirmed** | (zkir-inspected) | Circuit structure analysis confirms the claim |
+| **Confirmed** | (zkir-checked + source-verified) | Checker result corroborated by source inspection |
+| **Refuted** | (zkir-checked) | WASM checker produced unexpected accept/reject for the claim |
+| **Refuted** | (zkir-inspected) | Circuit structure contradicts the claim |
+| **Inconclusive** | (zkir-checker unavailable) | `@midnight-ntwrk/zkir-v2` could not be installed or loaded |
+```
+
+Add to the conflict resolution paragraph:
+
+```markdown
+**When WASM checker and Compact JS runtime disagree:** The checker is more authoritative for constraint behavior (it operates at the proof system level). The JS runtime is more authoritative for output values (it runs the actual contract logic). Flag the disagreement in your report.
+```
+
+- [ ] **Step 4: Update the version in frontmatter to 0.4.0**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-correctness/SKILL.md
+git commit -m "feat(verify): add ZKIR domain, dispatch, and verdicts to hub skill
+
+Adds ZKIR classification, zkir-checker dispatch instructions, 7 new verdict
+qualifiers, and checker/runtime conflict resolution guidance.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: Update `verify-compact` routing skill
+
+**Files:**
+- Modify: `plugins/midnight-verify/skills/verify-compact/SKILL.md`
+
+- [ ] **Step 1: Add ZKIR-related rows to the routing table**
+
+After the "Performance claims" row in the `## Claim Type → Method Routing` table, add:
+
+```markdown
+| Circuit constraint structure | "this contract produces N constraints" | **zkir-checker** (inspection) |
+| Compiled ZKIR properties | "disclosure compiles to declare_pub_input" | **zkir-checker** (inspection) |
+| Constraint correctness | "guard circuit correctly constrains authority hash" | **zkir-checker** (checker) + **contract-writer** (concurrent) |
+```
+
+- [ ] **Step 2: Update the version in frontmatter to 0.3.0**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-compact/SKILL.md
+git commit -m "feat(verify): add ZKIR routing rows to verify-compact skill
+
+Routes circuit structure, compiled ZKIR properties, and constraint correctness
+claims to the zkir-checker agent.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 13: Update `verify-by-execution` skill
+
+**Files:**
+- Modify: `plugins/midnight-verify/skills/verify-by-execution/SKILL.md`
+
+- [ ] **Step 1: Add optional ZKIR extraction step**
+
+After `## Step 4: Compile` and before `## Step 5: Write and Run the Runner Script`, add:
+
+```markdown
+## Step 4.5: Extract ZKIR (Optional)
+
+If the verifier requested ZKIR-level evidence alongside execution results, locate the `.zkir` JSON in the compilation output. It is typically found at:
+
+```
+<contract-name>/build/zkir/<circuit-name>.zkir
+```
+
+If found, note the path in your report so the verifier can dispatch the `zkir-checker` agent if needed. Do NOT run the checker yourself — your job is compilation and JS runtime execution.
+
+If no `.zkir` output is found (some compilation modes may not produce it), note this in your report.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-by-execution/SKILL.md
+git commit -m "feat(verify): add optional ZKIR extraction step to execution skill
+
+Allows contract-writer to surface .zkir paths for cross-method verification.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 14: Update `verifier` agent and `plugin.json`
+
+**Files:**
+- Modify: `plugins/midnight-verify/agents/verifier.md`
+- Modify: `plugins/midnight-verify/.claude-plugin/plugin.json`
+
+- [ ] **Step 1: Update the verifier agent to include ZKIR dispatch**
+
+In the `## Dispatching Sub-Agents` section, add after the SDK verification block:
+
+```markdown
+**ZKIR verification:**
+- Checker verification → dispatch `midnight-verify:zkir-checker`
+- Circuit inspection → dispatch `midnight-verify:zkir-checker`
+- Regression sweep → dispatch `midnight-verify:zkir-checker` with instruction to load `midnight-verify:zkir-regression`
+```
+
+Update the `skills:` frontmatter to add `midnight-verify:verify-zkir`:
+
+```
+skills: midnight-verify:verify-correctness, midnight-verify:verify-compact, midnight-verify:verify-sdk, midnight-verify:verify-zkir
+```
+
+Add a ZKIR example to the `description:` frontmatter:
+
+```
+  Example 6: User runs /verify "constrain_bits enforces 8-bit range" — the
+  orchestrator classifies this as a ZKIR opcode claim, dispatches the
+  zkir-checker agent to run fixture circuits through the WASM checker.
+```
+
+- [ ] **Step 2: Update plugin.json**
+
+Change `version` from `"0.3.0"` to `"0.4.0"`.
+
+Add to `keywords` array: `"zkir"`, `"circuit"`, `"proof"`, `"checker"`, `"wasm"`.
+
+Update `description` to include ZKIR:
+
+```json
+"description": "Verification framework for Midnight claims — verifies Compact code by compiling and executing test contracts, SDK/TypeScript claims by type-checking and devnet E2E testing, ZKIR circuits by running through the WASM checker and inspecting compiled structure, or by inspecting source code. Multi-agent pipeline with explicit /verify command."
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/midnight-verify/agents/verifier.md plugins/midnight-verify/.claude-plugin/plugin.json
+git commit -m "chore(verify): bump version to 0.4.0, add ZKIR to verifier and plugin manifest
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 15: Validate the complete plugin structure
+
+- [ ] **Step 1: Verify all new files exist**
+
+```bash
+echo "=== New agent ===" && ls plugins/midnight-verify/agents/zkir-checker.md
+echo "=== New skills ===" && ls plugins/midnight-verify/skills/verify-zkir/SKILL.md plugins/midnight-verify/skills/verify-by-zkir-checker/SKILL.md plugins/midnight-verify/skills/verify-by-zkir-inspection/SKILL.md plugins/midnight-verify/skills/zkir-regression/SKILL.md
+echo "=== Fixtures ===" && ls plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/templates/ && ls plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/test-cases/manifest.json
+echo "=== Circuit categories ===" && ls plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/circuits/
+echo "=== Test case categories ===" && ls plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/test-cases/
+```
+
+Expected: All files present. Circuit categories: arithmetic, constraints, comparison, control-flow, division. Test case categories match.
+
+- [ ] **Step 2: Verify all skill frontmatter parses correctly**
+
+```bash
+for f in plugins/midnight-verify/skills/*/SKILL.md; do echo "--- $f ---"; head -3 "$f"; done
+```
+
+Expected: Each skill file starts with `---` and has a `name:` field.
+
+- [ ] **Step 3: Verify plugin.json version is 0.4.0**
+
+```bash
+cat plugins/midnight-verify/.claude-plugin/plugin.json | grep version
+```
+
+Expected: `"version": "0.4.0"`
+
+- [ ] **Step 4: Count total test cases in manifest matches fixture files**
+
+```bash
+node -e "const m = JSON.parse(require('fs').readFileSync('plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/test-cases/manifest.json','utf8')); console.log('Manifest entries:', m.test_cases.length)"
+```
+
+Expected: 24 test cases.
+
+- [ ] **Step 5: Commit final validation (if any fixes were needed)**
+
+Only commit if fixes were made during validation. Otherwise, move on.

--- a/docs/superpowers/plans/2026-03-30-zkir-checker-rework.md
+++ b/docs/superpowers/plans/2026-03-30-zkir-checker-rework.md
@@ -1,0 +1,621 @@
+# ZKIR Checker Rework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rework the ZKIR checker skill to use the real PLONK verification pipeline (compile without `--skip-zk` → execute → serialize → check with real keys), delete all hand-crafted fixtures, rewrite regression as a claim list, and update the agent/inspection skill.
+
+**Architecture:** The `@midnight-ntwrk/zkir-v2` WASM package is a full PLONK prover/verifier requiring circuit-specific keys from compilation. The checker skill's pipeline becomes: compile Compact in place → execute via JS runtime → `proofDataIntoSerializedPreimage()` (5 args) → `check()` with `keyProvider`. Hand-crafted `.zkir` and fixtures are removed entirely.
+
+**Tech Stack:** `@midnight-ntwrk/zkir-v2` (WASM PLONK verifier), `@midnight-ntwrk/compact-runtime` (`proofDataIntoSerializedPreimage`), Compact CLI (without `--skip-zk`).
+
+**Spec:** `docs/superpowers/specs/2026-03-30-zkir-checker-rework-design.md`
+
+---
+
+### Task 1: Delete all fixture files
+
+**Files:**
+- Delete: `plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures/` (entire directory tree, 52 files)
+
+- [ ] **Step 1: Delete the fixtures directory**
+
+```bash
+rm -rf plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures
+```
+
+Verify it's gone:
+
+```bash
+ls plugins/midnight-verify/skills/verify-by-zkir-checker/
+```
+
+Expected: Only `SKILL.md` remains.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add -A plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures
+git commit -m "refactor(verify): remove hand-crafted ZKIR fixtures
+
+Hand-crafted .zkir circuits cannot be executed through the real PLONK
+checker — it requires proving keys from Compact compilation. Fixtures
+are replaced by the claim-based regression approach.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Rewrite `verify-by-zkir-checker` skill
+
+**Files:**
+- Rewrite: `plugins/midnight-verify/skills/verify-by-zkir-checker/SKILL.md`
+
+- [ ] **Step 1: Replace the entire skill file**
+
+Write the following content to `plugins/midnight-verify/skills/verify-by-zkir-checker/SKILL.md`:
+
+```markdown
+---
+name: midnight-verify:verify-by-zkir-checker
+description: >-
+  Verification by running the full ZK proof pipeline: compile Compact without
+  --skip-zk to generate PLONK keys, execute the circuit via JS runtime to get
+  proof data, serialize with proofDataIntoSerializedPreimage(), then verify
+  with the @midnight-ntwrk/zkir-v2 WASM PLONK checker. Supports both contract
+  mode (verify a user's .compact file) and claim mode (write a minimal contract
+  to test a claim). Loaded by the zkir-checker agent.
+version: 0.4.1
+---
+
+# Verify by ZKIR Checker
+
+You are verifying a Compact contract or ZKIR claim by running the full zero-knowledge proof pipeline. This uses the real PLONK verifier — the same verification path the Midnight network uses. Follow these steps in order.
+
+## Critical Rule
+
+**Always compile without `--skip-zk`.** The whole point of this method is using the real PLONK verifier with real proving keys. A checker ACCEPT proves the ZK proof is valid for those specific inputs. It does NOT prove the circuit is correct for all inputs.
+
+**What this proves that `verify-by-execution` doesn't:** The execution skill compiles with `--skip-zk` and runs the JS runtime — it proves the contract logic works. This skill proves the contract's zero-knowledge proof is valid: constraints are satisfied, transcript encoding is correct, proof data serializes properly, and the PLONK verifier accepts.
+
+## Step 1: Set Up the Workspace
+
+The workspace lives at `.midnight-expert/verify/zkir-workspace/` relative to the project root.
+
+**First time (workspace does not exist):**
+
+```bash
+mkdir -p .midnight-expert/verify/zkir-workspace
+cd .midnight-expert/verify/zkir-workspace
+npm init -y
+npm install @midnight-ntwrk/zkir-v2 @midnight-ntwrk/compact-runtime
+```
+
+**Subsequent times (workspace exists):**
+
+```bash
+cd .midnight-expert/verify/zkir-workspace
+npm ls @midnight-ntwrk/zkir-v2
+```
+
+If `npm ls` reports errors, run `npm install` to repair.
+
+**Create the job directory:**
+
+```bash
+JOB_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+mkdir -p .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID
+```
+
+## Step 2: Get the Contract
+
+### Contract Mode (primary)
+
+The user provides a `.compact` file or path. The contract may have imports and dependencies on other `.compact` files in its directory — **compile it where it lives**, directing only the build output to the job directory.
+
+If the contract has already been compiled with keys (a build directory exists containing `keys/*.prover` and `zkir/*.bzkir`), copy those build artifacts to the job directory instead of recompiling.
+
+### Claim Mode
+
+No user contract provided — you're verifying a natural language claim about ZK behavior. Write a minimal `.compact` contract in the job directory that exercises the claim.
+
+You may load compact-core skills as hints for writing correct Compact code. The compiled output is your evidence, not the skill content.
+
+## Step 3: Compile Without `--skip-zk`
+
+```bash
+compact compile -- <source-path> .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID/build/
+```
+
+**The source path is the `.compact` file where it lives** (contract mode) or in the job directory (claim mode). The build output always goes to `jobs/$JOB_ID/build/`.
+
+This produces:
+- `build/zkir/<circuit>.zkir` — ZKIR JSON
+- `build/zkir/<circuit>.bzkir` — ZKIR binary
+- `build/keys/<circuit>.prover` — PLONK proving key
+- `build/keys/<circuit>.verifier` — PLONK verifying key
+- `build/contract/index.js` — compiled JS contract
+- `build/compiler/contract-info.json` — circuit metadata
+
+If compilation fails, report the error. For claim mode, fix the contract and retry up to 2 times, then report Inconclusive.
+
+**Note:** Compilation without `--skip-zk` is slower than with it because it generates PLONK proving keys. This is expected — you are running the real ZK pipeline.
+
+## Step 4: Execute Via JS Runtime
+
+Import the compiled contract and execute the circuit(s) to get proof data:
+
+```javascript
+import * as compactRuntime from '@midnight-ntwrk/compact-runtime';
+import { Contract } from '<job-dir>/build/contract/index.js';
+
+// Create contract instance (may need witnesses depending on the contract)
+const contract = new Contract(witnesses);
+
+// Create initial state
+const initialZswapLocalState = { coinPublicKey: new Uint8Array(32) };
+const state = contract.initialState({ initialZswapLocalState, initialPrivateState: {} });
+
+// Create circuit context
+const context = compactRuntime.createCircuitContext(
+  compactRuntime.dummyContractAddress(),
+  initialZswapLocalState.coinPublicKey,
+  state.currentContractState.data,
+  state.currentPrivateState
+);
+
+// Execute the circuit via the circuits interface
+const circuitResult = contract.circuits.<circuitName>(context);
+
+// circuitResult contains: { result, context, proofData, gasCost }
+// proofData contains: { input, output, publicTranscript, privateTranscriptOutputs }
+```
+
+Check `build/compiler/contract-info.json` for the list of circuits. Each circuit with `"proof": true` can be verified through the PLONK checker.
+
+In **contract mode**, verify each provable circuit. In **claim mode**, only the circuit relevant to the claim.
+
+## Step 5: Serialize Proof Data
+
+```javascript
+const serializedPreimage = compactRuntime.proofDataIntoSerializedPreimage(
+  circuitResult.proofData.input,
+  circuitResult.proofData.output,
+  circuitResult.proofData.publicTranscript,
+  circuitResult.proofData.privateTranscriptOutputs,
+  '<circuitName>'  // keyLocation — matches the circuit name
+);
+```
+
+**This function takes 5 individual arguments, not an object.** The `keyLocation` parameter is the circuit name (e.g., `'increment'`) which the key provider uses to look up the correct keys.
+
+## Step 6: Run the PLONK Checker
+
+```javascript
+import { check } from '@midnight-ntwrk/zkir-v2';
+import { readFileSync } from 'fs';
+
+const keyProvider = {
+  async lookupKey(keyLocation) {
+    return {
+      proverKey: readFileSync(`<job-dir>/build/keys/${keyLocation}.prover`),
+      verifierKey: readFileSync(`<job-dir>/build/keys/${keyLocation}.verifier`),
+      ir: readFileSync(`<job-dir>/build/zkir/${keyLocation}.bzkir`)
+    };
+  },
+  async getParams(k) {
+    return readFileSync(`${process.env.HOME}/.compact/params/params_${k}.bin`);
+  }
+};
+
+try {
+  const result = await check(serializedPreimage, keyProvider);
+  // ACCEPTED — result is an array of outputs (bigint or undefined for void)
+  console.log(JSON.stringify({ verdict: 'ACCEPTED', outputs: result.map(v => v?.toString()) }));
+} catch (e) {
+  // REJECTED — error message identifies which constraint failed
+  console.log(JSON.stringify({ verdict: 'REJECTED', error: e.message }));
+}
+```
+
+**Checker error message catalog:**
+- `"Communications commitment mismatch"` — tampered raw bytes or commitment error
+- `"Public transcript input mismatch for input N; expected: Some(XX), computed: Some(YY)"` — wrong transcript values
+- `"Failed direct assertion"` — assert input is boolean 0
+- `"Expected boolean, found: XX"` — non-boolean to assert/cond_select/constrain_to_boolean
+- `"Failed equality constraint: XX != YY"` — constrain_eq inputs differ
+- `"Bit bound failed: XX is not N-bit"` — constrain_bits value exceeds range
+- `"Ran out of private transcript outputs"` — missing witness data
+- `"Transcripts not fully consumed"` — extra unused witness data
+
+## Step 7: Negative Testing (When Appropriate)
+
+For claims about rejection behavior (e.g., "tampering with the transcript is detected"), tamper with the proof data **before serialization** and confirm the checker rejects with the expected error:
+
+```javascript
+// Example: modify a transcript value
+const tamperedProofData = {
+  ...circuitResult.proofData,
+  publicTranscript: circuitResult.proofData.publicTranscript.map(op => {
+    if ('addi' in op) return { addi: { immediate: 999 } }; // Wrong value
+    return op;
+  })
+};
+
+const tamperedSerialized = compactRuntime.proofDataIntoSerializedPreimage(
+  tamperedProofData.input,
+  tamperedProofData.output,
+  tamperedProofData.publicTranscript,
+  tamperedProofData.privateTranscriptOutputs,
+  '<circuitName>'
+);
+
+// This should reject with "Public transcript input mismatch"
+const result = await check(tamperedSerialized, keyProvider);
+```
+
+A rejection in a negative test **confirms** the claim (the constraint is enforced).
+
+## Step 8: Report
+
+```
+### ZKIR Checker Report
+
+**Claim:** [verbatim]
+
+**Contract source:** [user's file path / minimal contract written for claim]
+
+**Compact source:**
+\`\`\`compact
+[source code]
+\`\`\`
+
+**Compilation:** [compiler version, circuit count, compilation time]
+
+**Execution:** [which circuit(s) executed, proof data summary]
+
+**Checker verdict:** ACCEPTED / REJECTED: [error message]
+
+**Interpretation:** [Confirmed / Refuted / Inconclusive] — [explanation]
+```
+
+## Step 9: Clean Up
+
+```bash
+rm -rf .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID
+```
+
+Do NOT remove the base workspace — it's shared across jobs.
+```
+
+- [ ] **Step 2: Verify the rewrite**
+
+```bash
+head -12 plugins/midnight-verify/skills/verify-by-zkir-checker/SKILL.md
+```
+
+Expected: New frontmatter with version `0.4.1` and description mentioning "full ZK proof pipeline" and "PLONK".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-by-zkir-checker/SKILL.md
+git commit -m "refactor(verify): rewrite zkir-checker skill with real PLONK pipeline
+
+Replaces the hand-crafted .zkir approach with the verified pipeline:
+compile without --skip-zk → execute via JS runtime →
+proofDataIntoSerializedPreimage() → check() with real PLONK keys.
+
+Supports contract mode (verify user's .compact) and claim mode
+(write minimal contract). Includes concrete API details:
+5-arg serialization, keyProvider shape, error message catalog.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Rewrite `zkir-regression` skill
+
+**Files:**
+- Rewrite: `plugins/midnight-verify/skills/zkir-regression/SKILL.md`
+
+- [ ] **Step 1: Replace the entire skill file**
+
+Write the following content to `plugins/midnight-verify/skills/zkir-regression/SKILL.md`:
+
+```markdown
+---
+name: midnight-verify:zkir-regression
+description: >-
+  Run a curated set of verification claims against the current toolchain to
+  detect behavioral changes. Each claim is verified through the normal
+  verification pipeline (verifier → agents → checker/execution). Supports
+  full sweep (all categories) and targeted sweep (single category). Invocable
+  as /midnight-verify:zkir-regression or loadable by agents as a sense-check
+  when they suspect toolchain issues.
+version: 0.4.1
+argument-hint: "[category: arithmetic|types|state|privacy|zk-proof|transcript]"
+---
+
+# ZKIR Regression Sweep
+
+Run a curated set of verification claims against the current toolchain to detect behavioral changes. Unlike fixture-based testing, this exercises the full verification pipeline — claim classification, contract writing, compilation, execution, and PLONK proof verification.
+
+Use this when:
+- A new compiler version or checker package version is released
+- An agent suspects unexpected behavior from the toolchain
+- You want a confidence check before presenting Midnight-specific claims
+
+## Step 1: Determine Mode
+
+If `$ARGUMENTS` is empty → **full sweep** (all categories).
+
+If `$ARGUMENTS` contains a category name → **targeted sweep** (that category only).
+
+Valid categories: `arithmetic`, `types`, `state`, `privacy`, `zk-proof`, `transcript`.
+
+## Step 2: Record Toolchain Versions
+
+```bash
+compact compile --language-version
+compact --version
+```
+
+Record both for the report header.
+
+## Step 3: Run Claims
+
+For each claim in the list below (filtered by category if targeted), dispatch the `midnight-verify:verifier` agent with:
+- The claim text
+- Instruction to verify using the appropriate method
+
+Collect the verdict for each claim. Do NOT stop on first failure — run all claims and collect all results.
+
+## Claim List
+
+| ID | Category | Claim | Expected Verdict |
+|---|---|---|---|
+| arith-1 | arithmetic | A pure circuit that adds two Uint32 values (3 + 4) returns the correct sum (7) | Confirmed (tested) |
+| arith-2 | arithmetic | A pure circuit that multiplies two Uint32 values (3 * 5) returns the correct product (15) | Confirmed (tested) |
+| types-1 | types | Assigning a value of 256 to a Uint8 variable produces a compiler error | Confirmed (tested) |
+| types-2 | types | A pure circuit returning a tuple allows 0-indexed access to each element | Confirmed (tested) |
+| state-1 | state | A counter contract's increment circuit updates the ledger state by the specified amount | Confirmed (tested) |
+| state-2 | state | Reading a counter ledger value returns the current on-chain state | Confirmed (tested) |
+| privacy-1 | privacy | A circuit that writes to the ledger requires a disclose() call | Confirmed (tested) |
+| zk-1 | zk-proof | A counter contract's increment circuit passes the full PLONK proof verification | Confirmed (zkir-checked) |
+| zk-2 | zk-proof | Tampering with the public transcript of a verified circuit causes PLONK checker rejection | Confirmed (zkir-checked) |
+| zk-3 | zk-proof | The PLONK checker error for a tampered transcript identifies the exact mismatched input | Confirmed (zkir-checked) |
+| transcript-1 | transcript | A counter increment circuit encodes ledger operations in the publicTranscript | Confirmed (zkir-inspected) |
+| transcript-2 | transcript | The compiled ZKIR for a counter increment contains declare_pub_input instructions | Confirmed (zkir-inspected) |
+
+## Step 4: Compare Results
+
+For each claim, compare the actual verdict against the expected verdict:
+- Verdict matches expected → **PASS**
+- Verdict does not match → **FAIL**
+- Verification returned Inconclusive but expected Confirmed → **FAIL** (toolchain may be unavailable)
+
+## Step 5: Report
+
+```markdown
+## ZKIR Regression Report
+
+**Toolchain:** compact CLI vX.Y.Z, language version A.B.C
+**Date:** YYYY-MM-DD
+**Mode:** [full sweep / targeted: <category>]
+**Ran:** N claims
+
+### Results
+
+| Category | Passed | Failed | Total |
+|---|---|---|---|
+| arithmetic | N | N | N |
+| types | N | N | N |
+| state | N | N | N |
+| privacy | N | N | N |
+| zk-proof | N | N | N |
+| transcript | N | N | N |
+| **Total** | **N** | **N** | **N** |
+
+### Failures (if any)
+
+**<claim-id>:** Expected <expected verdict>, got <actual verdict>
+- Claim: "<claim text>"
+- Actual result: [what the verification pipeline returned]
+- Interpretation: [what this failure suggests about toolchain changes]
+```
+
+If there are zero failures, end with:
+> All N claims passed. Toolchain behavior matches expectations.
+
+## Adding New Claims
+
+Add a row to the claim list table above. Each claim should:
+- Be verifiable through the normal `/verify` pipeline
+- Have a deterministic expected verdict
+- Test a specific, observable behavior
+- Include the expected verdict qualifier (tested, zkir-checked, zkir-inspected, source-verified)
+```
+
+- [ ] **Step 2: Verify the rewrite**
+
+```bash
+head -12 plugins/midnight-verify/skills/zkir-regression/SKILL.md
+```
+
+Expected: New frontmatter with version `0.4.1` and description mentioning "curated set of verification claims".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/zkir-regression/SKILL.md
+git commit -m "refactor(verify): rewrite zkir-regression as claim-based sweep
+
+Replaces fixture-based regression with a curated claim list that runs
+through the full verification pipeline. 12 initial claims across 6
+categories (arithmetic, types, state, privacy, zk-proof, transcript).
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Update `zkir-checker` agent
+
+**Files:**
+- Modify: `plugins/midnight-verify/agents/zkir-checker.md`
+
+- [ ] **Step 1: Update the agent description examples**
+
+Replace the current Example 1 and Example 2 (which reference fixtures) with:
+
+```
+  Example 1: Claim "add wraps modulo r" — writes a minimal Compact contract
+  that adds (r-1) + 1, compiles with full ZK pipeline, runs the PLONK checker,
+  confirms the result wraps to 0.
+
+  Example 2: Claim "constrain_bits enforces 8-bit range" — writes a contract
+  using Uint8, compiles without --skip-zk, verifies the PLONK proof accepts
+  for valid values and the compiler rejects overflow.
+```
+
+- [ ] **Step 2: Update the Important section**
+
+Replace the current body text (everything after `## Your Job` section) with:
+
+```markdown
+## Your Job
+
+Based on the claim you receive, load the appropriate skill:
+
+- **Checker claims** (ZK proof validity, constraint behavior, transcript integrity, proof data correctness) → load `midnight-verify:verify-by-zkir-checker` and follow it step by step
+- **Inspection claims** (compiled circuit structure, instruction counts, opcode usage, transcript encoding) → load `midnight-verify:verify-by-zkir-inspection` and follow it step by step
+- **Both** (claims about structure AND behavior) → load both skills. Compile once without `--skip-zk` (the checker method requires this) and share the build output with the inspection method. Don't compile twice.
+
+## Important
+
+- You do NOT classify claims or synthesize verdicts — the verifier orchestrator does that.
+- You may compile contracts in place (directing build output to the job directory) for user-provided contracts, or write minimal contracts in the job directory for claim-based verification.
+- For the checker method, always compile without `--skip-zk` — you need the PLONK proving keys.
+- For the inspection method alone (no checker), `--skip-zk` is fine since you only need the `.zkir` JSON.
+- You may load compact-core skills as hints for writing Compact test contracts, but test results and checker verdicts are your evidence, not skill content.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/midnight-verify/agents/zkir-checker.md
+git commit -m "refactor(verify): update zkir-checker agent for real PLONK pipeline
+
+Removes references to fixtures and hand-crafted .zkir. Updates examples
+and instructions to reflect compile-in-place with full ZK pipeline.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Update `verify-by-zkir-inspection` skill
+
+**Files:**
+- Modify: `plugins/midnight-verify/skills/verify-by-zkir-inspection/SKILL.md`
+
+- [ ] **Step 1: Add shared compilation note**
+
+After the Critical Rule section and before Step 1, add:
+
+```markdown
+## Shared Compilation
+
+When the zkir-checker agent is running both inspection and checker methods for the same contract, compile once without `--skip-zk` and share the build output. The `.zkir` JSON produced by full compilation is identical to `--skip-zk` output — the only difference is that full compilation also generates PLONK keys. Don't compile twice.
+
+If the checker method has already compiled the contract, use its build output for inspection. If running inspection alone, `--skip-zk` is fine since you only need the `.zkir` JSON.
+```
+
+- [ ] **Step 2: Update the compile command in Step 1**
+
+The current Step 1 hardcodes `--skip-zk`. Update the compilation section to note the alternative:
+
+Replace:
+```
+compact compile .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID/test-claim.compact --skip-zk
+```
+
+With:
+```
+compact compile -- --skip-zk <source-path> .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID/build/
+```
+
+And add after it:
+```
+If this inspection will be followed by checker verification, omit `--skip-zk` to avoid recompiling:
+
+\`\`\`bash
+compact compile -- <source-path> .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID/build/
+\`\`\`
+```
+
+Also update the compilation to compile the contract in place (for contract mode) matching the checker skill's pattern.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-by-zkir-inspection/SKILL.md
+git commit -m "refactor(verify): add shared compilation note to inspection skill
+
+When both inspection and checker run on the same contract, compile once
+without --skip-zk and share build output. Avoids double compilation.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Validate the rework
+
+- [ ] **Step 1: Verify fixtures are deleted**
+
+```bash
+ls plugins/midnight-verify/skills/verify-by-zkir-checker/fixtures 2>&1
+```
+
+Expected: `No such file or directory`
+
+- [ ] **Step 2: Verify checker skill mentions PLONK pipeline**
+
+```bash
+grep -c "proofDataIntoSerializedPreimage" plugins/midnight-verify/skills/verify-by-zkir-checker/SKILL.md
+```
+
+Expected: At least 2 (referenced in Steps 5 and 7).
+
+```bash
+grep -c "skip-zk" plugins/midnight-verify/skills/verify-by-zkir-checker/SKILL.md
+```
+
+Expected: At least 1 (the "without `--skip-zk`" rule).
+
+- [ ] **Step 3: Verify regression skill has claim list**
+
+```bash
+grep -c "^| " plugins/midnight-verify/skills/zkir-regression/SKILL.md
+```
+
+Expected: At least 14 (header row + 12 claims + total row).
+
+- [ ] **Step 4: Verify no remaining references to hand-crafted .zkir or fixtures**
+
+```bash
+grep -ri "hand-craft\|hand_craft\|fixture" plugins/midnight-verify/agents/zkir-checker.md plugins/midnight-verify/skills/verify-by-zkir-checker/SKILL.md plugins/midnight-verify/skills/zkir-regression/SKILL.md
+```
+
+Expected: No matches.
+
+- [ ] **Step 5: Verify git log shows the rework commits**
+
+```bash
+git log --oneline -6
+```
+
+Expected: 5 new commits (delete fixtures, rewrite checker, rewrite regression, update agent, update inspection).

--- a/docs/superpowers/specs/2026-03-28-zkir-verification-design.md
+++ b/docs/superpowers/specs/2026-03-28-zkir-verification-design.md
@@ -1,0 +1,406 @@
+# ZKIR Verification Design
+
+**Date:** 2026-03-28
+**Plugin:** midnight-verify (v0.3.0 → v0.4.0)
+**Scope:** Add ZKIR-level verification to the midnight-verify plugin
+
+## Problem
+
+The midnight-verify plugin can verify Compact claims by compiling and executing code (contract-writer), inspect source repos (source-investigator), type-check SDK usage (type-checker), and run E2E devnet tests (sdk-tester). But it has no method for verifying claims at the **ZKIR circuit level** — the zero-knowledge intermediate representation that the Compact compiler targets.
+
+This means claims about circuit constraint behavior, opcode semantics, compiled circuit structure, the public transcript protocol, and field arithmetic properties cannot be verified with ground truth. The `@midnight-ntwrk/zkir-v2` WASM checker provides a deterministic accept/reject oracle for ZKIR circuits, but the plugin doesn't use it.
+
+## Scope
+
+Three verification scenarios:
+
+1. **Claims about ZKIR** — opcode semantics, constraint behavior, field arithmetic, transcript protocol
+2. **Compiled circuit inspection** — instruction counts, opcode usage, transcript encoding patterns
+3. **ZKIR code in DApps** — verifying user-supplied `.zkir` files are well-formed and behave correctly
+
+Plus a **regression sweep** capability for running the full test circuit library against new toolchain versions.
+
+## Available Tooling
+
+| Name | Type | Version | ZKIR Role |
+|---|---|---|---|
+| `@midnight-ntwrk/zkir-v2` | npm WASM | 2.1.0 | WASM ZKIR v2 checker (browser + Node) |
+| `@midnight-ntwrk/compact-runtime` | npm TS | 0.15.0 | Runtime types, ProofData, circuit contexts |
+| `@midnight-ntwrk/onchain-runtime-v3` | npm WASM | 3.0.0 | On-chain VM execution |
+| `midnightntwrk/midnight-zk` | GitHub | `next` branch | Rust proof system, ZKIR relation builder, circuit gadgets |
+| `LFDT-Minokawa/compact` | GitHub | `main` branch | Compiler source: `zkir-passes.ss`, `zkir-v3-passes.ss`, `langs.ss` |
+
+No `@midnight-ntwrk/zkir-v3` npm package exists yet. The custom tools from the ZKIR reference document (`trace-oracle.mjs`, `dump-proof-data.mjs`) are not publicly available — wrapper scripts must be written.
+
+## New Components
+
+### Agent: `zkir-checker`
+
+- **Model:** opus (ZKIR construction is high-complexity)
+- **Color:** red
+- **Skills:** `verify-by-zkir-checker`, `verify-by-zkir-inspection`
+- **Responsibilities:**
+  - Compile Compact contracts and extract `.zkir` output
+  - Construct proof data (input, output, publicTranscript, privateTranscriptOutputs)
+  - Hand-craft `.zkir` JSON directly when needed (IR-level behavior, trivial circuits)
+  - Invoke the `@midnight-ntwrk/zkir-v2` WASM checker
+  - Inspect compiled `.zkir` structure (instruction counts, opcode usage, transcript encoding)
+  - Use fixture templates from the library when applicable
+- **Does NOT do:** Domain classification, verdict synthesis, SDK verification
+
+### Skill: `verify-zkir` (domain routing)
+
+Loaded by the verifier orchestrator to classify ZKIR claims and determine dispatch.
+
+**Claim Type → Method Routing:**
+
+| Claim Type | Example | Dispatch |
+|---|---|---|
+| Opcode semantics | "add wraps modulo r" | **zkir-checker** (checker method) |
+| Constraint behavior | "assert requires boolean input" | **zkir-checker** (checker method) |
+| Field arithmetic | "-1 is r-1 in ZKIR" | **zkir-checker** (checker method) |
+| Transcript protocol | "publicTranscript encodes ledger ops as field elements" | **zkir-checker** (checker method) |
+| Cryptographic opcodes | "persistent_hash produces two field elements" | **zkir-checker** (checker method) |
+| Compiled circuit structure | "this contract produces N instructions" | **zkir-checker** (inspection method) |
+| Circuit opcode usage | "guard counter uses persistent_hash for authority" | **zkir-checker** (inspection method) |
+| ZKIR version differences | "v3 uses named variables" | **source-investigator** |
+| Compiler internals | "zkir-passes.ss handles v2 serialization" | **source-investigator** |
+| Cross-domain | "this disclosure compiles to these ZKIR constraints" | **zkir-checker** (both) + **contract-writer** (concurrent) |
+
+**When in doubt:**
+- Observable checker behavior (accept/reject) → zkir-checker (checker method)
+- Compiled output properties → zkir-checker (inspection method)
+- Compiler/toolchain internals → source-investigator
+
+### Skill: `verify-by-zkir-checker` (method)
+
+Step-by-step instructions for running circuits through the WASM checker.
+
+**Step 1 — Workspace setup:**
+Lazy init at `.midnight-expert/verify/zkir-workspace/`:
+```bash
+mkdir -p .midnight-expert/verify/zkir-workspace
+cd .midnight-expert/verify/zkir-workspace
+npm init -y
+npm install @midnight-ntwrk/zkir-v2 @midnight-ntwrk/compact-runtime
+```
+Subsequent runs: `npm ls @midnight-ntwrk/zkir-v2` integrity check. Job isolation via `JOB_ID=$(uuidgen)` → `jobs/$JOB_ID/`.
+
+**Step 2 — Determine circuit source (order of preference):**
+1. **Fixture match** — check `${CLAUDE_SKILL_DIR}/fixtures/test-cases/` for existing coverage. Copy to job directory, skip to Step 5.
+2. **Compile from Compact** — write minimal `.compact`, compile with `compact compile --skip-zk`, extract `.zkir`. Default path for most claims.
+3. **Hand-craft `.zkir` JSON** — only for IR-level behavior not reachable from Compact, or trivially small circuits (2-5 instructions). Use templates from `${CLAUDE_SKILL_DIR}/fixtures/templates/`.
+
+**Step 3 — Construct proof data:**
+```json
+{
+  "description": "what this test verifies",
+  "circuit": "path/to/circuit.zkir",
+  "inputs": {
+    "input": { "value": [...], "alignment": [...] },
+    "output": { "value": [...], "alignment": [...] },
+    "publicTranscript": [...],
+    "privateTranscriptOutputs": [...]
+  },
+  "expect": "accept"
+}
+```
+For compiled circuits, extract proof data via `compact-runtime` types. For hand-crafted circuits, construct manually using fixture patterns.
+
+**Step 4 — Design positive and negative tests:**
+- **Positive:** construct valid proof data, expect accept
+- **Negative:** tamper with inputs, provide wrong witness, violate constraint, expect reject with specific error
+
+Error message catalog:
+- `"Failed direct assertion"` — assert input is boolean 0
+- `"Expected boolean, found: XX"` — non-boolean input to assert/cond_select/constrain_to_boolean
+- `"Failed equality constraint: XX != YY"` — constrain_eq inputs differ
+- `"Bit bound failed: XX is not N-bit"` — constrain_bits value exceeds range
+- `"Ran out of private transcript outputs"` — missing witness data
+- `"Transcripts not fully consumed"` — extra unused witness data
+- `"Public transcript input mismatch for input N"` — tampered public transcript
+
+**Step 5 — Run the checker:**
+Write a runner script invoking the WASM checker. The exact API must be discovered from `@midnight-ntwrk/zkir-v2` on first use — inspect the package exports and document the invocation pattern in the workspace.
+
+**Step 6 — Report:**
+```markdown
+### ZKIR Checker Report
+
+**Claim:** [verbatim]
+**Circuit source:** [fixture / compiled from Compact / hand-crafted]
+**Circuit:** [.zkir JSON or Compact source if compiled]
+**Proof data:** [inputs summary]
+**Checker verdict:** ACCEPTED / REJECTED: [error message]
+**Interpretation:** [Confirmed / Refuted / Inconclusive] — [explanation]
+```
+
+**Step 7 — Clean up:** `rm -rf .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID`
+
+**Critical rules:**
+- Checker ACCEPT proves constraints satisfied for those specific inputs, not for all inputs. Note this for universal claims.
+- Checker REJECT with a specific error message is strong evidence — the error identifies exactly which constraint failed.
+- When compiling from Compact, document where `compact compile` places the `.zkir` output.
+
+### Skill: `verify-by-zkir-inspection` (method)
+
+Step-by-step instructions for analyzing compiled circuit structure without running the checker.
+
+**When used:** Claims about instruction counts, opcode usage, transcript encoding, circuit structure.
+
+Uses the same zkir-workspace as the checker method for job isolation (`jobs/$JOB_ID/`). Does not require the WASM checker — only the Compact CLI and JSON parsing.
+
+**Step 1 — Compile:** Write minimal `.compact`, compile with `compact compile --skip-zk`.
+
+**Step 2 — Locate and parse `.zkir`:** Find `.zkir` JSON in build output. Parse and extract:
+- `version` — v2 or v3 format
+- `instructions` — full instruction array
+- `num_inputs` — input count
+- `do_communications_commitment` — transcript presence
+
+**Step 3 — Analyze based on claim:**
+
+| Claim type | Analysis |
+|---|---|
+| Instruction count | Count `instructions` array length |
+| Opcode usage | Filter by `op` field |
+| Transcript encoding | Look for `declare_pub_input`/`pi_skip` patterns |
+| I/O shape | Count `output`, `public_input`, `private_input` instructions |
+| Constraint structure | Trace data flow through `constrain_eq`, `assert`, `constrain_bits` |
+| Opcode presence/absence | Check whether specific opcode appears |
+
+**Step 4 — Report:**
+```markdown
+### ZKIR Inspection Report
+
+**Claim:** [verbatim]
+**Compact source:** [source]
+**ZKIR version:** v2 / v3
+**Analysis:** [relevant metrics]
+**Key findings:** [specific instructions/patterns with indices]
+**Interpretation:** [Confirmed / Refuted / Inconclusive] — [explanation]
+```
+
+**Critical rules:**
+- Inspection proves what the compiler emits for specific source. Does not prove circuit correctness — that requires the checker.
+- Always note the compiler version in the report.
+- When claim spans structure AND behavior, dispatch both methods.
+
+### Skill: `zkir-regression` (sweep)
+
+Runs the full fixture library against the current toolchain. Invocable as `/midnight-verify:zkir-regression` or loadable by agents as a sense-check.
+
+**Two modes:**
+
+**Full sweep** (no arguments):
+1. Ensure zkir-workspace initialized
+2. Load all test cases from `${CLAUDE_SKILL_DIR}/../verify-by-zkir-checker/fixtures/test-cases/` (resolve path and fail gracefully with a clear error if fixtures directory is not found)
+3. Run each through checker, compare to `expect`
+4. Re-compile fixture Compact sources to verify compilation still succeeds
+5. Produce summary report
+
+**Targeted sweep** (`/midnight-verify:zkir-regression <category>`):
+Same but filtered to a single opcode category (arithmetic, constraints, cryptographic, etc.).
+
+**Fixture directory structure:**
+```
+skills/verify-by-zkir-checker/fixtures/
+├── circuits/                    # Pre-crafted .zkir JSON
+│   ├── arithmetic/
+│   ├── constraints/
+│   ├── comparison/
+│   ├── control-flow/
+│   ├── type-encoding/
+│   ├── division/
+│   ├── cryptographic/
+│   ├── io/
+│   └── transcript/
+├── templates/                   # Parameterizable patterns
+│   ├── pure-circuit.json
+│   ├── witness-circuit.json
+│   └── transcript-circuit.json
+└── test-cases/                  # Test case JSON
+    ├── arithmetic/
+    │   ├── add-basic.json
+    │   ├── add-wrong.json
+    │   ├── add-wrap.json
+    │   └── ...
+    ├── constraints/
+    ├── ...
+    └── manifest.json
+```
+
+**manifest.json:**
+```json
+{
+  "version": "0.1.0",
+  "generated_for": "compact-compiler-v0.29.0",
+  "checker_package": "@midnight-ntwrk/zkir-v2@2.1.0",
+  "test_cases": [
+    {
+      "id": "add-basic",
+      "category": "arithmetic",
+      "opcode": "add",
+      "file": "arithmetic/add-basic.json",
+      "zkir_version": "v2",
+      "expect": "accept"
+    }
+  ]
+}
+```
+
+**Report format:**
+```markdown
+## ZKIR Regression Report
+
+**Toolchain:** compact compiler vX.Y.Z, @midnight-ntwrk/zkir-v2@A.B.C
+**Fixture version:** 0.1.0
+**Ran:** N test cases
+
+### Results
+
+| Category | Passed | Failed | Total |
+|---|---|---|---|
+| arithmetic | 6 | 0 | 6 |
+| constraints | 8 | 0 | 8 |
+| ... | | | |
+| **Total** | **N** | **0** | **N** |
+
+### Failures (if any)
+
+**add-wrap:** Expected accept, got REJECTED: "Failed equality constraint: 00 != 01"
+- Circuit: circuits/arithmetic/add-wrap.zkir
+- Interpretation: field wrap behavior may have changed
+```
+
+**Building the initial fixture library:**
+The ZKIR reference PDF documents 119 oracle traces covering all 26 opcodes. The initial fixture set should mirror the v2 subset (68 traces). The skill includes guidance on adding new fixtures.
+
+## Modified Components
+
+### `verify-correctness` hub skill
+
+**New domain classification row:**
+
+| Domain | Indicators | Route To |
+|---|---|---|
+| **ZKIR** | ZKIR opcodes, circuit constraints, field elements, proof data, `.zkir` files, transcript protocol, checker behavior, circuit structure | Load `midnight-verify:verify-zkir` |
+
+**New verdict qualifiers:**
+
+| Verdict | Qualifier | When to Use |
+|---|---|---|
+| Confirmed | (zkir-checked) | WASM checker accepted with expected inputs |
+| Confirmed | (zkir-checked + tested) | Both checker and Compact runtime agree |
+| Confirmed | (zkir-inspected) | Circuit structure analysis confirms claim |
+| Confirmed | (zkir-checked + source-verified) | Checker result + source inspection agree |
+| Refuted | (zkir-checked) | Checker produced unexpected accept/reject |
+| Refuted | (zkir-inspected) | Circuit structure contradicts claim |
+| Inconclusive | (zkir-checker unavailable) | `@midnight-ntwrk/zkir-v2` not installable |
+
+**Conflict resolution addition:** When WASM checker and Compact JS runtime disagree, the checker is more authoritative for constraint behavior (proof system level), the JS runtime is more authoritative for output values (contract logic). Flag disagreement.
+
+### `verify-compact` routing skill
+
+**New rows:**
+
+| Claim Type | Example | Dispatch |
+|---|---|---|
+| Circuit constraint structure | "this contract produces N constraints" | **zkir-checker** (inspection) |
+| Compiled ZKIR properties | "disclosure compiles to declare_pub_input" | **zkir-checker** (inspection) |
+| Constraint correctness | "guard circuit correctly constrains authority hash" | **zkir-checker** (checker) + **contract-writer** (concurrent) |
+
+### `verify-by-execution` skill
+
+**New optional Step 4.5 — Extract ZKIR for supplementary evidence:**
+After compilation, if the verifier requested ZKIR-level evidence, locate the `.zkir` output and include the path in the report. Do not run the checker — pass the path back so the verifier can dispatch zkir-checker if needed.
+
+### `plugin.json`
+
+Bump version to `0.4.0`. Add keywords: `zkir`, `circuit`, `proof`, `checker`, `wasm`.
+
+## File Layout
+
+```
+plugins/midnight-verify/
+├── .claude-plugin/plugin.json                   # MODIFIED (v0.4.0)
+├── agents/
+│   ├── verifier.md
+│   ├── contract-writer.md
+│   ├── source-investigator.md
+│   ├── type-checker.md
+│   ├── sdk-tester.md
+│   └── zkir-checker.md                          # NEW
+├── skills/
+│   ├── verify-correctness/SKILL.md              # MODIFIED
+│   ├── verify-compact/SKILL.md                  # MODIFIED
+│   ├── verify-sdk/SKILL.md
+│   ├── verify-by-execution/SKILL.md             # MODIFIED
+│   ├── verify-by-source/SKILL.md
+│   ├── verify-by-type-check/SKILL.md
+│   ├── verify-by-devnet/SKILL.md
+│   ├── verify-zkir/SKILL.md                     # NEW
+│   ├── verify-by-zkir-checker/
+│   │   ├── SKILL.md                             # NEW
+│   │   └── fixtures/
+│   │       ├── circuits/                        # NEW
+│   │       ├── templates/                       # NEW
+│   │       └── test-cases/                      # NEW
+│   ├── verify-by-zkir-inspection/SKILL.md       # NEW
+│   └── zkir-regression/SKILL.md                 # NEW
+├── commands/
+│   └── verify.md
+└── hooks/
+    ├── hooks.json
+    └── stop-check.sh
+```
+
+## End-to-End Flow Examples
+
+### Scenario 1: Opcode semantics claim
+
+```
+/verify "constrain_bits enforces that a value fits in N bits"
+
+→ verifier: domain=ZKIR, loads verify-zkir
+  routing: constraint behavior → zkir-checker (checker method)
+→ zkir-checker: loads verify-by-zkir-checker
+  finds fixtures: cb-8bit-zero.json, cb-8bit-255.json, cb-8bit-256.json
+  runs all three through checker
+  0 fits → ACCEPTED, 255 fits → ACCEPTED, 256 overflows → REJECTED
+→ verifier: Confirmed (zkir-checked)
+```
+
+### Scenario 2: Compiled circuit inspection
+
+```
+/verify "Counter increment compiles to fewer than 20 ZKIR instructions"
+
+→ verifier: domain=ZKIR, loads verify-zkir
+  routing: compiled circuit properties → zkir-checker (inspection)
+→ zkir-checker: loads verify-by-zkir-inspection
+  writes counter contract, compiles, parses .zkir: 14 instructions
+→ verifier: Confirmed (zkir-inspected)
+```
+
+### Scenario 3: Cross-domain
+
+```
+/verify "Guarded counter's persistent_hash correctly constrains authority key"
+
+→ verifier: domain=Compact+ZKIR, loads verify-compact + verify-zkir
+→ dispatches concurrently:
+  contract-writer: compile + run with valid/invalid keys
+  zkir-checker (checker): proof data with valid/wrong key → ACCEPTED/REJECTED
+  zkir-checker (inspection): confirms persistent_hash → test_eq → assert chain
+→ verifier: Confirmed (zkir-checked + tested)
+```
+
+### Scenario 4: Agent-triggered regression
+
+```
+(contract-writer encounters unexpected output)
+→ loads zkir-regression, runs targeted sweep on constraints
+→ detects constrain_bits behavior change
+→ reports regression to verifier for inclusion in verdict
+```

--- a/docs/superpowers/specs/2026-03-30-zkir-checker-rework-design.md
+++ b/docs/superpowers/specs/2026-03-30-zkir-checker-rework-design.md
@@ -1,0 +1,150 @@
+# ZKIR Checker Rework Design
+
+**Date:** 2026-03-30
+**Plugin:** midnight-verify (v0.4.0)
+**Scope:** Rework verify-by-zkir-checker, zkir-regression, and fixtures based on real WASM checker API discovery
+
+## Problem
+
+The initial ZKIR verification implementation assumed the `@midnight-ntwrk/zkir-v2` WASM package was a simple constraint checker: feed it `.zkir` JSON + proof data, get accept/reject. Investigation revealed it's a **full PLONK prover/verifier** that requires:
+
+- A `serializedPreimage` (Uint8Array) — not raw JSON
+- PLONK proving keys (circuit-specific, generated during compilation)
+- PLONK trusted setup parameters (from `~/.compact/params/params_${k}.bin`)
+
+Hand-crafted `.zkir` circuits cannot be executed through this checker — only circuits compiled from Compact (without `--skip-zk`) produce the required keys.
+
+## Verified Pipeline
+
+Tested and confirmed working:
+
+```
+Compact source (compiled in place, output directed to job dir)
+  → compact compile -- <source-path> <job-dir>/build/   (WITHOUT --skip-zk)
+  → produces: zkir/<circuit>.zkir, zkir/<circuit>.bzkir, keys/<circuit>.prover, keys/<circuit>.verifier
+  → execute circuit via JS runtime (import build/contract/index.js)
+  → proofDataIntoSerializedPreimage(input, output, publicTranscript, privateTranscriptOutputs, keyLocation)
+      (5 individual arguments, not an object)
+  → check(serializedPreimage, keyProvider)
+      keyProvider.lookupKey() → { proverKey, verifierKey, ir }
+      keyProvider.getParams(k) → reads ~/.compact/params/params_${k}.bin
+  → ACCEPTED (returns output array) or REJECTED (throws with specific error message)
+```
+
+Error messages match the ZKIR reference catalog exactly:
+- `"Communications commitment mismatch"` — tampered raw bytes
+- `"Public transcript input mismatch for input N; expected: Some(XX), computed: Some(YY)"` — wrong transcript values
+- `"Failed direct assertion"`, `"Expected boolean, found: XX"`, `"Bit bound failed"`, etc.
+
+## What Changes
+
+### Delete: All fixture files (52 files)
+
+Delete everything under `skills/verify-by-zkir-checker/fixtures/`:
+- `circuits/` — 5 subdirectories with hand-crafted `.zkir` files
+- `templates/` — 3 template JSON files
+- `test-cases/` — 5 subdirectories with test case JSON files + `manifest.json`
+
+These cannot be executed through the real checker and have no value as reference material — the agent can always read `.zkir` output from compilation.
+
+### Rewrite: `verify-by-zkir-checker` skill
+
+**Two modes:**
+
+**Contract mode** (primary) — user provides a `.compact` file or path. Compile it in place (it may have imports/dependencies), directing build output to the job directory.
+
+**Claim mode** — natural language claim about ZK behavior. Agent writes a minimal contract in the job directory.
+
+**Step-by-step flow:**
+
+1. **Workspace setup** — lazy init at `.midnight-expert/verify/zkir-workspace/` with `@midnight-ntwrk/zkir-v2` and `@midnight-ntwrk/compact-runtime`. Job directory via `JOB_ID=$(uuidgen)`.
+
+2. **Get the contract:**
+   - Contract mode: locate user's `.compact` file where it lives. Compile in place, directing output to job directory.
+   - Claim mode: write minimal `.compact` in the job directory, compile there.
+
+3. **Compile without `--skip-zk`** — `compact compile -- <source-path> <job-dir>/build/`. Produces `zkir/<circuit>.zkir`, `zkir/<circuit>.bzkir`, `keys/<circuit>.prover`, `keys/<circuit>.verifier`, `contract/index.js`, `compiler/contract-info.json`. If the contract was already compiled with keys elsewhere, copy the build artifacts instead.
+
+4. **Execute via JS runtime** — import compiled contract from `<job-dir>/build/contract/index.js`. Create state with appropriate context. Execute the circuit method(s) via the `circuits` interface (e.g., `contract.circuits.increment(context)`). The result contains `proofData` with `input`, `output`, `publicTranscript`, `privateTranscriptOutputs`.
+
+5. **Serialize proof data** — `compactRuntime.proofDataIntoSerializedPreimage(input, output, publicTranscript, privateTranscriptOutputs, keyLocation)`. Takes 5 individual arguments. Returns `Uint8Array`.
+
+6. **Run the checker** — create `keyProvider`:
+   ```javascript
+   const keyProvider = {
+     async lookupKey(keyLocation) {
+       return {
+         proverKey: readFileSync(`<job-dir>/build/keys/${keyLocation}.prover`),
+         verifierKey: readFileSync(`<job-dir>/build/keys/${keyLocation}.verifier`),
+         ir: readFileSync(`<job-dir>/build/zkir/${keyLocation}.bzkir`)
+       };
+     },
+     async getParams(k) {
+       return readFileSync(`${process.env.HOME}/.compact/params/params_${k}.bin`);
+     }
+   };
+   ```
+   Call `check(serializedPreimage, keyProvider)`. Accept = returns array of outputs. Reject = throws with error message.
+
+7. **Negative testing** (when appropriate) — for claims about rejection behavior, tamper with proof data before serialization (modify transcript values, swap witness data, alter outputs) and confirm the checker rejects with expected error.
+
+8. **Multi-circuit contracts** — check `compiler/contract-info.json` for circuits with `"proof": true`. In contract mode, verify each provable circuit. In claim mode, only the relevant circuit.
+
+9. **Report and clean up.**
+
+**Critical rules:**
+- Always compile without `--skip-zk`. The whole point is using the real PLONK verifier.
+- Compile the contract where it lives (it may have imports). Only direct the build output to the job directory.
+- `proofDataIntoSerializedPreimage` takes 5 individual arguments, not an object.
+- `keyProvider.getParams(k)` loads PLONK trusted setup params from `~/.compact/params/params_${k}.bin`. These are installed with the Compact CLI.
+- Checker accept returns an array (outputs as bigint, `undefined` for void). Checker reject throws with an error message.
+- A checker ACCEPT proves the ZK proof is valid for those specific inputs. It does NOT prove the circuit is correct for all inputs.
+
+**What this proves that `verify-by-execution` doesn't:** The execution skill compiles with `--skip-zk` and runs the JS runtime — it proves the contract logic works. This skill runs the full ZK pipeline — it proves the contract's zero-knowledge proof is valid: constraints are satisfied, transcript encoding is correct, proof data serializes properly, and the PLONK verifier accepts.
+
+### Rewrite: `zkir-regression` skill
+
+No fixtures, no cached artifacts. A curated list of claims with expected verdicts, embedded in the skill file itself.
+
+**The claim list** is a markdown table in the skill:
+
+```markdown
+| ID | Category | Claim | Expected |
+|---|---|---|---|
+| arith-1 | arithmetic | Adding two Uint32 values produces the correct sum | Confirmed |
+| ...etc |
+```
+
+**How the sweep works:**
+1. Parse the claim list from the skill
+2. For each claim, dispatch the normal verification pipeline (verifier → appropriate agents)
+3. Compare the verdict against the expected result
+4. Collect all results, report pass/fail
+
+**Two modes:**
+- Full sweep — all claims
+- Targeted — `/midnight-verify:zkir-regression <category>`
+
+**Report format:** Table of category/passed/failed, details on failures.
+
+**Adding new claims:** Add a row to the table in the skill file.
+
+### Update: `zkir-checker` agent
+
+Remove references to hand-crafted `.zkir` and fixture library. Replace with:
+- "You may compile contracts in place (directing build output to the job directory) for user-provided contracts, or write minimal contracts in the job directory for claim-based verification."
+
+### Update: `verify-by-zkir-inspection` skill
+
+Add note about shared compilation: when both inspection and checker methods are needed for the same contract, compile once without `--skip-zk` and share the build output. Don't compile twice.
+
+## File Changes
+
+| Action | Path |
+|---|---|
+| **Delete** | `skills/verify-by-zkir-checker/fixtures/` (entire directory, 52 files) |
+| **Rewrite** | `skills/verify-by-zkir-checker/SKILL.md` |
+| **Rewrite** | `skills/zkir-regression/SKILL.md` |
+| **Update** | `agents/zkir-checker.md` |
+| **Update** | `skills/verify-by-zkir-inspection/SKILL.md` |
+| No change | All other components (routing, hub, compact, execution, verifier, plugin.json) |

--- a/plugins/midnight-verify/.claude-plugin/plugin.json
+++ b/plugins/midnight-verify/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-verify",
-  "version": "0.3.0",
-  "description": "Verification framework for Midnight claims — verifies Compact code by compiling and executing test contracts, SDK/TypeScript claims by type-checking and devnet E2E testing, or by inspecting source code. Multi-agent pipeline with explicit /verify command.",
+  "version": "0.4.0",
+  "description": "Verification framework for Midnight claims — verifies Compact code by compiling and executing test contracts, SDK/TypeScript claims by type-checking and devnet E2E testing, ZKIR circuits by running through the WASM checker and inspecting compiled structure, or by inspecting source code. Multi-agent pipeline with explicit /verify command.",
   "author": {
     "name": "Aaron Bassett",
     "email": "aaron@devrel-ai.com"
@@ -21,6 +21,11 @@
     "fact-checking",
     "testing",
     "sdk",
-    "typescript"
+    "typescript",
+    "zkir",
+    "circuit",
+    "proof",
+    "checker",
+    "wasm"
   ]
 }

--- a/plugins/midnight-verify/agents/verifier.md
+++ b/plugins/midnight-verify/agents/verifier.md
@@ -27,7 +27,11 @@ description: >-
 
   Example 5: A claim needs multiple methods — the orchestrator dispatches
   agents concurrently, cross-references findings, synthesizes a combined verdict.
-skills: midnight-verify:verify-correctness, midnight-verify:verify-compact, midnight-verify:verify-sdk
+
+  Example 6: User runs /verify "constrain_bits enforces 8-bit range" — the
+  orchestrator classifies this as a ZKIR opcode claim, dispatches the
+  zkir-checker agent to compile a test contract and verify through the PLONK checker.
+skills: midnight-verify:verify-correctness, midnight-verify:verify-compact, midnight-verify:verify-sdk, midnight-verify:verify-zkir
 model: sonnet
 color: green
 ---
@@ -54,6 +58,11 @@ You are the Midnight verification orchestrator.
 - Devnet E2E → dispatch `midnight-verify:sdk-tester`
 - Source inspection → dispatch `midnight-verify:source-investigator`
 - Package checks → dispatch `devs:deps-maintenance` (fallback: run `npm view` directly)
+
+**ZKIR verification:**
+- Checker verification → dispatch `midnight-verify:zkir-checker`
+- Circuit inspection → dispatch `midnight-verify:zkir-checker`
+- Regression sweep → dispatch `midnight-verify:zkir-checker` with instruction to load `midnight-verify:zkir-regression`
 
 **When multiple methods are needed, dispatch agents concurrently.** They are independent and can run in parallel.
 

--- a/plugins/midnight-verify/agents/zkir-checker.md
+++ b/plugins/midnight-verify/agents/zkir-checker.md
@@ -1,0 +1,44 @@
+---
+name: zkir-checker
+description: >-
+  Use this agent to verify ZKIR-level claims by running circuits through the
+  @midnight-ntwrk/zkir-v2 WASM checker or inspecting compiled circuit structure.
+  Compiles Compact to extract .zkir, constructs proof data, invokes the checker,
+  and analyzes circuit properties. Dispatched by the verifier orchestrator agent.
+
+  Example 1: Claim "add wraps modulo r" — writes a minimal Compact contract
+  that adds (r-1) + 1, compiles with full ZK pipeline, runs the PLONK checker,
+  confirms the result wraps to 0.
+
+  Example 2: Claim "constrain_bits enforces 8-bit range" — writes a contract
+  using Uint8, compiles without --skip-zk, verifies the PLONK proof accepts
+  for valid values and the compiler rejects overflow.
+
+  Example 3: Claim "counter increment compiles to fewer than 20 instructions" —
+  compiles a counter contract, extracts .zkir, counts instructions.
+
+  Example 4: Claim "this circuit uses persistent_hash for authority" — compiles
+  a guarded counter, extracts .zkir, searches for persistent_hash opcode in
+  instruction list.
+skills: midnight-verify:verify-by-zkir-checker, midnight-verify:verify-by-zkir-inspection
+model: opus
+color: red
+---
+
+You are a ZKIR circuit verifier for Midnight.
+
+## Your Job
+
+Based on the claim you receive, load the appropriate skill:
+
+- **Checker claims** (ZK proof validity, constraint behavior, transcript integrity, proof data correctness) → load `midnight-verify:verify-by-zkir-checker` and follow it step by step
+- **Inspection claims** (compiled circuit structure, instruction counts, opcode usage, transcript encoding) → load `midnight-verify:verify-by-zkir-inspection` and follow it step by step
+- **Both** (claims about structure AND behavior) → load both skills. Compile once without `--skip-zk` (the checker method requires this) and share the build output with the inspection method. Don't compile twice.
+
+## Important
+
+- You do NOT classify claims or synthesize verdicts — the verifier orchestrator does that.
+- You may compile contracts in place (directing build output to the job directory) for user-provided contracts, or write minimal contracts in the job directory for claim-based verification.
+- For the checker method, always compile without `--skip-zk` — you need the PLONK proving keys.
+- For the inspection method alone (no checker), `--skip-zk` is fine since you only need the `.zkir` JSON.
+- You may load compact-core skills as hints for writing Compact test contracts, but test results and checker verdicts are your evidence, not skill content.

--- a/plugins/midnight-verify/skills/verify-by-execution/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-by-execution/SKILL.md
@@ -135,6 +135,18 @@ compact compile .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test-<cla
 
 Capture the full compiler output (stdout and stderr) regardless of success or failure.
 
+## Step 4.5: Extract ZKIR (Optional)
+
+If the verifier requested ZKIR-level evidence alongside execution results, locate the `.zkir` JSON in the compilation output. It is typically found at:
+
+```
+<contract-name>/build/zkir/<circuit-name>.zkir
+```
+
+If found, note the path in your report so the verifier can dispatch the `zkir-checker` agent if needed. Do NOT run the checker yourself — your job is compilation and JS runtime execution.
+
+If no `.zkir` output is found (some compilation modes may not produce it), note this in your report.
+
 ## Step 5: Write and Run the Runner Script
 
 **Create the runner script in the job directory:**

--- a/plugins/midnight-verify/skills/verify-by-zkir-checker/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-by-zkir-checker/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: midnight-verify:verify-by-zkir-checker
+description: >-
+  Verification by running the full ZK proof pipeline: compile Compact without
+  --skip-zk to generate PLONK keys, execute the circuit via JS runtime to get
+  proof data, serialize with proofDataIntoSerializedPreimage(), then verify
+  with the @midnight-ntwrk/zkir-v2 WASM PLONK checker. Supports both contract
+  mode (verify a user's .compact file) and claim mode (write a minimal contract
+  to test a claim). Loaded by the zkir-checker agent.
+version: 0.4.1
+---
+
+# Verify by ZKIR Checker
+
+You are verifying a Compact contract or ZKIR claim by running the full zero-knowledge proof pipeline. This uses the real PLONK verifier — the same verification path the Midnight network uses. Follow these steps in order.
+
+## Critical Rule
+
+**Always compile without `--skip-zk`.** The whole point of this method is using the real PLONK verifier with real proving keys. A checker ACCEPT proves the ZK proof is valid for those specific inputs. It does NOT prove the circuit is correct for all inputs.
+
+**What this proves that `verify-by-execution` doesn't:** The execution skill compiles with `--skip-zk` and runs the JS runtime — it proves the contract logic works. This skill proves the contract's zero-knowledge proof is valid: constraints are satisfied, transcript encoding is correct, proof data serializes properly, and the PLONK verifier accepts.
+
+## Step 1: Set Up the Workspace
+
+The workspace lives at `.midnight-expert/verify/zkir-workspace/` relative to the project root.
+
+**First time (workspace does not exist):**
+
+```bash
+mkdir -p .midnight-expert/verify/zkir-workspace
+cd .midnight-expert/verify/zkir-workspace
+npm init -y
+npm install @midnight-ntwrk/zkir-v2 @midnight-ntwrk/compact-runtime
+```
+
+**Subsequent times (workspace exists):**
+
+```bash
+cd .midnight-expert/verify/zkir-workspace
+npm ls @midnight-ntwrk/zkir-v2
+```
+
+If `npm ls` reports errors, run `npm install` to repair.
+
+**Create the job directory:**
+
+```bash
+JOB_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+mkdir -p .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID
+```
+
+## Step 2: Get the Contract
+
+### Contract Mode (primary)
+
+The user provides a `.compact` file or path. The contract may have imports and dependencies on other `.compact` files in its directory — **compile it where it lives**, directing only the build output to the job directory.
+
+If the contract has already been compiled with keys (a build directory exists containing `keys/*.prover` and `zkir/*.bzkir`), copy those build artifacts to the job directory instead of recompiling.
+
+### Claim Mode
+
+No user contract provided — you're verifying a natural language claim about ZK behavior. Write a minimal `.compact` contract in the job directory that exercises the claim.
+
+You may load compact-core skills as hints for writing correct Compact code. The compiled output is your evidence, not the skill content.
+
+## Step 3: Compile Without `--skip-zk`
+
+```bash
+compact compile -- <source-path> .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID/build/
+```
+
+**The source path is the `.compact` file where it lives** (contract mode) or in the job directory (claim mode). The build output always goes to `jobs/$JOB_ID/build/`.
+
+This produces:
+- `build/zkir/<circuit>.zkir` — ZKIR JSON
+- `build/zkir/<circuit>.bzkir` — ZKIR binary
+- `build/keys/<circuit>.prover` — PLONK proving key
+- `build/keys/<circuit>.verifier` — PLONK verifying key
+- `build/contract/index.js` — compiled JS contract
+- `build/compiler/contract-info.json` — circuit metadata
+
+If compilation fails, report the error. For claim mode, fix the contract and retry up to 2 times, then report Inconclusive.
+
+**Note:** Compilation without `--skip-zk` is slower than with it because it generates PLONK proving keys. This is expected — you are running the real ZK pipeline.
+
+## Step 4: Execute Via JS Runtime
+
+Import the compiled contract and execute the circuit(s) to get proof data:
+
+```javascript
+import * as compactRuntime from '@midnight-ntwrk/compact-runtime';
+import { Contract } from '<job-dir>/build/contract/index.js';
+
+// Create contract instance (may need witnesses depending on the contract)
+const contract = new Contract(witnesses);
+
+// Create initial state
+const initialZswapLocalState = { coinPublicKey: new Uint8Array(32) };
+const state = contract.initialState({ initialZswapLocalState, initialPrivateState: {} });
+
+// Create circuit context
+const context = compactRuntime.createCircuitContext(
+  compactRuntime.dummyContractAddress(),
+  initialZswapLocalState.coinPublicKey,
+  state.currentContractState.data,
+  state.currentPrivateState
+);
+
+// Execute the circuit via the circuits interface
+const circuitResult = contract.circuits.<circuitName>(context);
+
+// circuitResult contains: { result, context, proofData, gasCost }
+// proofData contains: { input, output, publicTranscript, privateTranscriptOutputs }
+```
+
+Check `build/compiler/contract-info.json` for the list of circuits. Each circuit with `"proof": true` can be verified through the PLONK checker.
+
+In **contract mode**, verify each provable circuit. In **claim mode**, only the circuit relevant to the claim.
+
+## Step 5: Serialize Proof Data
+
+```javascript
+const serializedPreimage = compactRuntime.proofDataIntoSerializedPreimage(
+  circuitResult.proofData.input,
+  circuitResult.proofData.output,
+  circuitResult.proofData.publicTranscript,
+  circuitResult.proofData.privateTranscriptOutputs,
+  '<circuitName>'  // keyLocation — matches the circuit name
+);
+```
+
+**This function takes 5 individual arguments, not an object.** The `keyLocation` parameter is the circuit name (e.g., `'increment'`) which the key provider uses to look up the correct keys.
+
+## Step 6: Run the PLONK Checker
+
+```javascript
+import { check } from '@midnight-ntwrk/zkir-v2';
+import { readFileSync } from 'fs';
+
+const keyProvider = {
+  async lookupKey(keyLocation) {
+    return {
+      proverKey: readFileSync(`<job-dir>/build/keys/${keyLocation}.prover`),
+      verifierKey: readFileSync(`<job-dir>/build/keys/${keyLocation}.verifier`),
+      ir: readFileSync(`<job-dir>/build/zkir/${keyLocation}.bzkir`)
+    };
+  },
+  async getParams(k) {
+    return readFileSync(`${process.env.HOME}/.compact/params/params_${k}.bin`);
+  }
+};
+
+try {
+  const result = await check(serializedPreimage, keyProvider);
+  // ACCEPTED — result is an array of outputs (bigint or undefined for void)
+  console.log(JSON.stringify({ verdict: 'ACCEPTED', outputs: result.map(v => v?.toString()) }));
+} catch (e) {
+  // REJECTED — error message identifies which constraint failed
+  console.log(JSON.stringify({ verdict: 'REJECTED', error: e.message }));
+}
+```
+
+**Checker error message catalog:**
+- `"Communications commitment mismatch"` — tampered raw bytes or commitment error
+- `"Public transcript input mismatch for input N; expected: Some(XX), computed: Some(YY)"` — wrong transcript values
+- `"Failed direct assertion"` — assert input is boolean 0
+- `"Expected boolean, found: XX"` — non-boolean to assert/cond_select/constrain_to_boolean
+- `"Failed equality constraint: XX != YY"` — constrain_eq inputs differ
+- `"Bit bound failed: XX is not N-bit"` — constrain_bits value exceeds range
+- `"Ran out of private transcript outputs"` — missing witness data
+- `"Transcripts not fully consumed"` — extra unused witness data
+
+## Step 7: Negative Testing (When Appropriate)
+
+For claims about rejection behavior (e.g., "tampering with the transcript is detected"), tamper with the proof data **before serialization** and confirm the checker rejects with the expected error:
+
+```javascript
+// Example: modify a transcript value
+const tamperedProofData = {
+  ...circuitResult.proofData,
+  publicTranscript: circuitResult.proofData.publicTranscript.map(op => {
+    if ('addi' in op) return { addi: { immediate: 999 } }; // Wrong value
+    return op;
+  })
+};
+
+const tamperedSerialized = compactRuntime.proofDataIntoSerializedPreimage(
+  tamperedProofData.input,
+  tamperedProofData.output,
+  tamperedProofData.publicTranscript,
+  tamperedProofData.privateTranscriptOutputs,
+  '<circuitName>'
+);
+
+// This should reject with "Public transcript input mismatch"
+const result = await check(tamperedSerialized, keyProvider);
+```
+
+A rejection in a negative test **confirms** the claim (the constraint is enforced).
+
+## Step 8: Report
+
+```
+### ZKIR Checker Report
+
+**Claim:** [verbatim]
+
+**Contract source:** [user's file path / minimal contract written for claim]
+
+**Compact source:**
+\`\`\`compact
+[source code]
+\`\`\`
+
+**Compilation:** [compiler version, circuit count, compilation time]
+
+**Execution:** [which circuit(s) executed, proof data summary]
+
+**Checker verdict:** ACCEPTED / REJECTED: [error message]
+
+**Interpretation:** [Confirmed / Refuted / Inconclusive] — [explanation]
+```
+
+## Step 9: Clean Up
+
+```bash
+rm -rf .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID
+```
+
+Do NOT remove the base workspace — it's shared across jobs.

--- a/plugins/midnight-verify/skills/verify-by-zkir-inspection/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-by-zkir-inspection/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: midnight-verify:verify-by-zkir-inspection
+description: >-
+  Verification by compiling Compact to ZKIR and analyzing the compiled circuit
+  structure. Extracts .zkir JSON from compilation output, parses instruction
+  arrays, counts opcodes, traces data flow, and checks transcript encoding.
+  Does not run the WASM checker — for constraint behavior, use
+  verify-by-zkir-checker instead. Loaded by the zkir-checker agent.
+version: 0.4.0
+---
+
+# Verify by ZKIR Inspection
+
+You are verifying a claim about compiled circuit structure by compiling Compact code and analyzing the resulting `.zkir` JSON. Follow these steps in order.
+
+## Critical Rule
+
+**Inspection proves what the compiler emits for specific source. It does NOT prove the circuit is correct.** Proving constraint correctness requires running the checker — use `verify-by-zkir-checker` for that. If the claim spans both structure and behavior, perform inspection first, then hand off to the checker.
+
+## Shared Compilation
+
+When the zkir-checker agent is running both inspection and checker methods for the same contract, compile once without `--skip-zk` and share the build output. The `.zkir` JSON produced by full compilation is identical to `--skip-zk` output — the only difference is that full compilation also generates PLONK keys. Don't compile twice.
+
+If the checker method has already compiled the contract, use its build output for inspection. If running inspection alone, `--skip-zk` is fine since you only need the `.zkir` JSON.
+
+## Step 1: Set Up and Compile
+
+Uses the same workspace as the checker method: `.midnight-expert/verify/zkir-workspace/`. Does not require the WASM checker — only the Compact CLI and JSON parsing.
+
+Create a job directory:
+
+```bash
+JOB_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+mkdir -p .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID
+```
+
+Write a minimal `.compact` contract targeting the claim. Only include what's needed to test the specific structural property.
+
+Get the current language version and compile:
+
+```bash
+compact compile --language-version
+compact compile -- --skip-zk <source-path> .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID/build/
+```
+
+For user-provided contracts, compile the contract where it lives (it may have imports) and direct only the build output to the job directory.
+
+If this inspection will be followed by checker verification, omit `--skip-zk` to avoid recompiling:
+
+```bash
+compact compile -- <source-path> .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID/build/
+```
+
+Capture the compiler output. Note the compiler version — ZKIR output may change between versions.
+
+## Step 2: Locate and Parse the `.zkir`
+
+After compilation, find the `.zkir` JSON in the build output directory. The typical structure is:
+
+```
+test-claim/build/zkir/<circuit-name>.zkir
+```
+
+Read the `.zkir` JSON and extract the top-level fields:
+
+```bash
+# Quick overview
+node -e "
+const zkir = JSON.parse(require('fs').readFileSync('<path-to-zkir>', 'utf8'));
+console.log(JSON.stringify({
+  version: zkir.version,
+  do_communications_commitment: zkir.do_communications_commitment,
+  num_inputs: zkir.num_inputs,
+  instruction_count: zkir.instructions.length,
+  opcodes: [...new Set(zkir.instructions.map(i => i.op))].sort()
+}, null, 2));
+"
+```
+
+## Step 3: Analyze Based on the Claim
+
+Perform targeted analysis based on what the claim asserts:
+
+| Claim type | Analysis approach |
+|---|---|
+| Instruction count | `zkir.instructions.length` |
+| Opcode usage | `zkir.instructions.filter(i => i.op === '<opcode>')` — count and list indices |
+| Opcode presence/absence | Check if opcode appears: `zkir.instructions.some(i => i.op === '<opcode>')` |
+| Transcript encoding | Look for `declare_pub_input` and `pi_skip` instructions (v2), count groups |
+| I/O shape | Count `output`, `public_input`, `private_input` instructions |
+| Constraint structure | Trace data flow: find constraint instructions, follow their input variable references back through the DAG to see what feeds into them |
+| ZKIR version format | Check `zkir.version.major` — 2 for v2, 3 for v3 |
+| Variable numbering | In v2, check that instructions reference sequential integer indices. In v3, look for named variables like `%v.0`, `%v.1` |
+
+For complex structural claims, write a small Node.js script in the job directory to perform the analysis and output structured JSON.
+
+## Step 4: Report
+
+```
+### ZKIR Inspection Report
+
+**Claim:** [verbatim]
+
+**Compact source:**
+\`\`\`compact
+[the contract you compiled]
+\`\`\`
+
+**Compiler version:** [output of compact compile --language-version]
+
+**ZKIR version:** v2 / v3
+
+**Analysis:**
+- Total instructions: N
+- [other relevant metrics based on claim type]
+
+**Key findings:**
+[specific instructions, indices, and patterns that address the claim]
+
+**Interpretation:** [Confirmed / Refuted / Inconclusive] — [explanation]
+```
+
+## Step 5: Clean Up
+
+```bash
+rm -rf .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID
+```

--- a/plugins/midnight-verify/skills/verify-compact/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-compact/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   execution (compile+run), source inspection, or both. Loaded by the verifier
   agent alongside the hub skill. Provides the claim type → method routing table
   and guidance on negative testing.
-version: 0.2.0
+version: 0.3.0
 ---
 
 # Compact Claim Classification
@@ -31,6 +31,9 @@ When you receive a Compact-related claim, classify it using this table to determ
 | Architecture/design rationale | "Compact uses Field as the base numeric type because..." | **source-investigator** |
 | Cross-component behavior | "Compiled output is compatible with compact-runtime v0.X" | **Both (concurrent)** |
 | Performance claims | "MerkleTree operations cost more gates than Map" | **contract-writer** (can measure circuit metrics at compile time) |
+| Circuit constraint structure | "this contract produces N constraints" | **zkir-checker** (inspection) |
+| Compiled ZKIR properties | "disclosure compiles to declare_pub_input" | **zkir-checker** (inspection) |
+| Constraint correctness | "guard circuit correctly constrains authority hash" | **zkir-checker** (checker) + **contract-writer** (concurrent) |
 
 **When in doubt:** If the claim involves observable runtime behavior, prefer **contract-writer**. If it's about what exists in the codebase or how something is implemented internally, prefer **source-investigator**. If it could benefit from both, dispatch both concurrently.
 

--- a/plugins/midnight-verify/skills/verify-correctness/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-correctness/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   dispatches sub-agents (contract-writer and/or source-investigator) based
   on the domain skill's routing, and synthesizes final verdicts. Always loaded
   first by the verifier agent.
-version: 0.3.0
+version: 0.4.0
 ---
 
 # Verification Hub
@@ -23,7 +23,8 @@ Determine what domain the claim belongs to:
 |---|---|---|
 | **Compact language** | Compact syntax, stdlib functions, types, disclosure, compiler behavior, patterns, privacy, circuit costs | Load `midnight-verify:verify-compact` |
 | **SDK/TypeScript** | API signatures, @midnight-ntwrk packages, import paths, type definitions, providers, DApp connector | Load `midnight-verify:verify-sdk` |
-| **Cross-domain** | Spans both Compact and SDK, or protocol/architecture | Load both domain skills |
+| **ZKIR** | ZKIR opcodes, circuit constraints, field elements, proof data, `.zkir` files, transcript protocol, checker behavior, circuit structure | Load `midnight-verify:verify-zkir` |
+| **Cross-domain** | Spans Compact and SDK, Compact and ZKIR, or protocol/architecture | Load applicable domain skills |
 
 ### 2. Load the Domain Skill
 
@@ -38,6 +39,8 @@ Based on the domain skill's routing:
 - **Type-checking needed** → dispatch `midnight-verify:type-checker` agent with the claim and what type assertion to make
 - **Devnet E2E needed** → dispatch `midnight-verify:sdk-tester` agent with the claim and what behavior to observe
 - **Package/version check needed** → dispatch `devs:deps-maintenance` agent with the package name and version claim. If deps-maintenance is not available (plugin not installed), run `npm view` directly as a fallback.
+- **ZKIR checker verification needed** → dispatch `midnight-verify:zkir-checker` agent with the claim and whether to use the checker method, inspection method, or both
+- **ZKIR regression sweep needed** → dispatch `midnight-verify:zkir-checker` agent and instruct it to load the `midnight-verify:zkir-regression` skill
 - **Multiple methods needed** → dispatch applicable agents **concurrently** (they are independent and can run in parallel)
 
 When dispatching, pass:
@@ -71,8 +74,17 @@ Collect the sub-agent report(s) and produce the final verdict.
 | **Refuted** | (package-verified) | Package doesn't exist or version doesn't match |
 | **Inconclusive** | (devnet unavailable) | Claim needs E2E testing but devnet is not running |
 | **Inconclusive** | (type-check insufficient) | Types match but claim is about runtime behavior — can't verify without devnet |
+| **Confirmed** | (zkir-checked) | WASM checker accepted the circuit with expected inputs |
+| **Confirmed** | (zkir-checked + tested) | Both WASM checker and Compact JS runtime agree |
+| **Confirmed** | (zkir-inspected) | Circuit structure analysis confirms the claim |
+| **Confirmed** | (zkir-checked + source-verified) | Checker result corroborated by source inspection |
+| **Refuted** | (zkir-checked) | WASM checker produced unexpected accept/reject for the claim |
+| **Refuted** | (zkir-inspected) | Circuit structure contradicts the claim |
+| **Inconclusive** | (zkir-checker unavailable) | `@midnight-ntwrk/zkir-v2` could not be installed or loaded |
 
 **When sub-agents disagree:** Execution evidence wins. The code ran and produced a result — that's more authoritative than interpreting source. But you MUST note the disagreement in your report so the user is aware.
+
+**When WASM checker and Compact JS runtime disagree:** The checker is more authoritative for constraint behavior (it operates at the proof system level). The JS runtime is more authoritative for output values (it runs the actual contract logic). Flag the disagreement in your report.
 
 **Inconclusive verdicts must explain:**
 - Why the claim couldn't be tested via execution

--- a/plugins/midnight-verify/skills/verify-zkir/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-zkir/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: midnight-verify:verify-zkir
+description: >-
+  ZKIR claim classification and method routing. Determines what kind of ZKIR
+  claim is being verified and which verification method applies: WASM checker
+  (accept/reject testing), circuit inspection (compiled structure analysis),
+  or source investigation. Handles claims about opcode semantics, constraint
+  behavior, field arithmetic, transcript protocol, and compiled circuit
+  properties. Loaded by the verifier agent alongside the hub skill.
+version: 0.4.0
+---
+
+# ZKIR Claim Classification
+
+This skill classifies ZKIR-related claims and determines which verification method to use. The verifier (orchestrator) agent loads this alongside the hub skill (`verify-correctness`).
+
+## Claim Type → Method Routing
+
+When you receive a ZKIR-related claim, classify it using this table to determine which agent(s) to dispatch:
+
+### Claims About ZKIR Behavior
+
+| Claim Type | Example | Dispatch |
+|---|---|---|
+| Opcode semantics | "add wraps modulo r", "mul by zero produces zero" | **zkir-checker** (checker method) |
+| Constraint behavior | "assert requires boolean input", "constrain_eq fails on unequal values" | **zkir-checker** (checker method) |
+| Field arithmetic | "there are no negative numbers, -1 is r-1", "(r-1) + 1 = 0" | **zkir-checker** (checker method) |
+| Transcript protocol | "publicTranscript encodes ledger ops as field elements", "popeq bridges public_input" | **zkir-checker** (checker method) |
+| Cryptographic opcodes | "persistent_hash produces two field elements", "ec_mul_generator derives public key" | **zkir-checker** (checker method) |
+| Proof data validity | "extra private transcript outputs cause rejection", "tampered public transcript is detected" | **zkir-checker** (checker method) |
+| Type encoding | "encode converts a curve point to two field elements", "decode is the inverse of encode" | **zkir-checker** (checker method) |
+
+### Claims About Compiled Circuit Structure
+
+| Claim Type | Example | Dispatch |
+|---|---|---|
+| Instruction count | "this contract produces N instructions" | **zkir-checker** (inspection method) |
+| Opcode usage | "guard counter uses persistent_hash for authority" | **zkir-checker** (inspection method) |
+| Transcript encoding | "increment circuit uses 3 transcript ops", "disclosure compiles to declare_pub_input" | **zkir-checker** (inspection method) |
+| I/O shape | "this pure circuit has no private_input instructions" | **zkir-checker** (inspection method) |
+| ZKIR version format | "compiled output uses v2 format with implicit variable numbering" | **zkir-checker** (inspection method) |
+
+### Claims About ZKIR Internals
+
+| Claim Type | Example | Dispatch |
+|---|---|---|
+| ZKIR version differences | "v3 uses named variables, v2 uses integer indices" | **source-investigator** |
+| Compiler internals | "zkir-passes.ss handles v2 serialization" | **source-investigator** |
+| Checker implementation | "the WASM checker enforces transcript integrity" | **source-investigator** |
+
+### Cross-Domain Claims
+
+| Claim Type | Example | Dispatch |
+|---|---|---|
+| Compact → ZKIR mapping | "this Compact disclosure compiles to these ZKIR constraints" | **zkir-checker** (both methods) + **contract-writer** (concurrent) |
+| Behavior + structure | "the guard circuit uses persistent_hash AND correctly rejects wrong keys" | **zkir-checker** (both methods) |
+| ZKIR + runtime agreement | "the checker and JS runtime agree on this circuit's behavior" | **zkir-checker** (checker) + **contract-writer** (concurrent) |
+
+### Routing Rules
+
+**When in doubt:**
+- Observable checker behavior (accept/reject with specific inputs) → **zkir-checker** (checker method)
+- Compiled output properties (structure, counts, patterns) → **zkir-checker** (inspection method)
+- Compiler/toolchain internals (how the compiler works, not what it produces) → **source-investigator**
+
+**When multiple methods apply, dispatch concurrently.** Checker and inspection are independent and can run in parallel within the same agent.
+
+## Hints from the ZKIR Reference
+
+The ZKIR reference document (Compact compiler v0.29.0) documents 26 opcodes across 8 categories. When a claim is about a specific opcode, mention the category to help the zkir-checker write an appropriate test contract:
+
+- **Arithmetic:** add, mul, neg
+- **Constraints:** assert, constrain_bits, constrain_eq, constrain_to_boolean
+- **Control Flow:** cond_select, copy
+- **Type Encoding:** decode, encode, reconstitute_field
+- **Division:** div_mod_power_of_two
+- **Cryptographic:** ec_mul, ec_mul_generator, hash_to_curve, persistent_hash, transient_hash
+- **I/O:** impact, output, private_input, public_input
+- **Comparison:** less_than, test_eq

--- a/plugins/midnight-verify/skills/zkir-regression/SKILL.md
+++ b/plugins/midnight-verify/skills/zkir-regression/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: midnight-verify:zkir-regression
+description: >-
+  Run a curated set of verification claims against the current toolchain to
+  detect behavioral changes. Each claim is verified through the normal
+  verification pipeline (verifier → agents → checker/execution). Supports
+  full sweep (all categories) and targeted sweep (single category). Invocable
+  as /midnight-verify:zkir-regression or loadable by agents as a sense-check
+  when they suspect toolchain issues.
+version: 0.4.1
+argument-hint: "[category: arithmetic|types|state|privacy|zk-proof|transcript]"
+---
+
+# ZKIR Regression Sweep
+
+Run a curated set of verification claims against the current toolchain to detect behavioral changes. Each claim is verified through the full pipeline — claim classification, contract writing, compilation, execution, and PLONK proof verification.
+
+Use this when:
+- A new compiler version or checker package version is released
+- An agent suspects unexpected behavior from the toolchain
+- You want a confidence check before presenting Midnight-specific claims
+
+## Step 1: Determine Mode
+
+If `$ARGUMENTS` is empty → **full sweep** (all categories).
+
+If `$ARGUMENTS` contains a category name → **targeted sweep** (that category only).
+
+Valid categories: `arithmetic`, `types`, `state`, `privacy`, `zk-proof`, `transcript`.
+
+## Step 2: Record Toolchain Versions
+
+```bash
+compact compile --language-version
+compact --version
+```
+
+Record both for the report header.
+
+## Step 3: Run Claims
+
+For each claim in the list below (filtered by category if targeted), dispatch the `midnight-verify:verifier` agent with:
+- The claim text
+- Instruction to verify using the appropriate method
+
+Collect the verdict for each claim. Do NOT stop on first failure — run all claims and collect all results.
+
+## Claim List
+
+| ID | Category | Claim | Expected Verdict |
+|---|---|---|---|
+| arith-1 | arithmetic | A pure circuit that adds two Uint32 values (3 + 4) returns the correct sum (7) | Confirmed (tested) |
+| arith-2 | arithmetic | A pure circuit that multiplies two Uint32 values (3 * 5) returns the correct product (15) | Confirmed (tested) |
+| types-1 | types | Assigning a value of 256 to a Uint8 variable produces a compiler error | Confirmed (tested) |
+| types-2 | types | A pure circuit returning a tuple allows 0-indexed access to each element | Confirmed (tested) |
+| state-1 | state | A counter contract's increment circuit updates the ledger state by the specified amount | Confirmed (tested) |
+| state-2 | state | Reading a counter ledger value returns the current on-chain state | Confirmed (tested) |
+| privacy-1 | privacy | A circuit that writes to the ledger requires a disclose() call | Confirmed (tested) |
+| zk-1 | zk-proof | A counter contract's increment circuit passes the full PLONK proof verification | Confirmed (zkir-checked) |
+| zk-2 | zk-proof | Tampering with the public transcript of a verified circuit causes PLONK checker rejection | Confirmed (zkir-checked) |
+| zk-3 | zk-proof | The PLONK checker error for a tampered transcript identifies the exact mismatched input | Confirmed (zkir-checked) |
+| transcript-1 | transcript | A counter increment circuit encodes ledger operations in the publicTranscript | Confirmed (zkir-inspected) |
+| transcript-2 | transcript | The compiled ZKIR for a counter increment contains declare_pub_input instructions | Confirmed (zkir-inspected) |
+
+## Step 4: Compare Results
+
+For each claim, compare the actual verdict against the expected verdict:
+- Verdict matches expected → **PASS**
+- Verdict does not match → **FAIL**
+- Verification returned Inconclusive but expected Confirmed → **FAIL** (toolchain may be unavailable)
+
+## Step 5: Report
+
+```markdown
+## ZKIR Regression Report
+
+**Toolchain:** compact CLI vX.Y.Z, language version A.B.C
+**Date:** YYYY-MM-DD
+**Mode:** [full sweep / targeted: <category>]
+**Ran:** N claims
+
+### Results
+
+| Category | Passed | Failed | Total |
+|---|---|---|---|
+| arithmetic | N | N | N |
+| types | N | N | N |
+| state | N | N | N |
+| privacy | N | N | N |
+| zk-proof | N | N | N |
+| transcript | N | N | N |
+| **Total** | **N** | **N** | **N** |
+
+### Failures (if any)
+
+**<claim-id>:** Expected <expected verdict>, got <actual verdict>
+- Claim: "<claim text>"
+- Actual result: [what the verification pipeline returned]
+- Interpretation: [what this failure suggests about toolchain changes]
+```
+
+If there are zero failures, end with:
+> All N claims passed. Toolchain behavior matches expectations.
+
+## Adding New Claims
+
+Add a row to the claim list table above. Each claim should:
+- Be verifiable through the normal `/verify` pipeline
+- Have a deterministic expected verdict
+- Test a specific, observable behavior
+- Include the expected verdict qualifier (tested, zkir-checked, zkir-inspected, source-verified)


### PR DESCRIPTION
## Summary

- Adds ZK proof verification using the real PLONK pipeline — compile Compact without `--skip-zk`, execute via JS runtime, serialize proof data with `proofDataIntoSerializedPreimage()`, verify through `@midnight-ntwrk/zkir-v2` WASM PLONK checker
- New `zkir-checker` agent (opus) with two method skills: `verify-by-zkir-checker` (full PLONK verification) and `verify-by-zkir-inspection` (compiled circuit structure analysis)
- New `verify-zkir` domain routing skill and `zkir-regression` claim-based toolchain regression sweep
- Updated hub skill with ZKIR domain classification and 7 new verdict qualifiers (zkir-checked, zkir-inspected, etc.)
- Plugin bumped to v0.4.0

## Test plan

- [ ] Run `/verify "counter increment passes PLONK proof verification"` — should dispatch zkir-checker, compile without --skip-zk, execute, serialize, check → Confirmed (zkir-checked)
- [ ] Run `/verify "counter increment compiles to fewer than 20 ZKIR instructions"` — should dispatch zkir-checker inspection method → Confirmed (zkir-inspected)
- [ ] Run `/midnight-verify:zkir-regression zk-proof` — should run the 3 zk-proof claims and report pass/fail
- [ ] Verify that `/verify "Tuples are 0-indexed"` still routes to contract-writer (existing Compact verification unaffected)

Generated with [Claude Code](https://claude.com/claude-code)