### PR TITLE
feat(verify): add cross-domain witness verification

### DIFF
--- a/plugins/midnight-verify/.claude-plugin/plugin.json
+++ b/plugins/midnight-verify/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-verify",
-  "version": "0.4.0",
-  "description": "Verification framework for Midnight claims — verifies Compact code by compiling and executing test contracts, SDK/TypeScript claims by type-checking and devnet E2E testing, ZKIR circuits by running through the WASM checker and inspecting compiled structure, or by inspecting source code. Multi-agent pipeline with explicit /verify command.",
+  "version": "0.5.0",
+  "description": "Verification framework for Midnight claims — verifies Compact code by compiling and executing test contracts, SDK/TypeScript claims by type-checking and devnet E2E testing, ZKIR circuits by running through the WASM checker and inspecting compiled structure, witness implementations by cross-domain type-checking and execution against compiled contracts, or by inspecting source code. Multi-agent pipeline with explicit /verify command.",
   "author": {
     "name": "Aaron Bassett",
     "email": "aaron@devrel-ai.com"
@@ -26,6 +26,7 @@
     "circuit",
     "proof",
     "checker",
-    "wasm"
+    "wasm",
+    "witness"
   ]
 }

--- a/plugins/midnight-verify/agents/verifier.md
+++ b/plugins/midnight-verify/agents/verifier.md
@@ -31,7 +31,12 @@ description: >-
   Example 6: User runs /verify "constrain_bits enforces 8-bit range" — the
   orchestrator classifies this as a ZKIR opcode claim, dispatches the
   zkir-checker agent to compile a test contract and verify through the PLONK checker.
-skills: midnight-verify:verify-correctness, midnight-verify:verify-compact, midnight-verify:verify-sdk, midnight-verify:verify-zkir
+
+  Example 7: User runs /verify contracts/counter.compact src/witnesses.ts —
+  the orchestrator classifies this as a witness verification, dispatches the
+  witness-verifier agent to compile, type-check, run structural analysis, and
+  execute the contract with the witness.
+skills: midnight-verify:verify-correctness, midnight-verify:verify-compact, midnight-verify:verify-sdk, midnight-verify:verify-zkir, midnight-verify:verify-witness
 model: sonnet
 color: green
 ---
@@ -44,7 +49,9 @@ You are the Midnight verification orchestrator.
 2. Based on the claim domain:
    - Compact claims → load `midnight-verify:verify-compact`
    - SDK/TypeScript claims → load `midnight-verify:verify-sdk`
-   - Cross-domain → load both
+   - ZKIR claims → load `midnight-verify:verify-zkir`
+   - Witness claims → load `midnight-verify:verify-witness`
+   - Cross-domain → load applicable domain skills
 3. Follow the hub skill's process exactly.
 
 ## Dispatching Sub-Agents
@@ -63,6 +70,10 @@ You are the Midnight verification orchestrator.
 - Checker verification → dispatch `midnight-verify:zkir-checker`
 - Circuit inspection → dispatch `midnight-verify:zkir-checker`
 - Regression sweep → dispatch `midnight-verify:zkir-checker` with instruction to load `midnight-verify:zkir-regression`
+
+**Witness verification:**
+- Witness verification → dispatch `midnight-verify:witness-verifier`
+- Witness + ZKIR → dispatch `midnight-verify:witness-verifier` first, then pass build output path to `midnight-verify:zkir-checker` (sequential)
 
 **When multiple methods are needed, dispatch agents concurrently.** They are independent and can run in parallel.
 

--- a/plugins/midnight-verify/agents/witness-verifier.md
+++ b/plugins/midnight-verify/agents/witness-verifier.md
@@ -1,0 +1,45 @@
+---
+name: witness-verifier
+description: >-
+  Use this agent to verify that TypeScript witness implementations correctly
+  match Compact contract declarations. Compiles the contract, type-checks the
+  witness against generated types, runs structural analysis (name matching,
+  return tuple shape, WitnessContext usage, private state patterns), and
+  executes the combined contract+witness pipeline. Dispatched by the verifier
+  orchestrator agent.
+
+  Example 1: User runs /verify contracts/counter.compact src/witnesses.ts —
+  the agent compiles the contract, type-checks the witness against the generated
+  Witnesses type, runs the structural checklist, and executes the circuit with
+  the witness implementation.
+
+  Example 2: Claim "This witness correctly implements the counter contract" —
+  the agent asks for or identifies the relevant .compact and .ts files, then
+  runs the full verification pipeline.
+
+  Example 3: Claim "This contract + witness produces a valid ZK proof" —
+  the agent compiles without --skip-zk, runs its pipeline, and reports the
+  build output path so the zkir-checker can run PLONK verification.
+skills: midnight-verify:verify-by-witness
+model: opus
+color: orange
+---
+
+You are a cross-domain witness verifier for Midnight.
+
+## Your Job
+
+Load `midnight-verify:verify-by-witness` and follow it step by step. The skill defines a 5-phase pipeline:
+
+1. **Setup** — initialize workspace, locate the .compact and .ts files
+2. **Compile and Type-Check** — compile the contract, type-check the witness against generated types
+3. **Structural Checklist** — automated checks for name matching, return tuple shape, WitnessContext usage, private state immutability, side effects
+4. **Execute** — run the circuit with the witness via JS runtime
+5. **Optional Devnet E2E** — dispatch to sdk-tester if devnet is available
+
+## Important
+
+- You do NOT classify claims or synthesize verdicts — the verifier orchestrator does that.
+- The Compact contract must be compiled where it lives (it may have imports). Direct build output to the job directory.
+- For claims that also need PLONK verification, compile without `--skip-zk` and report the build output path so the verifier can pass it to the zkir-checker.
+- You may load `compact-core:compact-witness-ts` as a hint for understanding witness patterns, but your verification results are the evidence, not skill content.

--- a/plugins/midnight-verify/skills/verify-by-witness/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-by-witness/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: midnight-verify:verify-by-witness
+description: >-
+  Cross-domain witness verification pipeline. Compiles the Compact contract,
+  type-checks the TypeScript witness against the compiled contract's generated
+  Witnesses type, runs structural checklist analysis (name matching, return
+  tuple shape, WitnessContext usage, private state immutability, side effects),
+  executes the circuit with the witness via JS runtime, and optionally
+  dispatches to sdk-tester for devnet E2E. Loaded by the witness-verifier agent.
+version: 0.5.0
+---
+
+# Verify by Witness
+
+You are verifying that a TypeScript witness implementation correctly matches and works with a Compact contract. Follow these phases in order.
+
+## Critical Rule
+
+**Witness verification is cross-domain.** You need both the `.compact` contract file and the `.ts` witness implementation file. If you only have one, ask for the other. Do not attempt verification with only one file.
+
+## Phase 1: Setup and Locate Files
+
+The workspace lives at `.midnight-expert/verify/witness-workspace/` relative to the project root.
+
+**First time (workspace does not exist):**
+
+```bash
+mkdir -p .midnight-expert/verify/witness-workspace
+cd .midnight-expert/verify/witness-workspace
+npm init -y
+npm install @midnight-ntwrk/compact-runtime typescript
+```
+
+**Subsequent times:**
+
+```bash
+cd .midnight-expert/verify/witness-workspace
+npm ls typescript
+```
+
+If errors, `npm install` to repair.
+
+**Create the job directory:**
+
+```bash
+JOB_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+mkdir -p .midnight-expert/verify/witness-workspace/jobs/$JOB_ID
+```
+
+**Locate the files:**
+
+- **Two files provided:** Verify both exist. The `.compact` file stays where it is (it may have imports and dependencies on other `.compact` files in its directory). Copy the `.ts` witness file to the job directory.
+- **Claim provided:** Identify the relevant files from the claim text. If the claim names specific files or paths, locate them. If not, use `AskUserQuestion` to ask which files to verify.
+
+## Phase 2: Compile and Type-Check
+
+### Compile the Compact contract
+
+Compile the contract where it lives, directing build output to the job directory:
+
+```bash
+compact compile -- --skip-zk <source-path> .midnight-expert/verify/witness-workspace/jobs/$JOB_ID/build/
+```
+
+If the verifier indicated this claim also needs PLONK verification (Witness + ZKIR), compile without `--skip-zk` instead:
+
+```bash
+compact compile -- <source-path> .midnight-expert/verify/witness-workspace/jobs/$JOB_ID/build/
+```
+
+This produces `build/contract/index.js` and `build/contract/index.d.ts` which export the generated `Witnesses` type.
+
+### Type-check the witness
+
+Create a type-check harness in the job directory that imports the witness file and validates it against the generated types:
+
+```typescript
+// jobs/$JOB_ID/witness-check.ts
+import type { Witnesses } from './build/contract/index.js';
+import witnesses from '<absolute-path-to-witness-file>';
+
+// This assignment checks that the witness object satisfies the generated Witnesses type
+const _typeCheck: Witnesses<any> = witnesses;
+```
+
+Create a `tsconfig.json` for the job:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": false,
+    "esModuleInterop": true
+  },
+  "include": ["witness-check.ts"]
+}
+```
+
+Run the type check:
+
+```bash
+cd .midnight-expert/verify/witness-workspace/jobs/$JOB_ID
+npx tsc --noEmit --project tsconfig.json 2>&1
+```
+
+**If tsc exits 0:** Types match — the witness satisfies the generated `Witnesses` type.
+**If tsc exits non-zero:** Type mismatches found — the compiler errors are evidence of what doesn't match.
+
+Note: The exact shape of the type-check harness depends on how the compiled contract exports the `Witnesses` type. Read `build/contract/index.d.ts` to understand the export shape and adapt the harness accordingly.
+
+## Phase 3: Structural Checklist
+
+Read both the compiled `build/contract/index.d.ts` (for witness declarations) and the `.ts` witness file (for implementations). Perform these automated checks:
+
+### Check 1: Name Matching
+
+Parse the witness function names from the compiled type declarations. Check that every declared witness name exists in the TypeScript implementation with exact casing.
+
+**PASS:** All declared witness names have matching implementations.
+**FAIL:** List missing or misspelled names.
+
+### Check 2: Return Tuple Shape
+
+Check that each witness function returns `[PrivateState, ReturnValue]` — a two-element tuple where the first element is the private state type. Look for return type annotations or actual return statements.
+
+**PASS:** All witnesses return a tuple with private state as the first element.
+**FAIL:** List witnesses that return just the value without the private state wrapper.
+
+### Check 3: WitnessContext First Parameter
+
+Check that each witness function's first parameter is the `WitnessContext` type (containing `ledger`, `privateState`, `contractAddress`).
+
+**PASS:** All witnesses accept `WitnessContext` as their first parameter.
+**FAIL:** List witnesses with wrong or missing first parameter.
+
+### Check 4: Private State Immutability
+
+Check that witness functions create new state objects rather than mutating the existing `privateState` in place. Look for:
+- **Correct patterns:** Object spread (`{ ...context.privateState, key: newValue }`), `Object.assign({}, ...)`, creating new objects
+- **Incorrect patterns:** Direct property assignment (`context.privateState.key = value`), array `.push()`, `.splice()`, etc.
+
+**PASS:** No direct mutation patterns found.
+**FAIL:** List locations where private state appears to be mutated directly.
+
+### Check 5: No Side Effects
+
+Check for non-deterministic or side-effecting code that should not appear in witnesses:
+- `console.log`, `console.warn`, `console.error`
+- `fetch`, `XMLHttpRequest`
+- `fs.readFile`, `fs.writeFile`, any `fs` usage
+- `Math.random`, `Date.now`, `crypto.getRandomValues`
+- `setTimeout`, `setInterval`
+
+**PASS:** No side effects found.
+**FAIL:** List locations of non-deterministic or side-effecting code.
+
+Note: These checks are heuristic — they read source text and look for patterns. They are not as authoritative as compilation or execution. Report findings alongside the mechanical results.
+
+## Phase 4: Execute with Witness
+
+Import the compiled contract and execute the circuit(s) with the witness:
+
+```javascript
+import { Contract } from '<job-dir>/build/contract/index.js';
+import witnesses from '<absolute-path-to-witness-file>';
+
+// Create contract instance with the witness implementations
+const contract = new Contract(witnesses);
+
+// Create initial state
+const initialZswapLocalState = { coinPublicKey: new Uint8Array(32) };
+const state = contract.initialState({
+  initialZswapLocalState,
+  initialPrivateState: { /* appropriate initial private state */ }
+});
+
+// Create circuit context
+const context = compactRuntime.createCircuitContext(
+  compactRuntime.dummyContractAddress(),
+  initialZswapLocalState.coinPublicKey,
+  state.currentContractState.data,
+  state.currentPrivateState
+);
+
+// Execute each circuit that uses witnesses
+const result = contract.circuits.<circuitName>(context);
+```
+
+Check `build/compiler/contract-info.json` — circuits with a non-empty `witnesses` array use witnesses.
+
+**Success:** The circuit executed without error and produced valid proof data. The contract + witness combination works.
+
+**Failure:** Capture the error. Common witness execution errors:
+- `"expected tuple, got <type>"` — witness returns wrong shape
+- `"missing witness: <name>"` — witness function not provided
+- `"Contract constructor: expected 1 argument"` — witnesses object not passed
+- Type errors at runtime — witness returns wrong types
+
+## Phase 5: Optional Devnet E2E
+
+Check devnet health (load `midnight-tooling:devnet` skill for endpoints). If all services are reachable, dispatch to `midnight-verify:sdk-tester` for the full deploy+call lifecycle with the witness.
+
+If devnet is unavailable, note in the report: "Behavioral verification passed locally. Full deploy+call lifecycle verification requires a running devnet."
+
+## Report
+
+```
+### Witness Verification Report
+
+**Contract:** [path to .compact]
+**Witness:** [path to .ts]
+
+**Type Check:** PASS / FAIL
+[tsc output if failed]
+
+**Structural Checklist:**
+- Name matching: PASS / FAIL — [details]
+- Return tuple shape: PASS / FAIL — [details]
+- WitnessContext pattern: PASS / FAIL — [details]
+- Private state immutability: PASS / FAIL — [details]
+- No side effects: PASS / FAIL — [details]
+
+**Execution:** PASS / FAIL
+[execution output or error]
+
+**Devnet E2E:** PASS / FAIL / SKIPPED (devnet unavailable)
+
+**Interpretation:** [Confirmed / Refuted / Inconclusive] — [summary]
+```
+
+If the verifier indicated PLONK verification is needed, include the build output path in the report so the verifier can pass it to the zkir-checker:
+
+```
+**Build output:** .midnight-expert/verify/witness-workspace/jobs/$JOB_ID/build/
+```
+
+## Clean Up
+
+```bash
+rm -rf .midnight-expert/verify/witness-workspace/jobs/$JOB_ID
+```
+
+Do NOT remove the base workspace — it's shared across jobs. If the verifier needs the build output for zkir-checker, do NOT clean up until the verifier confirms the zkir-checker is done.

--- a/plugins/midnight-verify/skills/verify-correctness/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-correctness/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   dispatches sub-agents (contract-writer and/or source-investigator) based
   on the domain skill's routing, and synthesizes final verdicts. Always loaded
   first by the verifier agent.
-version: 0.4.0
+version: 0.5.0
 ---
 
 # Verification Hub
@@ -24,7 +24,8 @@ Determine what domain the claim belongs to:
 | **Compact language** | Compact syntax, stdlib functions, types, disclosure, compiler behavior, patterns, privacy, circuit costs | Load `midnight-verify:verify-compact` |
 | **SDK/TypeScript** | API signatures, @midnight-ntwrk packages, import paths, type definitions, providers, DApp connector | Load `midnight-verify:verify-sdk` |
 | **ZKIR** | ZKIR opcodes, circuit constraints, field elements, proof data, `.zkir` files, transcript protocol, checker behavior, circuit structure | Load `midnight-verify:verify-zkir` |
-| **Cross-domain** | Spans Compact and SDK, Compact and ZKIR, or protocol/architecture | Load applicable domain skills |
+| **Witness** | Witness implementation, WitnessContext, private state, `[PrivateState, T]` return tuple, `.compact` + `.ts` file pair, witness declarations, type mappings | Load `midnight-verify:verify-witness` |
+| **Cross-domain** | Spans Compact and SDK, Compact and ZKIR, Witness and ZKIR, or protocol/architecture | Load applicable domain skills |
 
 ### 2. Load the Domain Skill
 
@@ -41,6 +42,8 @@ Based on the domain skill's routing:
 - **Package/version check needed** → dispatch `devs:deps-maintenance` agent with the package name and version claim. If deps-maintenance is not available (plugin not installed), run `npm view` directly as a fallback.
 - **ZKIR checker verification needed** → dispatch `midnight-verify:zkir-checker` agent with the claim and whether to use the checker method, inspection method, or both
 - **ZKIR regression sweep needed** → dispatch `midnight-verify:zkir-checker` agent and instruct it to load the `midnight-verify:zkir-regression` skill
+- **Witness verification needed** → dispatch `midnight-verify:witness-verifier` agent with the claim and both file paths (if provided)
+- **Witness + ZKIR verification needed** → dispatch `midnight-verify:witness-verifier` first (it compiles and verifies), then pass the build output path to `midnight-verify:zkir-checker` for PLONK verification. These are sequential, not concurrent.
 - **Multiple methods needed** → dispatch applicable agents **concurrently** (they are independent and can run in parallel)
 
 When dispatching, pass:
@@ -81,6 +84,11 @@ Collect the sub-agent report(s) and produce the final verdict.
 | **Refuted** | (zkir-checked) | WASM checker produced unexpected accept/reject for the claim |
 | **Refuted** | (zkir-inspected) | Circuit structure contradicts the claim |
 | **Inconclusive** | (zkir-checker unavailable) | `@midnight-ntwrk/zkir-v2` could not be installed or loaded |
+| **Confirmed** | (witness-verified) | Type check + structural checklist + execution all pass |
+| **Confirmed** | (witness-verified + tested) | Local verification + devnet E2E both pass |
+| **Confirmed** | (witness-verified + zkir-checked) | Witness verification + PLONK proof valid |
+| **Refuted** | (witness-verified) | Type check, structural check, or execution failed |
+| **Inconclusive** | (devnet unavailable) | Local witness verification passed but devnet E2E needed and unavailable |
 
 **When sub-agents disagree:** Execution evidence wins. The code ran and produced a result — that's more authoritative than interpreting source. But you MUST note the disagreement in your report so the user is aware.
 

--- a/plugins/midnight-verify/skills/verify-sdk/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-sdk/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   package checks. Handles both claims about the SDK API itself and
   verification of user code that uses the SDK. Loaded by the verifier
   agent alongside the hub skill.
-version: 0.3.0
+version: 0.4.0
 ---
 
 # SDK Claim Classification
@@ -40,7 +40,7 @@ When you receive an SDK-related claim, classify it using this table to determine
 | Claim Type | Example | Dispatch |
 |---|---|---|
 | DApp code type-correctness | "This provider setup code is valid" | **type-checker** |
-| Witness implementation | "This witness correctly implements the contract interface" | **type-checker** (+ **contract-writer** for the Compact side) |
+| Witness implementation | "This witness correctly implements the contract interface" | **witness-verifier** |
 | Provider configuration | "This provider config connects to devnet correctly" | **type-checker** + **sdk-tester** |
 | Import usage patterns | "This file's SDK imports are correct" | **type-checker** |
 | Transaction handling code | "This error handling catches CallTxFailedError" | **type-checker** |

--- a/plugins/midnight-verify/skills/verify-witness/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-witness/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: midnight-verify:verify-witness
+description: >-
+  Witness claim classification and method routing. Determines what kind of
+  witness claim is being verified and dispatches to the witness-verifier agent.
+  Handles claims about witness type correctness, name matching, return tuple
+  shape, type mappings, behavioral correctness, private state patterns, and
+  two-file verification. Loaded by the verifier agent alongside the hub skill.
+version: 0.5.0
+---
+
+# Witness Claim Classification
+
+This skill classifies witness-related claims and determines which agent(s) to dispatch. The verifier (orchestrator) agent loads this alongside the hub skill (`verify-correctness`).
+
+## Claim Type → Method Routing
+
+When you receive a witness-related claim, classify it using this table:
+
+### Claims About the Contract-Witness Interface
+
+| Claim Type | Example | Dispatch |
+|---|---|---|
+| Witness type correctness | "This witness correctly implements the contract interface" | **witness-verifier** |
+| Witness name matching | "The witness names match the contract declarations" | **witness-verifier** |
+| Witness return type | "This witness returns the correct [PrivateState, ReturnValue] tuple" | **witness-verifier** |
+| Type mapping correctness | "The Field parameters map to bigint in the witness" | **witness-verifier** |
+| WitnessContext usage | "This witness correctly uses the ledger from WitnessContext" | **witness-verifier** |
+| Private state patterns | "This witness doesn't mutate private state in place" | **witness-verifier** |
+
+### Claims About Witness Behavior
+
+| Claim Type | Example | Dispatch |
+|---|---|---|
+| Behavioral correctness | "This contract + witness combination produces valid results" | **witness-verifier** |
+| Two-file verification | `/verify contracts/counter.compact src/witnesses.ts` | **witness-verifier** (both files) |
+| Witness + devnet E2E | "This witness works correctly when deployed" | **witness-verifier** + **sdk-tester** (concurrent) |
+
+### Cross-Domain Claims
+
+| Claim Type | Example | Dispatch |
+|---|---|---|
+| Witness + ZK proof | "This contract + witness produces a valid ZK proof" | **witness-verifier** first, then **zkir-checker** (sequential — witness-verifier passes build output path) |
+
+### Routing Rules
+
+**When in doubt:**
+- Claims about the contract-witness interface → **witness-verifier**
+- Claims about just the TypeScript types (no contract involved) → **type-checker** (existing SDK path)
+- Claims about just the Compact declarations (no witness implementation) → **contract-writer** (existing Compact path)
+
+**For Witness + ZKIR claims:** dispatch witness-verifier first (it compiles and verifies), then pass the build output path to zkir-checker. These are sequential, not concurrent, because the zkir-checker depends on the compiled artifacts.
+
+## Hints from Existing Skills
+
+The witness-verifier may consult these skills for context. They are **hints only** — never cite them as evidence.
+
+- `compact-core:compact-witness-ts` — witness implementation patterns, WitnessContext API, type mappings
+- `compact-core:compact-structure` — witness declarations, disclosure rules
+- `compact-core:compact-review` — witness consistency review checklist


### PR DESCRIPTION
## Summary

- Adds witness verification that checks the interface between Compact contract declarations and TypeScript witness implementations
- New `witness-verifier` agent (opus) with 5-phase pipeline: compile contract → type-check witness against generated `Witnesses` type → structural checklist (name matching, return tuple shape, WitnessContext, private state immutability, side effects) → execute contract+witness → optional devnet E2E
- New `verify-witness` domain routing skill and `verify-by-witness` method skill
- Own workspace at `.midnight-expert/verify/witness-workspace/`
- For Witness+ZKIR claims, witness-verifier runs first and passes build output to zkir-checker (sequential, avoids double compilation)
- Plugin bumped to v0.5.0

## Test plan

- [ ] Run `/verify contracts/counter.compact src/witnesses.ts` — should dispatch witness-verifier, run all 5 phases, report witness verification results
- [ ] Run `/verify "This witness correctly implements the counter contract"` — should classify as Witness domain, ask for file paths, verify
- [ ] Verify that `/verify "deployContract returns DeployedContract"` still routes to type-checker (existing SDK verification unaffected)
- [ ] Verify the SDK skill's witness row now routes to witness-verifier instead of type-checker

Generated with [Claude Code](https://claude.com/claude-code)