### PR TITLE
feat: add ledger protocol verification and testing skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-expert",
   "metadata": {
-    "version": "0.11.0",
+    "version": "0.12.0",
     "description": "AI agent plugins for the Midnight data-protection blockchain. Covers Compact smart contract development, privacy-preserving patterns, DApp frontend design, and Midnight toolchain management."
   },
   "owner": {

--- a/docs/superpowers/plans/2026-03-31-ledger-verification.md
+++ b/docs/superpowers/plans/2026-03-31-ledger-verification.md
@@ -1,0 +1,1062 @@
+# Ledger Protocol Verification and Testing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add ledger/protocol verification domain to the midnight-verify plugin and ledger-testing skill to the midnight-cq plugin.
+
+**Architecture:** Two new skill files in midnight-verify (domain routing + Rust crate-level source investigation method). Four new files in midnight-cq (one skill + three references). Nine modifications to existing agents and skills for ledger-specific dispatch, source routing, and execution guidance. No new agents.
+
+**Tech Stack:** Markdown skill/agent files following existing midnight-verify and midnight-cq patterns. No runtime code.
+
+**Spec:** `docs/superpowers/specs/2026-03-31-ledger-verification-design.md`
+
+---
+
+## File Map
+
+### midnight-verify plugin (`plugins/midnight-verify/`)
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `skills/verify-ledger/SKILL.md` | Domain skill — claim classification and routing table for ledger/protocol claims |
+| Create | `skills/verify-by-ledger-source/SKILL.md` | Method skill — Rust crate-level source investigation guidance, 24-crate routing table |
+| Modify | `agents/verifier.md` | Add ledger domain, dispatch rules, examples |
+| Modify | `skills/verify-correctness/SKILL.md` | Add Ledger/Protocol to domain classification, verdict qualifiers |
+| Modify | `agents/source-investigator.md` | Add ledger example, verify-by-ledger-source skill reference |
+| Modify | `skills/verify-by-type-check/SKILL.md` | Add Ledger API Execution Mode section |
+| Modify | `skills/verify-by-execution/SKILL.md` | Add Ledger Execution Mode section |
+
+### midnight-cq plugin (`plugins/midnight-cq/`)
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `skills/ledger-testing/SKILL.md` | Testing code that uses ledger-v8 and onchain-runtime |
+| Create | `skills/ledger-testing/references/transaction-construction-patterns.md` | Proof staging, Intent construction, well-formedness |
+| Create | `skills/ledger-testing/references/ledger-state-patterns.md` | ZswapLocalState, DustLocalState, serialization |
+| Create | `skills/ledger-testing/references/crypto-fixture-patterns.md` | Hex fixture generation, crypto function testing |
+| Modify | `.claude-plugin/plugin.json` | Add ledger keywords |
+| Modify | `README.md` | Document ledger-testing skill |
+| Modify | `agents/cq-runner.md` | Detect ledger-v8 in dependencies |
+| Modify | `agents/cq-reviewer.md` | Audit ledger test quality patterns |
+
+---
+
+## Important Context for Implementers
+
+### Plugin paths
+
+All midnight-verify files are relative to `plugins/midnight-verify/`.
+All midnight-cq files are relative to `plugins/midnight-cq/`.
+
+### Existing pattern to follow
+
+**Skill files** use YAML frontmatter (`name`, `description`, `version`) then markdown body. See any existing `SKILL.md` for the pattern.
+
+**Agent files** use YAML frontmatter (`name`, `description`, `skills`, `model`, `color`) then markdown body. See `agents/verifier.md` for the orchestrator pattern.
+
+**Reference files** are plain markdown (no frontmatter) under `skills/<skill-name>/references/`.
+
+### Key repos
+
+- Primary: `midnightntwrk/midnight-ledger` — Rust workspace, 24 crates, produces WASM bindings
+- npm packages: `@midnight-ntwrk/ledger-v8`, `@midnight-ntwrk/zkir-v2`, `@midnight-ntwrk/onchain-runtime`
+
+### Clone protocol
+
+Always use SSH (`git@github.com:`) not HTTPS for cloning repos.
+
+---
+
+## Task 1: Create verify-ledger domain skill
+
+**Files:**
+- Create: `plugins/midnight-verify/skills/verify-ledger/SKILL.md`
+
+- [ ] **Step 1: Create the skill directory**
+
+```bash
+mkdir -p plugins/midnight-verify/skills/verify-ledger
+```
+
+- [ ] **Step 2: Write the domain skill file**
+
+Create `plugins/midnight-verify/skills/verify-ledger/SKILL.md` with this exact content:
+
+```markdown
+---
+name: midnight-verify:verify-ledger
+description: >-
+  Ledger/protocol claim classification and method routing. Determines what kind
+  of ledger claim is being verified and which verification methods apply:
+  source investigation (primary), type-checking (pre-flight for TypeScript API),
+  compilation/execution (secondary for testable claims), or ledger-v8 execution
+  (secondary for API behavioral claims). Handles claims about transaction
+  structure, token mechanics (Night/Zswap/Dust), cost model, on-chain VM,
+  contract execution, cryptographic primitives, well-formedness rules, and the
+  @midnight-ntwrk/ledger-v8 TypeScript API. Loaded by the verifier agent
+  alongside the hub skill.
+version: 0.1.0
+---
+
+# Ledger/Protocol Claim Classification
+
+This skill classifies ledger and protocol claims and determines which verification method to use. The verifier (orchestrator) agent loads this alongside the hub skill (`verify-correctness`).
+
+## Verification Flow
+
+Ledger claims have a richer verification hierarchy than other domains because the ledger crates produce the compiled output that the contract-writer and zkir-checker already work with.
+
+1. **Type-check (pre-flight)** — for TypeScript API claims only. Dispatch type-checker against the existing sdk-workspace (ledger-v8 is already installed). Pre-flight only, never a standalone verdict.
+2. **Source investigation (primary)** — always runs for protocol claims. Dispatch source-investigator, which loads `verify-by-ledger-source` for Rust crate-level routing.
+3. **Compilation/execution (secondary)** — for claims testable via Compact contracts. Dispatch contract-writer (compile + execute, extract ledger-level evidence) or zkir-checker (inspect compiled circuits).
+4. **Ledger-v8 execution (secondary)** — for claims about TypeScript API behavioral output. Write a script that calls ledger-v8 functions and observes output.
+
+## Claim Type → Method Routing
+
+### Claims About Protocol Structure
+
+| Claim Type | Example | Pre-flight | Primary | Secondary |
+|---|---|---|---|---|
+| Transaction format | "Transactions contain intents, offers, and binding randomness" | — | source-investigator | — |
+| Segment ordering | "Segment 0 is guaranteed, executes first" | — | source-investigator | contract-writer (negative test) |
+| Causal precedence | "Contract A calling B means A causally precedes B" | — | source-investigator | — |
+| Replay protection | "Intent hashes stored in TimeFilterMap" | — | source-investigator | — |
+| Well-formedness | "Disjoint check prevents input/output overlap" | — | source-investigator | contract-writer (build invalid tx) |
+| Proof staging | "UnprovenTransaction transitions to Proven via prove()" | — | source-investigator | ledger-v8 execution |
+
+### Claims About Token Mechanics
+
+| Claim Type | Example | Pre-flight | Primary | Secondary |
+|---|---|---|---|---|
+| Night UTXO | "UTXO uniqueness from (intent_hash, output_no)" | — | source-investigator | — |
+| Zswap commitments | "CoinCommitment = Hash<(CoinInfo, CoinPublicKey)>" | — | source-investigator | ledger-v8 execution (call coinCommitment) |
+| Zswap nullifiers | "CoinNullifier = Hash<(CoinInfo, CoinSecretKey)>" | — | source-investigator | ledger-v8 execution (call coinNullifier) |
+| Zswap transients | "Transients use ephemeral single-leaf Merkle tree" | — | source-investigator | — |
+| Dust generation | "Dust generates proportional to backing Night value" | — | source-investigator | — |
+| Dust spending | "Dust spend requires ZK proof of generation chain" | — | source-investigator | — |
+| Token types | "NIGHT is TokenType::Unshielded with raw [0u8; 32]" | — | source-investigator | ledger-v8 execution (call nativeToken) |
+
+### Claims About Cost Model
+
+| Claim Type | Example | Pre-flight | Primary | Secondary |
+|---|---|---|---|---|
+| Cost dimensions | "SyntheticCost has 5 dimensions: read, compute, block, write, churn" | — | source-investigator | — |
+| Fee formula | "Fee = max(read, compute, block) + write + churn" | — | source-investigator | contract-writer (compile, measure cost) |
+| Block limits | "Block usage limit is 200,000 bytes" | — | source-investigator | — |
+| Price adjustment | "Per-dimension price targets 50% block fullness" | — | source-investigator | — |
+| Guaranteed limits | "Guaranteed section has separate cost bounds" | — | source-investigator | — |
+
+### Claims About On-Chain VM
+
+| Claim Type | Example | Pre-flight | Primary | Secondary |
+|---|---|---|---|---|
+| Opcode semantics | "idx loads from Map by key" | — | source-investigator | zkir-checker (inspect compiled) |
+| StateValue types | "5 types: Null, Cell, Map, Array, BoundedMerkleTree" | — | source-investigator | — |
+| Stack machine | "VM is a stack machine, always exactly 1 item initially" | — | source-investigator | — |
+| Cached reads | "idxc requires value to be cached in memory" | — | source-investigator | — |
+
+### Claims About Contract Execution
+
+| Claim Type | Example | Pre-flight | Primary | Secondary |
+|---|---|---|---|---|
+| Contract address | "ContractAddress = Hash<ContractDeploy>" | — | source-investigator | — |
+| Effects system | "Effects declare claimed nullifiers, commitments, calls" | — | source-investigator | contract-writer (compile + execute) |
+| Caller determination | "Caller is calling contract, then single UTXO owner, then None" | — | source-investigator | — |
+| Transcripts | "Guaranteed transcript executes before fees are taken" | — | source-investigator | — |
+
+### Claims About Cryptographic Primitives
+
+| Claim Type | Example | Pre-flight | Primary | Secondary |
+|---|---|---|---|---|
+| Pedersen commitments | "Value commitment = g*r + h*v where h = hash(type, segment)" | — | source-investigator | — |
+| Fiat-Shamir binding | "Binding uses challenge c = hash(ErasedIntent, g*r, g*s)" | — | source-investigator | — |
+| Signatures | "Schnorr over Secp256k1 per BIP 340" | — | source-investigator | — |
+| Hashing | "field::hash uses Poseidon" | — | source-investigator | — |
+| Merkle trees | "Commitment tree uses persistent Merkle tree" | — | source-investigator | — |
+
+### Claims About Ledger TypeScript API
+
+| Claim Type | Example | Pre-flight | Primary | Secondary |
+|---|---|---|---|---|
+| Type/export existence | "ledger-v8 exports Transaction class" | type-checker | source-investigator | — |
+| Function signature | "coinCommitment takes (coin, coinPublicKey)" | type-checker | source-investigator | — |
+| Function behavior | "nativeToken() returns the NIGHT raw token type" | type-checker | source-investigator | ledger-v8 execution |
+| Class API | "ZswapLocalState has spend() method" | type-checker | source-investigator | — |
+| CostModel API | "CostModel.initialCostModel() returns default fee config" | type-checker | source-investigator | ledger-v8 execution |
+
+### Claims About Formal Properties
+
+| Claim Type | Example | Pre-flight | Primary | Secondary |
+|---|---|---|---|---|
+| Balance preservation | "Total funds preserved except mints, dust, and treasury" | — | source-investigator | — |
+| Transaction binding | "Assembled transaction cannot be disassembled" | — | source-investigator | — |
+| Infragility | "Defensively-created tx survives malicious merge" | — | source-investigator | — |
+| Causality | "Contract call A → B implies A success ⟹ B success" | — | source-investigator | — |
+| Self-determination | "User cannot spend another user's funds" | — | source-investigator | — |
+
+### Routing Rules
+
+**When in doubt:**
+- Protocol structure, token mechanics, crypto primitives → source-investigator (Rust source is authoritative)
+- TypeScript API surface → type-checker pre-flight + source-investigator (trace WASM binding to Rust)
+- Testable behavior (cost, well-formedness, token operations) → source-investigator + contract-writer or ledger-v8 execution as secondary
+- Formal properties → source-investigator only (these are about the proof structure in code)
+
+**Source investigation is always primary.** Secondary methods (compilation, execution) provide corroborating evidence but are not required for a verdict.
+
+## Hints from Existing Skills
+
+The verifier or sub-agents may consult these skills for context. They are **hints only** — never cite them as evidence.
+
+- `compact-core:compact-standard-library` — stdlib functions that map to ledger primitives
+- `compact-core:compact-compilation` — how Compact compiles to ZKIR (relevant for VM claims)
+- `midnight-tooling:compact-cli` — compiler behavior and flags
+```
+
+- [ ] **Step 3: Verify the file was created correctly**
+
+```bash
+head -5 plugins/midnight-verify/skills/verify-ledger/SKILL.md
+```
+
+Expected: YAML frontmatter with `name: midnight-verify:verify-ledger`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-ledger/SKILL.md
+git commit -m "feat(midnight-verify): add verify-ledger domain skill
+
+Routing table for ledger/protocol claim classification. Covers
+transaction structure, token mechanics, cost model, VM, contracts,
+crypto primitives, TypeScript API, and formal properties.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Create verify-by-ledger-source method skill
+
+**Files:**
+- Create: `plugins/midnight-verify/skills/verify-by-ledger-source/SKILL.md`
+
+- [ ] **Step 1: Create the skill directory**
+
+```bash
+mkdir -p plugins/midnight-verify/skills/verify-by-ledger-source
+```
+
+- [ ] **Step 2: Write the method skill file**
+
+Create `plugins/midnight-verify/skills/verify-by-ledger-source/SKILL.md` with this exact content:
+
+```markdown
+---
+name: midnight-verify:verify-by-ledger-source
+description: >-
+  Verification by source code inspection of the Midnight ledger Rust codebase.
+  Searches and reads the actual Rust implementation to verify claims about
+  transaction structure, token mechanics, cost model, on-chain VM, contract
+  execution, and cryptographic primitives. Routes claims to specific crates
+  within the 24-crate workspace. Uses octocode-mcp for quick lookups, falls
+  back to local cloning for deep investigation. Loaded by the source-investigator
+  agent when the claim domain is ledger/protocol.
+version: 0.1.0
+---
+
+# Verify by Ledger Source Code Inspection
+
+You are verifying a claim about the Midnight ledger protocol by reading the actual Rust source code. Follow these steps in order.
+
+## Critical Rule
+
+**Source code is evidence. Everything else is a hint.**
+
+| Source | Role | Rule |
+|---|---|---|
+| Rust source code (function definitions, type definitions, implementations) | Primary evidence | Always the target. Verdicts must cite Rust source. |
+| Test files in the repo | Navigation aid | Follow test imports to find the right source code. Can be run as a last resort (clone to /tmp, `cargo test`), but realistically never needed. |
+| `spec/` documents (13 specification files) | Hints only | Useful for orienting where to look. Never evidence on their own. Any claim derived from specs must be corroborated by Rust source inspection. |
+| `docs/api/` generated TypeScript docs | Navigation aid | Useful for finding what's exported via WASM, then trace back to Rust source. |
+
+## Step 1: Determine Where to Look
+
+**Crate routing — match the claim to the right crate and path:**
+
+| Claim About | Crate | Key Paths |
+|---|---|---|
+| Coin types, commitments, nullifiers, token types | `coin-structure` | `src/coin.rs`, `src/contract.rs`, `src/transfer.rs` |
+| NIGHT constant, ShieldedTokenType, UnshieldedTokenType | `coin-structure` | `src/coin.rs` |
+| Hashing (persistent, transient, Poseidon) | `base-crypto` | `src/hash.rs` |
+| Signatures (Schnorr/Secp256k1, BIP340) | `base-crypto` | `src/signatures.rs` |
+| FAB encoding (field-aligned binary) | `base-crypto` | `src/fab/` |
+| Pedersen commitments, value commitments | `transient-crypto` | `src/commitment.rs` |
+| Encryption (Poseidon CTR, ECDH) | `transient-crypto` | `src/encryption.rs` |
+| Merkle trees | `transient-crypto` | `src/merkle_tree.rs` |
+| Curve operations (Fr, embedded curve) | `transient-crypto` | `src/curve.rs` |
+| ZK proof structures, prover traits | `transient-crypto` | `src/proofs.rs` |
+| VM opcodes, instruction execution | `onchain-vm` | `src/ops.rs`, `src/vm.rs` |
+| VM cost model (per-instruction costs) | `onchain-vm` | `src/cost_model.rs` |
+| StateValue types (Null, Cell, Map, Array, BoundedMerkleTree) | `onchain-state` | `src/` |
+| Contract state, runtime context, transcripts | `onchain-runtime` | `src/context.rs`, `src/transcript.rs` |
+| Communication commitment | `onchain-runtime` | `src/` (re-exported) |
+| Transaction structure, assembly, well-formedness | `ledger` | `src/structure.rs`, `src/construct.rs`, `src/semantics.rs` |
+| Transaction proving and verification | `ledger` | `src/prove.rs`, `src/verify.rs` |
+| Dust operations (spend, registration, generation) | `ledger` | `src/dust.rs` |
+| Intent structure, replay protection | `ledger` | `src/structure.rs` |
+| Zswap offers, inputs, outputs, transients | `zswap` | `src/` |
+| Zswap local state, chain state | `zswap` | `src/` |
+| Fee token, cost model at ledger level | `ledger` | `src/structure.rs` (FEE_TOKEN) |
+| Serialization format | `serialize` | `src/` |
+| Storage (MPT, delta tracking) | `storage`, `storage-core` | `src/` |
+| WASM bindings (ledger-v8 JS API) | `ledger-wasm` | `src/lib.rs`, `src/crypto.rs`, `src/tx.rs`, `src/zswap_wasm.rs`, `src/dust.rs` |
+| WASM bindings (onchain-runtime JS API) | `onchain-runtime-wasm` | `src/` |
+| ZKIR v2 checker/prover | `zkir` | `src/ir.rs`, `src/ir_vm.rs` |
+| Precompiled circuits | `zkir-precompiles` | `dust/`, `zswap/`, `token-vault/`, etc. |
+| Proof server HTTP API | `proof-server` | `src/main.rs` |
+
+**Crate dependency graph:**
+
+```
+base-crypto → transient-crypto → coin-structure → onchain-state → onchain-vm → onchain-runtime
+                                                                                      ↓
+                                                              zswap ← ledger ← ledger-wasm (WASM)
+```
+
+Supporting: `serialize`, `storage-core`, `storage`. Proofs: `zkir`, `zkir-v3`.
+
+## Step 2: Search with octocode-mcp
+
+Start with targeted lookups using the `octocode-mcp` tools:
+
+1. **`githubSearchCode`** — search for specific function names, type names, implementations in `midnightntwrk/midnight-ledger`
+2. **`githubGetFileContent`** — read a specific file once you know the path
+3. **`githubViewRepoStructure`** — understand crate layout if unsure
+
+**Search strategy:**
+
+- For crypto primitive claims: start in `base-crypto/src/` or `transient-crypto/src/`
+- For transaction/protocol claims: start in `ledger/src/` then trace to `zswap/`, `coin-structure/`
+- For VM/runtime claims: start in `onchain-vm/src/` then `onchain-runtime/`
+- For TypeScript API claims: start in `ledger-wasm/src/` to find the WASM binding, then trace to the underlying Rust implementation
+- Start narrow (exact function/type name), broaden if no results
+- Verify you're on the default branch
+
+## Step 3: Clone Locally if Needed
+
+If octocode-mcp results are insufficient — tracing cross-crate dependencies, following trait implementations across crates, or understanding the full call chain:
+
+```bash
+CLONE_DIR=$(mktemp -d)
+git clone --depth 1 git@github.com:midnightntwrk/midnight-ledger.git "$CLONE_DIR/midnight-ledger"
+```
+
+Always use SSH protocol (`git@github.com:`), not HTTPS.
+
+After investigation, clean up:
+
+```bash
+rm -rf "$CLONE_DIR"
+```
+
+## Step 4: Read and Interpret Source
+
+**What counts as evidence (ordered by strength):**
+
+1. **Rust function/type/trait definitions** — strong evidence. If the source defines a struct with field X, that's definitive.
+2. **Rust test files** — navigation aid. Follow test imports to pinpoint source. Not evidence themselves.
+3. **`spec/` documents** — hints for where to look. The 13 spec files (preliminaries, intents-transactions, zswap, dust, night, contracts, cost-model, field-aligned-binary, onchain-runtime, properties, storage-io-cost-modeling, cardano-system-transactions) describe intended behavior but must be corroborated by Rust source.
+4. **`docs/api/` TypeScript docs** — navigation aid. Generated from WASM bindings. Trace back to Rust.
+
+**Watch for:**
+
+- The workspace has 24 crates. A type defined in `coin-structure` may be re-exported through `ledger` and appear via WASM in `ledger-wasm`. Trace to the original definition.
+- `#[wasm_bindgen]` functions in `*-wasm` crates are thin wrappers. The real implementation is in the underlying Rust crate.
+- Feature flags control what's compiled: `proof-verifying` (default), `proving`, `test-utilities`, `mock-verify`. Some code only exists behind features.
+- The `static` crate provides version identifiers via proc macro.
+
+## Step 5: Report
+
+**Your report must include:**
+
+1. **The claim as received** — verbatim
+2. **Where you looked** — crate name, file path(s), line numbers
+3. **What the source shows** — quote or summarize the relevant Rust code
+4. **GitHub links** — full URLs to exact files/lines (e.g., `https://github.com/midnightntwrk/midnight-ledger/blob/main/coin-structure/src/coin.rs#L42`)
+5. **Your interpretation** — does the source confirm, refute, or leave the claim inconclusive?
+
+**Report format:**
+
+```
+### Source Investigation Report
+
+**Claim:** [verbatim]
+
+**Searched:** [crate(s) and method — octocode-mcp search / local clone]
+
+**Found:**
+- Crate: [crate-name]
+- File: [path/to/file.rs:line-range]
+- Link: [full GitHub URL]
+- Content: [relevant Rust code snippet or summary]
+
+**Interpretation:** [Confirmed / Refuted / Inconclusive] — [explanation]
+```
+
+If inconclusive, explain:
+- What you searched and why it wasn't definitive
+- Whether compilation/execution might resolve it (the verifier orchestrator decides whether to dispatch contract-writer or zkir-checker)
+```
+
+- [ ] **Step 3: Verify the file was created correctly**
+
+```bash
+head -5 plugins/midnight-verify/skills/verify-by-ledger-source/SKILL.md
+```
+
+Expected: YAML frontmatter with `name: midnight-verify:verify-by-ledger-source`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-by-ledger-source/SKILL.md
+git commit -m "feat(midnight-verify): add verify-by-ledger-source method skill
+
+Rust crate-level source investigation guidance for the source-investigator
+agent. 24-crate routing table, dependency graph, search strategy, and
+strict evidence rules.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Update verifier orchestrator agent
+
+**Files:**
+- Modify: `plugins/midnight-verify/agents/verifier.md`
+
+- [ ] **Step 1: Add ledger examples to the description**
+
+In the YAML frontmatter `description` field, after the existing Example 9 about wallet SDK architecture claims, add:
+
+```yaml
+
+  Example 10: User runs /verify "SyntheticCost has 5 dimensions" — the
+  orchestrator classifies this as a ledger/protocol cost model claim,
+  dispatches the source-investigator (primary) to inspect the Rust source,
+  and optionally the contract-writer (secondary) to compile a contract and
+  measure its cost.
+
+  Example 11: User runs /verify "coinCommitment returns a hex string" — the
+  orchestrator classifies this as a ledger TypeScript API claim, dispatches
+  the type-checker (pre-flight) and source-investigator (primary), and
+  optionally runs ledger-v8 execution to call the function and observe output.
+```
+
+- [ ] **Step 2: Add verify-ledger to the skills list**
+
+In the frontmatter `skills:` field, append `, midnight-verify:verify-ledger` to the end of the comma-separated list.
+
+- [ ] **Step 3: Add ledger to the domain routing in the body**
+
+In the body section listing domain routing (the numbered list under "Based on the claim domain:"), after the bullet for "Wallet SDK claims", add:
+
+```markdown
+   - Ledger/Protocol claims → load `midnight-verify:verify-ledger`
+```
+
+- [ ] **Step 4: Add ledger dispatch rules to the body**
+
+In the body section "## Dispatching Sub-Agents", after the wallet SDK verification subsection and before "**When multiple methods are needed...**", add:
+
+```markdown
+**Ledger/Protocol verification:**
+- Source investigation (primary) → dispatch `midnight-verify:source-investigator` with instruction to load `midnight-verify:verify-by-ledger-source`
+- Type-check (pre-flight, TS API claims only) → dispatch `midnight-verify:type-checker` (uses existing sdk-workspace, ledger-v8 already installed)
+- Compilation/execution (secondary) → dispatch `midnight-verify:contract-writer` with instruction to extract ledger-level evidence (cost data, well-formedness, balance checks)
+- ZKIR inspection (secondary) → dispatch `midnight-verify:zkir-checker` with instruction to inspect compiled circuit structure for VM/opcode claims
+- Ledger-v8 execution (secondary) → dispatch `midnight-verify:type-checker` in ledger execution mode to call ledger-v8 functions and observe output
+
+**For ledger claims, source investigation always runs.** Secondary methods provide corroborating evidence. Dispatch source-investigator first; dispatch secondary agents concurrently if the claim is testable.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/midnight-verify/agents/verifier.md
+git commit -m "feat(midnight-verify): add ledger domain to verifier orchestrator
+
+Add ledger/protocol dispatch rules, examples, and skill reference.
+Ledger claims dispatch source-investigator as primary with contract-writer,
+zkir-checker, and type-checker as secondary methods.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Update verify-correctness hub skill
+
+**Files:**
+- Modify: `plugins/midnight-verify/skills/verify-correctness/SKILL.md`
+
+- [ ] **Step 1: Add Ledger/Protocol to the domain classification table**
+
+In "### 1. Classify the Domain", add a new row to the table after the "Wallet SDK" row:
+
+```markdown
+| **Ledger/Protocol** | Transaction structure (intents, segments, offers, binding), token mechanics (Night UTXO, Zswap commitment/nullifier, Dust generation), cost model (SyntheticCost, fee pricing, block limits), on-chain VM (opcodes, StateValue, stack machine), contract execution (deployment, calls, effects, transcripts), cryptographic primitives (Pedersen, Fiat-Shamir, signatures, Merkle trees), @midnight-ntwrk/ledger-v8 API, well-formedness rules, FAB encoding, formal security properties | Load `midnight-verify:verify-ledger` |
+```
+
+- [ ] **Step 2: Add ledger dispatch rules to section 3**
+
+In "### 3. Dispatch Sub-Agents", after the wallet SDK verification subsection and before "**Multiple methods needed**", add:
+
+```markdown
+**Ledger/Protocol verification:**
+- Source investigation (primary, always runs) → dispatch `midnight-verify:source-investigator` agent with instruction to load `midnight-verify:verify-by-ledger-source`
+- Type-check (pre-flight, TS API claims only) → dispatch `midnight-verify:type-checker` agent (uses existing sdk-workspace)
+- Compilation/execution (secondary) → dispatch `midnight-verify:contract-writer` agent with instruction to extract ledger-level evidence
+- ZKIR inspection (secondary) → dispatch `midnight-verify:zkir-checker` agent for VM/opcode claims
+- Ledger-v8 execution (secondary) → dispatch `midnight-verify:type-checker` agent in ledger execution mode
+
+**For ledger claims, source investigation always runs.** Secondary methods provide corroborating evidence and are dispatched concurrently when the claim is testable.
+```
+
+- [ ] **Step 3: Add ledger verdict qualifiers to section 4**
+
+In "### 4. Synthesize the Verdict", in the verdict options table, after the wallet SDK rows, add:
+
+```markdown
+| **Confirmed** | (source-verified) | Rust source confirms the ledger/protocol claim |
+| **Confirmed** | (source-verified + tested) | Rust source confirmed, compilation/execution also confirms (ledger domain) |
+| **Confirmed** | (tested) | Compilation/execution directly confirms (e.g., cost model output, well-formedness check) (ledger domain) |
+| **Refuted** | (source-verified) | Rust source contradicts the ledger/protocol claim |
+| **Refuted** | (tested) | Compilation/execution contradicts the claim (ledger domain) |
+| **Inconclusive** | — | Source investigation insufficient, no execution path available (ledger domain) |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-correctness/SKILL.md
+git commit -m "feat(midnight-verify): add ledger domain to verify-correctness hub
+
+Add Ledger/Protocol to domain classification table, dispatch rules,
+and verdict qualifiers including Confirmed (tested) for direct
+compilation/execution evidence.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Update source-investigator agent
+
+**Files:**
+- Modify: `plugins/midnight-verify/agents/source-investigator.md`
+
+- [ ] **Step 1: Add ledger example to description**
+
+In the YAML frontmatter `description` field, after the existing Example 4 about wallet SDK, add:
+
+```yaml
+
+  Example 5: Claim "CoinCommitment = Hash<(CoinInfo, CoinPublicKey)>" — searches
+  midnightntwrk/midnight-ledger coin-structure crate for the CoinCommitment
+  type definition. Uses verify-by-ledger-source for Rust crate-level routing.
+```
+
+- [ ] **Step 2: Add verify-by-ledger-source to the skills list**
+
+In the frontmatter, find the `skills:` line and append `, midnight-verify:verify-by-ledger-source`.
+
+The line currently reads:
+```
+skills: midnight-verify:verify-by-source, midnight-verify:verify-by-wallet-source
+```
+
+Change it to:
+```
+skills: midnight-verify:verify-by-source, midnight-verify:verify-by-wallet-source, midnight-verify:verify-by-ledger-source
+```
+
+- [ ] **Step 3: Add ledger routing to the body**
+
+In the body, after the existing paragraph about wallet SDK routing ("**When the claim domain is wallet SDK**..."), add:
+
+```markdown
+**When the claim domain is ledger/protocol**, load `midnight-verify:verify-by-ledger-source` instead of `midnight-verify:verify-by-source`. The ledger source skill provides Rust crate-level routing across the 24-crate workspace, dependency graph context, and guidance on tracing WASM bindings back to Rust implementations. The general verify-by-source skill is for Compact compiler and DApp SDK source — not ledger internals.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/midnight-verify/agents/source-investigator.md
+git commit -m "feat(midnight-verify): add ledger to source-investigator agent
+
+Load verify-by-ledger-source for ledger/protocol claims. Adds example
+and Rust crate-level routing for the 24-crate workspace.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Update verify-by-type-check with Ledger API Execution Mode
+
+**Files:**
+- Modify: `plugins/midnight-verify/skills/verify-by-type-check/SKILL.md`
+
+- [ ] **Step 1: Add Ledger API Execution Mode section**
+
+In `skills/verify-by-type-check/SKILL.md`, after the existing "## Wallet SDK Workspace Mode" section (which ends with the mode selection bullet points) and before "## Step 2: Determine the Mode", add:
+
+```markdown
+## Ledger API Execution Mode
+
+When the verifier passes `domain: 'ledger'` context and the claim is about behavioral output of a `@midnight-ntwrk/ledger-v8` function (not just its type signature), go beyond type-checking — write a script that calls the function and observes the output.
+
+**This uses the existing sdk-workspace** (ledger-v8 is already installed there). No separate workspace needed.
+
+**When to use this mode:**
+- Claim is about what a ledger-v8 function *returns* (not just its signature)
+- Examples: "nativeToken() returns [0,0,...,0]", "coinCommitment produces a 64-char hex string", "CostModel.initialCostModel() has specific default values"
+
+**Script pattern:**
+
+```bash
+cat > .midnight-expert/verify/sdk-workspace/jobs/$JOB_ID/ledger-exec.mjs << 'EXEC_EOF'
+// Import the specific function being tested
+import { nativeToken, coinCommitment, CostModel } from '@midnight-ntwrk/ledger';
+
+// Call the function and capture output
+const result = nativeToken();
+
+// Output structured JSON for interpretation
+console.log(JSON.stringify({
+  result: typeof result === 'bigint' ? result.toString() : result,
+  type: typeof result
+}));
+EXEC_EOF
+```
+
+Run it:
+
+```bash
+cd .midnight-expert/verify/sdk-workspace/jobs/$JOB_ID
+node ledger-exec.mjs
+```
+
+**Report this as "ledger-v8 execution" evidence**, not as type-checking evidence. Include the script source, output, and interpretation in your report.
+
+**Mode selection summary:**
+- `domain: 'wallet-sdk'` → use `.midnight-expert/verify/wallet-sdk-workspace/`
+- `domain: 'ledger'` + behavioral claim → use sdk-workspace + ledger execution script
+- `domain: 'ledger'` + type claim → use sdk-workspace + normal tsc type assertions
+- Otherwise → use `.midnight-expert/verify/sdk-workspace/` (existing behavior)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-by-type-check/SKILL.md
+git commit -m "feat(midnight-verify): add ledger API execution mode to type-checker
+
+Ledger-v8 behavioral claims can be verified by calling exported functions
+and observing output. Uses existing sdk-workspace (ledger-v8 already
+installed).
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Update verify-by-execution with Ledger Execution Mode
+
+**Files:**
+- Modify: `plugins/midnight-verify/skills/verify-by-execution/SKILL.md`
+
+- [ ] **Step 1: Add Ledger Execution Mode section**
+
+In `skills/verify-by-execution/SKILL.md`, after the existing "## Step 7: Clean Up" section (the last section, ending at line 225), append:
+
+```markdown
+## Ledger Execution Mode
+
+When dispatched for a ledger/protocol claim, you compile and execute a Compact contract as usual, but after execution you extract **ledger-level evidence** — cost data, transaction properties, well-formedness results — in addition to the normal runtime output.
+
+**When to use this mode:** The verifier dispatches you with a ledger claim that is testable via compilation. Examples:
+- "Fee calculation uses max(read, compute, block) + write + churn" → compile a contract, compute its cost
+- "Well-formedness rejects overlapping inputs" → build a transaction with overlapping inputs, check wellFormed() rejects
+- "Counter increment costs N bytes of block usage" → compile counter, measure SyntheticCost.block_usage
+
+**What to extract after compilation and execution:**
+
+| Claim type | What to extract | How |
+|---|---|---|
+| Cost model claims | SyntheticCost breakdown | Import CostModel from ledger-v8, call `cost()` on the compiled transaction |
+| Well-formedness claims | Acceptance/rejection | Call `wellFormed()` on the transaction, capture result |
+| Balance claims | Per-segment per-token balance | Inspect transaction structure after construction |
+| Transaction structure | Intent/offer properties | Read compiled transaction fields |
+| Proof staging | Stage transitions | Construct UnprovenTransaction, call `prove()`, observe state change |
+
+**Extended runner script pattern:**
+
+After the normal circuit execution (Step 5), add ledger-level evidence extraction:
+
+```javascript
+import { CostModel, WellFormedStrictness } from '@midnight-ntwrk/ledger';
+
+// ... normal circuit execution from Step 5 ...
+
+// Extract cost data
+const cost = transaction.cost();
+console.log(JSON.stringify({
+  circuitResult: result,
+  cost: {
+    read_time: cost.read_time?.toString(),
+    compute_time: cost.compute_time?.toString(),
+    block_usage: cost.block_usage?.toString(),
+    bytes_written: cost.bytes_written?.toString(),
+    bytes_churned: cost.bytes_churned?.toString(),
+  },
+  wellFormed: transaction.wellFormed(WellFormedStrictness.default()),
+}));
+```
+
+**Include the ledger-level evidence in your report** alongside the normal execution report. The verifier orchestrator uses both to synthesize the verdict.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-by-execution/SKILL.md
+git commit -m "feat(midnight-verify): add ledger execution mode to contract-writer
+
+Ledger claims testable via Compact compilation now extract ledger-level
+evidence: cost data, well-formedness, balance checks, and proof staging.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Create ledger-testing skill and references (midnight-cq)
+
+**Files:**
+- Create: `plugins/midnight-cq/skills/ledger-testing/SKILL.md`
+- Create: `plugins/midnight-cq/skills/ledger-testing/references/transaction-construction-patterns.md`
+- Create: `plugins/midnight-cq/skills/ledger-testing/references/ledger-state-patterns.md`
+- Create: `plugins/midnight-cq/skills/ledger-testing/references/crypto-fixture-patterns.md`
+
+- [ ] **Step 1: Create the directories**
+
+```bash
+mkdir -p plugins/midnight-cq/skills/ledger-testing/references
+```
+
+- [ ] **Step 2: Write the main skill file**
+
+Create `plugins/midnight-cq/skills/ledger-testing/SKILL.md`. The plan file at `docs/superpowers/plans/2026-03-31-ledger-verification.md` is this file — use the spec at `docs/superpowers/specs/2026-03-31-ledger-verification-design.md` section 2.1 for the content outline. The skill file should follow the same pattern as the wallet-testing skill at `plugins/midnight-cq/skills/wallet-testing/SKILL.md`.
+
+The SKILL.md must include:
+- YAML frontmatter with `name: ledger-testing` and description triggering on: write ledger tests, test transaction construction, test proof staging, test ZswapLocalState, test DustLocalState, test cost model, test coinCommitment, test ledger-v8, test onchain-runtime, test well-formedness
+- Decision guide table (when to use this vs compact-testing, wallet-testing, etc.)
+- The 5 core testing challenges from the spec: proof staging type parameters, hex string types, state immutability, time-dependent Dust, cost model assertions
+- Code examples for each challenge showing correct and incorrect patterns
+- Anti-patterns table
+- Reference file index
+
+- [ ] **Step 3: Write transaction-construction-patterns.md reference**
+
+Create `plugins/midnight-cq/skills/ledger-testing/references/transaction-construction-patterns.md` with content covering:
+
+- Proof staging lifecycle with code examples:
+  - Creating UnprovenTransaction (Transaction<SignatureEnabled, PreProof, PreBinding>)
+  - Calling `prove()` to transition to Transaction<SignatureEnabled, Proof, PreBinding>
+  - Calling `bind()` to transition to Transaction<SignatureEnabled, Proof, FiatShamirPedersen>
+  - Erasing proofs/signatures for storage
+- Building Intents with `addCall()`, `addDeploy()`, merging intents
+- Testing well-formedness:
+  ```typescript
+  import { WellFormedStrictness } from '@midnight-ntwrk/ledger';
+  
+  it('should be well-formed', () => {
+    const result = transaction.wellFormed(WellFormedStrictness.default());
+    expect(result).toBe(true);
+  });
+  
+  it('should reject overlapping inputs', () => {
+    const result = invalidTransaction.wellFormed(WellFormedStrictness.default());
+    expect(result).toBe(false);
+  });
+  ```
+- Testing transaction merging
+- Testing fee calculation via CostModel
+
+- [ ] **Step 4: Write ledger-state-patterns.md reference**
+
+Create `plugins/midnight-cq/skills/ledger-testing/references/ledger-state-patterns.md` with content covering:
+
+- ZswapLocalState patterns:
+  ```typescript
+  it('should return new state after spend', () => {
+    const original = zswapState;
+    const updated = original.spend(coinInfo);
+    // Assert on updated, NOT original — state is immutable
+    expect(updated).not.toBe(original);
+    expect(updated.coins.length).toBe(original.coins.length - 1);
+  });
+  ```
+- ZswapLocalState: apply(), applyFailed(), revertTransaction(), replayEvents(), watchFor(), clearPending()
+- DustLocalState with time control:
+  ```typescript
+  it('should calculate time-dependent balance', () => {
+    const fixedTime = new Date('2026-01-01T00:00:00Z');
+    const balance = dustState.walletBalance(fixedTime);
+    expect(balance).toBeDefined();
+  });
+  ```
+- DustLocalState: spend(), replayEvents(), processTtls(), generationInfo()
+- Serialization round-trips:
+  ```typescript
+  it('should survive serialize/deserialize', () => {
+    const serialized = state.serialize();
+    const restored = ZswapLocalState.deserialize(serialized);
+    // Compare relevant properties
+    expect(restored.coins.length).toBe(state.coins.length);
+  });
+  ```
+- LedgerState.apply() for on-chain state testing
+
+- [ ] **Step 5: Write crypto-fixture-patterns.md reference**
+
+Create `plugins/midnight-cq/skills/ledger-testing/references/crypto-fixture-patterns.md` with content covering:
+
+- Using sample functions for test fixtures:
+  ```typescript
+  import {
+    sampleCoinPublicKey,
+    sampleContractAddress,
+    sampleRawTokenType,
+    sampleSigningKey,
+    sampleEncryptionPublicKey,
+    sampleIntentHash,
+    sampleUserAddress,
+    sampleDustSecretKey,
+  } from '@midnight-ntwrk/ledger';
+  
+  // GOOD: Use sample functions for valid test data
+  const pk = sampleCoinPublicKey();
+  const contractAddr = sampleContractAddress();
+  
+  // BAD: Arbitrary strings that may not be valid hex
+  const pk = '0xdeadbeef'; // Wrong length, may fail validation
+  ```
+- Testing coinCommitment and coinNullifier:
+  ```typescript
+  it('should produce deterministic commitment', () => {
+    const coin = createShieldedCoinInfo(tokenType, value);
+    const commitment1 = coinCommitment(coin, pk);
+    const commitment2 = coinCommitment(coin, pk);
+    expect(commitment1).toBe(commitment2); // Deterministic
+    expect(typeof commitment1).toBe('string'); // Hex string
+    expect(commitment1.length).toBe(64); // 32 bytes hex-encoded
+  });
+  ```
+- Testing token type functions:
+  ```typescript
+  it('should distinguish token types', () => {
+    const night = nativeToken();
+    const fee = feeToken();
+    const shielded = shieldedToken(rawType);
+    const unshielded = unshieldedToken(rawType);
+    expect(night).not.toBe(fee);
+  });
+  ```
+- Encode/decode round-trip testing:
+  ```typescript
+  it('should round-trip CoinPublicKey encoding', () => {
+    const pk = sampleCoinPublicKey();
+    const encoded = encodeCoinPublicKey(pk);
+    const decoded = decodeCoinPublicKey(encoded);
+    expect(decoded).toBe(pk);
+  });
+  ```
+- Testing signData and verifySignature
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/midnight-cq/skills/ledger-testing/
+git commit -m "feat(midnight-cq): add ledger-testing skill with references
+
+Testing guide for code using @midnight-ntwrk/ledger-v8 and
+onchain-runtime. Covers proof staging, state management, time-dependent
+Dust, cost model assertions, crypto fixtures, and serialization.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Update midnight-cq plugin metadata and documentation
+
+**Files:**
+- Modify: `plugins/midnight-cq/.claude-plugin/plugin.json`
+- Modify: `plugins/midnight-cq/README.md`
+
+- [ ] **Step 1: Update plugin.json keywords**
+
+In `plugins/midnight-cq/.claude-plugin/plugin.json`, add these keywords to the existing `keywords` array:
+
+```json
+"ledger",
+"ledger-v8",
+"transaction",
+"zswap",
+"onchain-runtime",
+"proof-staging",
+"cost-model"
+```
+
+- [ ] **Step 2: Update README.md**
+
+In `plugins/midnight-cq/README.md`, after the existing `### dapp-connector-testing` section and before `### quality-check`, add:
+
+```markdown
+### ledger-testing
+
+Write tests for code that uses `@midnight-ntwrk/ledger-v8` and `@midnight-ntwrk/onchain-runtime` directly. Covers proof staging lifecycle (UnprovenTransaction → proved → erased), ZswapLocalState and DustLocalState management, time-dependent Dust balance assertions, CostModel fee calculations, cryptographic fixture generation via `sample*` functions, and serialization round-trip testing.
+
+**Triggers on**: write ledger tests, test transaction construction, test proof staging, test ZswapLocalState, test DustLocalState, test cost model, test coinCommitment, test ledger-v8, test onchain-runtime, test well-formedness
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/midnight-cq/.claude-plugin/plugin.json plugins/midnight-cq/README.md
+git commit -m "docs(midnight-cq): add ledger-testing to metadata and README
+
+Update plugin.json keywords and README documentation for the new
+ledger-testing skill.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Update midnight-cq agents to recognize ledger projects
+
+**Files:**
+- Modify: `plugins/midnight-cq/agents/cq-runner.md`
+- Modify: `plugins/midnight-cq/agents/cq-reviewer.md`
+
+- [ ] **Step 1: Update cq-runner agent**
+
+In `plugins/midnight-cq/agents/cq-runner.md`, in the body's "### Step 1: Detect Project Type" section, add this row to the detection table after the existing DApp Connector row:
+
+```markdown
+| `@midnight-ntwrk/ledger-v8` or `@midnight-ntwrk/onchain-runtime` in `package.json` deps | Ledger project — check for proof staging, state management, and crypto fixture patterns |
+```
+
+- [ ] **Step 2: Update cq-reviewer agent**
+
+In `plugins/midnight-cq/agents/cq-reviewer.md`:
+
+**Change 1:** In "### Step 1 — Load Skills", after the dapp-connector-testing bullet, add:
+
+```markdown
+- `midnight-cq:ledger-testing` — defines correct proof staging patterns, state immutability, time-dependent Dust testing, cost model assertions, and crypto fixture generation for ledger projects
+```
+
+**Change 2:** In "### Step 2 — Scan Tooling Presence", add these rows to the tooling inventory checklist after the Effect test patterns row:
+
+```markdown
+| Ledger deps | `Grep @midnight-ntwrk/ledger-v8 in package.json` | Determines if Ledger project |
+| Onchain runtime deps | `Grep @midnight-ntwrk/onchain-runtime in package.json` | Determines if Onchain Runtime project |
+| Ledger sample fixtures | `Grep sampleCoinPublicKey in **/*.test.ts` | If ledger project — using proper fixtures |
+```
+
+**Change 3:** In "### Step 5 — Assess Test Quality", after the DApp Connector test quality checks table, add:
+
+```markdown
+**Ledger test quality checks (if ledger project):**
+
+| Check | Good Pattern | Bad Pattern | Severity |
+|-------|-------------|------------|---------|
+| sample* functions used for fixtures | `sampleCoinPublicKey()`, `sampleContractAddress()` | Arbitrary hex strings like `'0xdeadbeef'` | Warning |
+| Proof staging transitions tested | `prove()` → `bind()` → `eraseProofs()` in sequence | Skipping stages or only testing final state | Warning |
+| State immutability respected | Assertions on returned state, not original | Asserting on original after mutation | Critical |
+| Time controlled in Dust tests | Fixed `Date` passed to `walletBalance()` | `Date.now()` or no time parameter | Critical |
+| Cost model checks specific dimensions | `expect(cost.block_usage).toBe(...)` | `expect(cost).toBeDefined()` | Warning |
+| Well-formedness negative tests | Building invalid tx, asserting rejection | Only testing valid transactions | Suggestion |
+| Serialization round-trips tested | `serialize()` → `deserialize()` → assert equality | No persistence tests | Suggestion |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/midnight-cq/agents/cq-runner.md plugins/midnight-cq/agents/cq-reviewer.md
+git commit -m "feat(midnight-cq): update agents to recognize ledger projects
+
+cq-runner detects ledger-v8 and onchain-runtime dependencies.
+cq-reviewer loads ledger-testing skill and audits proof staging,
+state immutability, time control, cost model, and fixture quality.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Final verification
+
+- [ ] **Step 1: Verify all new files exist**
+
+```bash
+echo "=== midnight-verify new files ==="
+ls -la plugins/midnight-verify/skills/verify-ledger/SKILL.md
+ls -la plugins/midnight-verify/skills/verify-by-ledger-source/SKILL.md
+
+echo "=== midnight-cq ledger-testing ==="
+ls -la plugins/midnight-cq/skills/ledger-testing/SKILL.md
+ls -la plugins/midnight-cq/skills/ledger-testing/references/transaction-construction-patterns.md
+ls -la plugins/midnight-cq/skills/ledger-testing/references/ledger-state-patterns.md
+ls -la plugins/midnight-cq/skills/ledger-testing/references/crypto-fixture-patterns.md
+```
+
+Expected: all 6 files exist.
+
+- [ ] **Step 2: Verify YAML frontmatter is valid**
+
+```bash
+for f in \
+  plugins/midnight-verify/skills/verify-ledger/SKILL.md \
+  plugins/midnight-verify/skills/verify-by-ledger-source/SKILL.md \
+  plugins/midnight-cq/skills/ledger-testing/SKILL.md; do
+  echo "--- $f ---"
+  head -3 "$f"
+  echo ""
+done
+```
+
+Expected: each file starts with `---` and has a `name:` field.
+
+- [ ] **Step 3: Count commits**
+
+```bash
+git log --oneline HEAD~11..HEAD
+```
+
+Expected: 11 commits (1 spec + 10 implementation).
+
+- [ ] **Step 4: Verify git status is clean**
+
+```bash
+git status
+```
+
+Expected: clean working tree.

--- a/docs/superpowers/specs/2026-03-31-ledger-verification-design.md
+++ b/docs/superpowers/specs/2026-03-31-ledger-verification-design.md
@@ -1,0 +1,293 @@
+# Ledger Protocol Verification and Testing — Design Spec
+
+**Date:** 2026-03-31
+**Status:** Approved
+**Scope:** Add ledger/protocol verification domain to midnight-verify plugin; add ledger-testing skill to midnight-cq plugin
+
+## Overview
+
+The Midnight ledger (`midnightntwrk/midnight-ledger`) is a Rust workspace producing WASM bindings that ship as npm packages (`@midnight-ntwrk/ledger-v8`, `@midnight-ntwrk/zkir-v2`, `@midnight-ntwrk/onchain-runtime`). It defines the protocol layer: transaction structure, three token systems (Night/Zswap/Dust), cost model, on-chain VM, contract execution, and cryptographic primitives. Claims about the ledger are foundational — errors here cascade into bad Compact code and bad DApp architecture.
+
+## Design Decisions
+
+- **Separate domain**: verify-ledger is a parallel domain skill (like verify-compact, verify-wallet-sdk). It owns all claims about the ledger — both protocol-level (Rust implementation) and TypeScript API (`ledger-v8`). There is minor overlap with verify-sdk for ledger-v8 type claims, but that's acceptable: verify-sdk covers ledger-v8 when it's part of a broader SDK usage check, verify-ledger covers it when the claim is specifically about the ledger.
+- **Reuse agents**: No new agents. The existing source-investigator, type-checker, contract-writer, and zkir-checker agents are dispatched with ledger-specific context.
+- **Source-first with rich secondary paths**: Source investigation against the Rust codebase is the primary method for all protocol claims. Unlike the wallet SDK (source-only for most claims), ledger claims have rich secondary verification via compilation and execution — because the ledger crates produce the compiled output that contract-writer and zkir-checker already work with.
+- **New method skill for source investigation**: `verify-by-ledger-source` contains the 24-crate routing table and Rust-specific search guidance. Loaded by the source-investigator for ledger claims.
+- **Execution guidance in existing skills**: Rather than new method skills, ledger-specific execution guidance is added to `verify-by-execution` (Ledger Execution Mode) and `verify-by-type-check` (Ledger API Execution Mode). These tell existing agents how to extract ledger-level evidence from their normal workflows.
+- **midnight-cq ledger-testing skill**: Guides developers writing tests for code that uses `ledger-v8` and `onchain-runtime` directly.
+
+## Part 1: midnight-verify — verify-ledger
+
+### 1.1 Domain Skill: verify-ledger
+
+**Purpose:** Classify ledger/protocol claims and route them to the correct verification methods.
+
+**Domain indicators** (how the verifier orchestrator recognizes ledger claims):
+
+- Transaction structure (intents, segments, offers, binding randomness, TTL)
+- Token mechanics (Night UTXO, Zswap commitment/nullifier, Dust generation/spending/registration)
+- Cost model (SyntheticCost dimensions, fee pricing, block limits, normalization, guaranteed segment limits)
+- On-chain VM (opcodes, StateValue types, stack machine, cached/uncached reads, tainted values)
+- Contract execution (ContractState, deployment, calls, transcripts, effects, caller determination)
+- Cryptographic primitives (Pedersen commitments, Fiat-Shamir binding, coin commitments, nullifiers, Merkle trees, Poseidon hash)
+- `@midnight-ntwrk/ledger-v8` API surface (Transaction class, ZswapLocalState, DustLocalState, LedgerState, CostModel, Intent)
+- `@midnight-ntwrk/onchain-runtime` API surface (ContractState, StateValue, VM operations)
+- Well-formedness rules (disjoint check, sequencing/causal precedence, effects check, balancing check, Pedersen check, TTL check)
+- Field-aligned binary encoding (FAB format)
+- Formal security properties (balance preservation, transaction binding, infragility, causality, self-determination)
+- Replay protection (TimeFilterMap, intent hash history)
+- Proof staging (UnprovenTransaction → proved → proof-erased → signature-erased)
+
+**Verification flow:**
+
+| Claim Category | Pre-flight | Primary | Secondary |
+|---|---|---|---|
+| Protocol structure (tx format, segments, offers) | — | source-investigator | contract-writer (build tx, check well-formedness) |
+| Token mechanics (Night UTXO, Zswap, Dust) | — | source-investigator | contract-writer (test token operations) |
+| Cost model (dimensions, formulas, limits) | — | source-investigator | contract-writer (compile, measure cost) |
+| On-chain VM (opcodes, state types) | — | source-investigator | zkir-checker (inspect compiled ZKIR) |
+| Contract execution (effects, caller, transcripts) | — | source-investigator | contract-writer (compile + execute) |
+| Crypto primitives (commitments, nullifiers, hashes) | — | source-investigator | ledger-v8 execution (call functions, observe output) |
+| Ledger TypeScript API (types, signatures, exports) | type-checker | source-investigator | ledger-v8 execution |
+| Well-formedness rules | — | source-investigator | contract-writer (build invalid tx, confirm rejection) |
+| FAB encoding | — | source-investigator | — |
+| Security properties (theorems) | — | source-investigator | — |
+
+**Verdict qualifiers:**
+
+- `Confirmed (source-verified)` — Rust source confirms the claim
+- `Confirmed (source-verified + tested)` — source confirmed, compilation/execution also confirms
+- `Confirmed (tested)` — compilation/execution directly confirms (e.g., cost model output matches claim)
+- `Refuted (source-verified)` — Rust source contradicts the claim
+- `Refuted (tested)` — compilation/execution contradicts the claim
+- `Inconclusive` — source investigation insufficient, no execution path available
+
+### 1.2 Method Skill: verify-by-ledger-source
+
+**Purpose:** Rust crate-level source investigation guidance for the source-investigator agent when handling ledger claims.
+
+**Repository routing table:**
+
+| Claim About | Crate | Key Paths |
+|---|---|---|
+| Coin types, commitments, nullifiers, token types | `coin-structure` | `src/coin.rs`, `src/contract.rs`, `src/transfer.rs` |
+| NIGHT constant, ShieldedTokenType, UnshieldedTokenType | `coin-structure` | `src/coin.rs` |
+| Hashing (persistent, transient, Poseidon) | `base-crypto` | `src/hash.rs` |
+| Signatures (Schnorr/Secp256k1, BIP340) | `base-crypto` | `src/signatures.rs` |
+| FAB encoding (field-aligned binary) | `base-crypto` | `src/fab/` |
+| Pedersen commitments, value commitments | `transient-crypto` | `src/commitment.rs` |
+| Encryption (Poseidon CTR, ECDH) | `transient-crypto` | `src/encryption.rs` |
+| Merkle trees | `transient-crypto` | `src/merkle_tree.rs` |
+| Curve operations (Fr, embedded curve) | `transient-crypto` | `src/curve.rs` |
+| ZK proof structures, prover traits | `transient-crypto` | `src/proofs.rs` |
+| VM opcodes, instruction execution | `onchain-vm` | `src/ops.rs`, `src/vm.rs` |
+| VM cost model (per-instruction costs) | `onchain-vm` | `src/cost_model.rs` |
+| StateValue types (Null, Cell, Map, Array, BoundedMerkleTree) | `onchain-state` | `src/` |
+| Contract state, runtime context, transcripts | `onchain-runtime` | `src/context.rs`, `src/transcript.rs` |
+| Communication commitment | `onchain-runtime` | `src/` (re-exported) |
+| Transaction structure, assembly, well-formedness | `ledger` | `src/structure.rs`, `src/construct.rs`, `src/semantics.rs` |
+| Transaction proving and verification | `ledger` | `src/prove.rs`, `src/verify.rs` |
+| Dust operations (spend, registration, generation) | `ledger` | `src/dust.rs` |
+| Intent structure, replay protection | `ledger` | `src/structure.rs` |
+| Zswap offers, inputs, outputs, transients | `zswap` | `src/` |
+| Zswap local state, chain state | `zswap` | `src/` |
+| Fee token, cost model at ledger level | `ledger` | `src/structure.rs` (FEE_TOKEN) |
+| Serialization format | `serialize` | `src/` |
+| Storage (MPT, delta tracking) | `storage`, `storage-core` | `src/` |
+| WASM bindings (ledger-v8 JS API) | `ledger-wasm` | `src/lib.rs`, `src/crypto.rs`, `src/tx.rs`, `src/zswap_wasm.rs`, `src/dust.rs` |
+| WASM bindings (onchain-runtime JS API) | `onchain-runtime-wasm` | `src/` |
+| ZKIR v2 checker/prover | `zkir` | `src/ir.rs`, `src/ir_vm.rs` |
+| Precompiled circuits | `zkir-precompiles` | `dust/`, `zswap/`, `token-vault/`, etc. |
+| Proof server HTTP API | `proof-server` | `src/main.rs` |
+
+**Crate dependency graph context:**
+
+```
+base-crypto → transient-crypto → coin-structure → onchain-state → onchain-vm → onchain-runtime
+                                                                                      ↓
+                                                              zswap ← ledger ← ledger-wasm (WASM)
+```
+
+Supporting: `serialize`, `storage-core`, `storage`. Proofs: `zkir`, `zkir-v3`.
+
+**Search strategy:**
+
+1. Start with octocode-mcp `githubSearchCode` against `midnightntwrk/midnight-ledger`
+2. For crypto primitive claims — start in `base-crypto` or `transient-crypto`
+3. For transaction/protocol claims — start in `ledger/src/` then trace to `zswap/`, `coin-structure/`
+4. For VM/runtime claims — start in `onchain-vm/src/` then `onchain-runtime/`
+5. For TypeScript API claims — start in `ledger-wasm/src/` to find the WASM binding, then trace to the underlying Rust implementation
+6. Clone locally (to /tmp, SSH, `--depth 1`) for cross-crate dependency tracing
+7. Clean up cloned repos after investigation
+
+**Evidence rules:**
+
+Source code is evidence. Everything else is a hint.
+
+| Source | Role | Rule |
+|---|---|---|
+| Rust source code (function definitions, type definitions, implementations) | Primary evidence | Always the target. Verdicts must cite Rust source. |
+| Test files in the repo | Navigation aid | Follow test imports to find the right source code. Can be run as a last resort (clone to /tmp, `cargo test`), but realistically never needed. |
+| `spec/` documents (13 specification files) | Hints only | Useful for orienting where to look. Never evidence on their own. Any claim derived from specs must be corroborated by Rust source inspection. |
+| `docs/api/` generated TypeScript docs | Navigation aid | Useful for finding what's exported via WASM, then trace back to Rust source. |
+
+### 1.3 Changes to Existing midnight-verify Components
+
+**verifier agent (`agents/verifier.md`):**
+- Add ledger/protocol to domain list in description
+- Add `midnight-verify:verify-ledger` to skills list
+- Add ledger dispatch rules: source-investigator (primary), type-checker (pre-flight for TS API claims), contract-writer (secondary for testable claims), zkir-checker (secondary for VM/circuit claims)
+- Add ledger examples to description
+
+**verify-correctness hub skill (`skills/verify-correctness/SKILL.md`):**
+- Add "Ledger/Protocol" row to domain classification table with indicators
+- Add ledger dispatch rules to section 3
+- Add ledger-specific verdict qualifiers to section 4
+- Note: ledger claims can dispatch contract-writer and zkir-checker as secondary verification
+
+**source-investigator agent (`agents/source-investigator.md`):**
+- Add ledger example to description
+- Add `midnight-verify:verify-by-ledger-source` to skills list
+- Add routing: when claim domain is ledger → load `verify-by-ledger-source`
+
+**verify-by-type-check skill (`skills/verify-by-type-check/SKILL.md`):**
+- Add "Ledger API Execution Mode" section
+- When domain is `ledger` and claim is about behavioral output of a ledger-v8 function: write a `.mjs` script that imports from `@midnight-ntwrk/ledger-v8`, calls the function, and outputs the result as JSON
+- Uses the existing `sdk-workspace` (ledger-v8 is already installed there)
+- This extends beyond type-checking — it calls functions and observes output
+
+**verify-by-execution skill (`skills/verify-by-execution/SKILL.md`):**
+- Add "Ledger Execution Mode" section
+- When dispatched for a ledger claim: compile a Compact contract as usual, but after execution, extract ledger-level evidence
+- Guidance on what evidence to extract:
+  - Cost claims → inspect SyntheticCost via `CostModel`
+  - Structure claims → inspect Transaction properties, well-formedness via `wellFormed()`
+  - Balance claims → check per-segment per-token-type balance
+  - VM claims → inspect compiled ZKIR instructions
+
+## Part 2: midnight-cq — ledger-testing
+
+### 2.1 Skill: ledger-testing
+
+**Purpose:** Guide developers writing tests for code that uses `@midnight-ntwrk/ledger-v8` and `@midnight-ntwrk/onchain-runtime` directly.
+
+**Target audience:** Developers working with transaction construction, proof staging, ZswapLocalState management, cost calculations, and cryptographic operations.
+
+**Scope — what users are doing:**
+- Constructing transactions (building Intents, adding contract calls, signing, proving, binding)
+- Managing proof staging (UnprovenTransaction → proved → proof-erased)
+- Working with ZswapLocalState (spend, apply, revert, replayEvents, watchFor)
+- Working with DustLocalState (time-dependent balances, replayEvents, processTtls)
+- Using CostModel for fee estimation
+- Calling cryptographic functions (coinCommitment, coinNullifier, persistentHash, etc.)
+- Serializing/deserializing ledger types for persistence
+- Building well-formed transactions (balancing, Pedersen checks, TTL)
+
+**What this skill does NOT cover:**
+- Testing Compact contract logic (use `compact-testing`)
+- Testing DApp UI flows (use `dapp-testing`)
+- Testing wallet SDK implementations (use `wallet-testing`)
+- Testing DApp Connector API integration (use `dapp-connector-testing`)
+
+**Core testing challenges:**
+
+1. **Proof staging type parameters** — Transaction<S,P,B> has three type parameters controlling state. Tests need to construct transactions at the right stage and transition them correctly through the pipeline.
+2. **Hex string types** — Many types (CoinPublicKey, ContractAddress, TokenType, Nullifier, etc.) are hex-encoded strings. Tests need valid hex fixtures, not arbitrary strings. The `sample*` functions (sampleCoinPublicKey, sampleContractAddress, etc.) generate valid test data.
+3. **State immutability** — ZswapLocalState and DustLocalState return new instances on mutation. Tests must assert on the returned state, not the original.
+4. **Time-dependent Dust** — DustLocalState.walletBalance() takes a Date parameter. Tests need to control time for deterministic results.
+5. **Cost model assertions** — SyntheticCost has 5 dimensions. Tests should assert on specific dimensions, not just "cost > 0".
+
+**Anti-patterns:**
+- Using arbitrary strings where hex-encoded types are expected (use sample* functions)
+- Asserting on original state after mutation instead of returned state
+- Not controlling time in Dust balance assertions
+- Asserting only that cost is non-zero instead of checking specific dimensions
+- Skipping proof staging transitions (going directly from Unproven to erased)
+- Not testing well-formedness rejection for invalid transactions
+
+### 2.2 Reference: transaction-construction-patterns.md
+
+- Proof staging lifecycle: UnprovenTransaction → prove() → Transaction<S,Proof,B> → bind() → eraseProofs()
+- Building Intents with addCall(), addDeploy()
+- Signing Intents (signatureData(), signature verification)
+- Transaction merging
+- Testing well-formedness: wellFormed() with WellFormedStrictness
+- Testing that invalid transactions are rejected (negative testing)
+
+### 2.3 Reference: ledger-state-patterns.md
+
+- ZswapLocalState: spend(), apply(), applyFailed(), revertTransaction(), replayEvents(), watchFor(), clearPending()
+- DustLocalState: spend(), replayEvents(), processTtls(), walletBalance(time), generationInfo()
+- Time control for Dust assertions
+- Serialization round-trip testing (serialize → deserialize → assert equality)
+- LedgerState.apply() for on-chain state testing
+- Testing coin lifecycle (pending → confirmed → spent via nullifier)
+
+### 2.4 Reference: crypto-fixture-patterns.md
+
+- Using sample functions: sampleCoinPublicKey(), sampleContractAddress(), sampleRawTokenType(), sampleSigningKey(), sampleEncryptionPublicKey(), sampleIntentHash(), sampleUserAddress(), sampleDustSecretKey()
+- Testing coinCommitment() and coinNullifier() with known inputs
+- Testing nativeToken(), feeToken(), shieldedToken(), unshieldedToken()
+- Verifying encode/decode round-trips (encodeCoinPublicKey ↔ decodeCoinPublicKey, etc.)
+- Testing signData() and verifySignature()
+
+### 2.5 Changes to midnight-cq
+
+**`.claude-plugin/plugin.json`:**
+- Add keywords: `"ledger"`, `"ledger-v8"`, `"transaction"`, `"zswap"`, `"onchain-runtime"`, `"proof-staging"`, `"cost-model"`
+
+**`README.md`:**
+- Add ledger-testing skill documentation
+
+**`agents/cq-runner.md`:**
+- Detect `@midnight-ntwrk/ledger-v8` or `@midnight-ntwrk/onchain-runtime` in package.json dependencies
+
+**`agents/cq-reviewer.md`:**
+- Load `midnight-cq:ledger-testing` skill
+- Add ledger test quality checks:
+  - sample* functions used for fixture generation (not arbitrary strings)
+  - Proof staging transitions tested in order
+  - State immutability respected (assert on returned state)
+  - Time controlled in Dust balance tests
+  - Cost model assertions check specific dimensions
+  - Well-formedness rejection tested (negative cases)
+
+## File Inventory
+
+### New files — midnight-verify (2)
+
+| File | Purpose |
+|---|---|
+| `skills/verify-ledger/SKILL.md` | Domain skill — routing table |
+| `skills/verify-by-ledger-source/SKILL.md` | Method skill — Rust crate-level source investigation |
+
+### Modified files — midnight-verify (5)
+
+| File | Change |
+|---|---|
+| `agents/verifier.md` | Add ledger domain, dispatch rules, examples |
+| `skills/verify-correctness/SKILL.md` | Add Ledger/Protocol to domain classification, verdict qualifiers |
+| `agents/source-investigator.md` | Add ledger example, verify-by-ledger-source skill reference |
+| `skills/verify-by-type-check/SKILL.md` | Add Ledger API Execution Mode section |
+| `skills/verify-by-execution/SKILL.md` | Add Ledger Execution Mode section |
+
+### New files — midnight-cq (4)
+
+| File | Purpose |
+|---|---|
+| `skills/ledger-testing/SKILL.md` | Testing code that uses ledger-v8 and onchain-runtime |
+| `skills/ledger-testing/references/transaction-construction-patterns.md` | Proof staging, Intent construction, well-formedness |
+| `skills/ledger-testing/references/ledger-state-patterns.md` | ZswapLocalState, DustLocalState, serialization |
+| `skills/ledger-testing/references/crypto-fixture-patterns.md` | Hex fixture generation, crypto function testing |
+
+### Modified files — midnight-cq (4)
+
+| File | Change |
+|---|---|
+| `.claude-plugin/plugin.json` | Add ledger keywords |
+| `README.md` | Document ledger-testing skill |
+| `agents/cq-runner.md` | Detect ledger-v8 in dependencies |
+| `agents/cq-reviewer.md` | Audit ledger test quality patterns |
+
+### Total: 6 new files, 9 modified files. No new agents.

--- a/plugins/midnight-cq/.claude-plugin/plugin.json
+++ b/plugins/midnight-cq/.claude-plugin/plugin.json
@@ -28,6 +28,13 @@
     "effect",
     "observable",
     "WalletBuilder",
-    "WalletFacade"
+    "WalletFacade",
+    "ledger",
+    "ledger-v8",
+    "transaction",
+    "zswap",
+    "onchain-runtime",
+    "proof-staging",
+    "cost-model"
   ]
 }

--- a/plugins/midnight-cq/.claude-plugin/plugin.json
+++ b/plugins/midnight-cq/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-cq",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Code quality tooling for Midnight Network projects — linting, formatting, type checking, testing, Git hooks, and CI workflows.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-cq/README.md
+++ b/plugins/midnight-cq/README.md
@@ -75,6 +75,12 @@ Write tests for DApp Connector API integration — the `window.midnight` injecti
 
 **Triggers on**: test DApp Connector API, test wallet connection, test makeTransfer, test balanceTransaction, mock ConnectedAPI, stub wallet for tests, test wallet errors, test PermissionRejected, test progressive enhancement
 
+### ledger-testing
+
+Write tests for code that uses `@midnight-ntwrk/ledger-v8` and `@midnight-ntwrk/onchain-runtime` directly. Covers proof staging lifecycle (UnprovenTransaction → proved → erased), ZswapLocalState and DustLocalState management, time-dependent Dust balance assertions, CostModel fee calculations, cryptographic fixture generation via `sample*` functions, and serialization round-trip testing.
+
+**Triggers on**: write ledger tests, test transaction construction, test proof staging, test ZswapLocalState, test DustLocalState, test cost model, test coinCommitment, test ledger-v8, test onchain-runtime, test well-formedness
+
 ### quality-check
 
 Run and interpret all quality checks for a Midnight project. Covers Biome lint and format output, TypeScript `tsc --noEmit` errors (including stale `managed/` artifacts), Compact compiler errors and disclosure violations, Vitest failures with simulator stack trace interpretation, and Playwright timeout and element-not-found failures.

--- a/plugins/midnight-cq/agents/cq-reviewer.md
+++ b/plugins/midnight-cq/agents/cq-reviewer.md
@@ -39,6 +39,7 @@ Before scanning anything, load the three preloaded skills so you have authoritat
 - `midnight-cq:dapp-testing` — defines the correct Playwright config, ContractProvider mocking, and E2E patterns
 - `midnight-cq:wallet-testing` — defines correct Effect boundary patterns, WalletBuilder setup, Observable testing for wallet SDK projects
 - `midnight-cq:dapp-connector-testing` — defines correct ConnectedAPI stub patterns, error handling, progressive enhancement for DApp Connector projects
+- `midnight-cq:ledger-testing` — defines correct proof staging patterns, state immutability, time-dependent Dust testing, cost model assertions, and crypto fixture generation for ledger projects
 
 ### Step 2 — Scan Tooling Presence
 
@@ -65,6 +66,9 @@ Use Glob, Grep, and Bash to detect what CQ tooling is present and what is missin
 | DApp Connector deps | `Grep @midnight-ntwrk/dapp-connector-api in package.json` | Determines if DApp Connector project |
 | Wallet test doubles | `Glob **/test/**/wallet-stub*.ts` | If wallet SDK or connector project |
 | Effect test patterns | `Grep Effect.runPromise in **/*.test.ts` | If wallet SDK project |
+| Ledger deps | `Grep @midnight-ntwrk/ledger-v8 in package.json` | Determines if Ledger project |
+| Onchain runtime deps | `Grep @midnight-ntwrk/onchain-runtime in package.json` | Determines if Onchain Runtime project |
+| Ledger sample fixtures | `Grep sampleCoinPublicKey in **/*.test.ts` | If ledger project — using proper fixtures |
 
 Record all presence/absence findings. Do not stop early — complete the full inventory.
 
@@ -191,6 +195,18 @@ Read the test files and check for these patterns and anti-patterns:
 | Progressive enhancement tested | Tests with PermissionRejected for optional methods | No degradation tests | Suggestion |
 | Wallet name/icon sanitized | XSS prevention tests for name and icon | No sanitization tests | Warning |
 | apiVersion validated | Semver check before connect | No version validation | Warning |
+
+**Ledger test quality checks (if ledger project):**
+
+| Check | Good Pattern | Bad Pattern | Severity |
+|-------|-------------|------------|---------|
+| sample* functions used for fixtures | `sampleCoinPublicKey()`, `sampleContractAddress()` | Arbitrary hex strings like `'0xdeadbeef'` | Warning |
+| Proof staging transitions tested | `prove()` → `bind()` → `eraseProofs()` in sequence | Skipping stages or only testing final state | Warning |
+| State immutability respected | Assertions on returned state, not original | Asserting on original after mutation | Critical |
+| Time controlled in Dust tests | Fixed `Date` passed to `walletBalance()` | `Date.now()` or no time parameter | Critical |
+| Cost model checks specific dimensions | `expect(cost.block_usage).toBe(...)` | `expect(cost).toBeDefined()` | Warning |
+| Well-formedness negative tests | Building invalid tx, asserting rejection | Only testing valid transactions | Suggestion |
+| Serialization round-trips tested | `serialize()` → `deserialize()` → assert equality | No persistence tests | Suggestion |
 
 ### Step 6 — Produce Report
 

--- a/plugins/midnight-cq/agents/cq-runner.md
+++ b/plugins/midnight-cq/agents/cq-runner.md
@@ -45,6 +45,7 @@ Use Glob and Bash to detect:
 | No test runner found | Tests not configured — report as finding |
 | `@midnight-ntwrk/wallet-sdk-*` in `package.json` deps | Wallet SDK project — check for Effect/Either test patterns |
 | `@midnight-ntwrk/dapp-connector-api` in `package.json` deps | DApp Connector integration — check for connector stub tests |
+| `@midnight-ntwrk/ledger-v8` or `@midnight-ntwrk/onchain-runtime` in `package.json` deps | Ledger project — check for proof staging, state management, and crypto fixture patterns |
 
 Record all findings before proceeding to Step 2.
 

--- a/plugins/midnight-cq/skills/ledger-testing/SKILL.md
+++ b/plugins/midnight-cq/skills/ledger-testing/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: ledger-testing
+description: >-
+  This skill should be used when the user asks to write ledger tests, test
+  transaction construction, test proof staging, test ZswapLocalState, test
+  DustLocalState, test cost model, test coinCommitment, test ledger-v8,
+  test onchain-runtime, or test well-formedness. Also triggered by requests
+  to write tests for code that uses @midnight-ntwrk/ledger-v8 or
+  @midnight-ntwrk/onchain-runtime directly, test proof staging lifecycle,
+  test token type functions, test crypto fixtures, or test serialization
+  round-trips for ledger types.
+version: 0.1.0
+---
+
+# Ledger Testing
+
+Write tests for code that uses `@midnight-ntwrk/ledger-v8` and
+`@midnight-ntwrk/onchain-runtime` directly.
+
+## When to Use This Skill
+
+| Question | Skill |
+|----------|-------|
+| Am I testing code that calls ledger-v8 or onchain-runtime APIs? | **ledger-testing** (this skill) |
+| Am I testing Compact contract logic? | `compact-testing` |
+| Am I building a custom wallet variant or capability? | `wallet-testing` |
+| Am I integrating with the wallet via the DApp Connector API? | `dapp-connector-testing` |
+| Am I testing DApp UI flows? | `dapp-testing` |
+
+## What This Skill Covers
+
+You are testing code that uses the ledger packages directly:
+
+- Constructing transactions (building Intents, adding contract calls, signing, proving, binding)
+- Managing proof staging (UnprovenTransaction → proved → proof-erased)
+- Working with ZswapLocalState (spend, apply, revert, replayEvents, watchFor)
+- Working with DustLocalState (time-dependent balances, replayEvents, processTtls)
+- Using CostModel for fee estimation
+- Calling cryptographic functions (coinCommitment, coinNullifier, persistentHash, etc.)
+- Serializing/deserializing ledger types for persistence
+- Building and validating well-formed transactions
+
+## What This Skill Does NOT Cover
+
+- Testing Compact contract logic (use `compact-testing`)
+- Testing DApp UI flows end-to-end (use `dapp-testing`)
+- Testing wallet SDK implementations (use `wallet-testing`)
+- Testing DApp Connector API integration (use `dapp-connector-testing`)
+
+## The Core Testing Challenges
+
+### 1. Proof Staging Type Parameters
+
+`Transaction<S, P, B>` has three type parameters controlling what stage the
+transaction is in. Tests need to construct transactions at the right stage and
+transition them through the pipeline in order.
+
+```typescript
+import {
+  UnprovenTransaction,
+  WellFormedStrictness,
+} from '@midnight-ntwrk/ledger-v8';
+
+// Stage 1 — Unproven: Transaction<SignatureEnabled, PreProof, PreBinding>
+const unproven: UnprovenTransaction = buildUnprovenTransaction();
+
+// Stage 2 — Proved: Transaction<SignatureEnabled, Proof, PreBinding>
+const proved = await unproven.prove(provingParams);
+
+// Stage 3 — Bound: Transaction<SignatureEnabled, Proof, FiatShamirPedersen>
+const bound = proved.bind(bindingParams);
+
+// Stage 4 — Erased proofs (for storage)
+const erased = bound.eraseProofs();
+```
+
+Each stage has different methods available. TypeScript enforces the transitions —
+calling `bind()` on an unproven transaction is a compile error.
+
+See `references/transaction-construction-patterns.md` for complete lifecycle examples.
+
+### 2. Hex String Types
+
+Many types (CoinPublicKey, ContractAddress, TokenType, Nullifier, etc.) are
+hex-encoded strings with specific lengths and encoding rules. Arbitrary strings
+will fail validation at runtime.
+
+```typescript
+import {
+  sampleCoinPublicKey,
+  sampleContractAddress,
+  sampleRawTokenType,
+} from '@midnight-ntwrk/ledger-v8';
+
+// GOOD: Use sample functions for valid test fixtures
+const pk = sampleCoinPublicKey();         // Valid 64-char hex
+const addr = sampleContractAddress();     // Valid contract address hex
+const rawType = sampleRawTokenType();     // Valid raw token type
+
+// BAD: Arbitrary strings will fail validation
+const pk = '0xdeadbeef';          // Wrong length, wrong format
+const addr = 'test-contract';     // Not a valid hex string
+```
+
+See `references/crypto-fixture-patterns.md` for all `sample*` functions and
+encode/decode patterns.
+
+### 3. State Immutability
+
+`ZswapLocalState` and `DustLocalState` return new instances on every mutation.
+The original is unchanged. Tests that assert on the original after calling
+`spend()`, `apply()`, or `revertTransaction()` will always pass — even if the
+operation is broken.
+
+```typescript
+it('should remove coin after spend', () => {
+  const original = zswapState;
+  const updated = original.spend(coinInfo);
+
+  // GOOD: Assert on the returned state
+  expect(updated.coins.length).toBe(original.coins.length - 1);
+
+  // BAD: Asserting on original — this always passes, proves nothing
+  // expect(original.coins.length).toBe(original.coins.length);
+});
+```
+
+See `references/ledger-state-patterns.md` for complete state mutation patterns.
+
+### 4. Time-Dependent Dust
+
+`DustLocalState.walletBalance()` takes a `Date` parameter. Dust balances
+change over time as TTLs expire. Tests that use `new Date()` or `Date.now()`
+are non-deterministic.
+
+```typescript
+it('should calculate balance at fixed time', () => {
+  // GOOD: Fixed time for deterministic results
+  const fixedTime = new Date('2026-01-01T00:00:00Z');
+  const balance = dustState.walletBalance(fixedTime);
+  expect(balance).toBeDefined();
+  expect(balance.available).toBe(expectedAmount);
+});
+
+// BAD: Non-deterministic — result changes as real time passes
+// const balance = dustState.walletBalance(new Date());
+```
+
+See `references/ledger-state-patterns.md` for time control patterns and TTL
+testing.
+
+### 5. Cost Model Assertions
+
+`SyntheticCost` has 5 dimensions: `read_time`, `compute_time`, `block_usage`,
+`bytes_written`, and `bytes_churned`. Asserting only that `cost` is defined
+proves nothing about the fee structure.
+
+```typescript
+import { CostModel } from '@midnight-ntwrk/ledger-v8';
+
+it('should calculate cost with expected dimensions', () => {
+  const cost = CostModel.calculate(transaction);
+
+  // GOOD: Assert specific dimensions
+  expect(cost.block_usage).toBeGreaterThan(0n);
+  expect(cost.bytes_written).toBeGreaterThanOrEqual(0n);
+  expect(cost.compute_time).toBeGreaterThan(0n);
+
+  // BAD: Proves nothing
+  // expect(cost).toBeDefined();
+});
+```
+
+See `references/transaction-construction-patterns.md` for cost model patterns.
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It's Wrong | Fix |
+|---|---|---|
+| Arbitrary strings for hex types | Fails validation at runtime; wrong length or encoding | Use `sample*` functions (sampleCoinPublicKey, sampleContractAddress, etc.) |
+| Asserting on original state after mutation | Returns always pass; the original is immutable and never changes | Assert on the value returned by spend()/apply()/revertTransaction() |
+| Using `new Date()` in Dust balance tests | Non-deterministic; test results change as real time passes | Pass a fixed `new Date('...')` to walletBalance() |
+| Asserting only that cost is non-zero | Proves nothing about SyntheticCost dimensions | Assert specific dimension values (block_usage, bytes_written, etc.) |
+| Skipping proof staging transitions | Tests bypass type safety; miss stage-dependent bugs | Test each transition: Unproven → prove() → bind() → eraseProofs() |
+| Not testing well-formedness rejection | Only happy-path testing; misses constraint violations | Build invalid transactions and assert wellFormed() returns false |
+| Sharing state instances across tests | State bleeds between tests; order-dependent failures | Construct fresh state objects in beforeEach |
+
+## Reference Files
+
+| Topic | Reference |
+|-------|-----------|
+| Proof staging lifecycle, Intent construction, well-formedness, transaction merging, fee calculation | `references/transaction-construction-patterns.md` |
+| ZswapLocalState, DustLocalState, time control, serialization, LedgerState.apply() | `references/ledger-state-patterns.md` |
+| sample* functions, coinCommitment/coinNullifier, token types, encode/decode, signData/verifySignature | `references/crypto-fixture-patterns.md` |

--- a/plugins/midnight-cq/skills/ledger-testing/references/crypto-fixture-patterns.md
+++ b/plugins/midnight-cq/skills/ledger-testing/references/crypto-fixture-patterns.md
@@ -1,0 +1,336 @@
+# Crypto Fixture Patterns
+
+Patterns for generating test fixtures and testing cryptographic functions
+from `@midnight-ntwrk/ledger-v8`.
+
+## Why sample* Functions Exist
+
+Many ledger types are hex-encoded strings with specific lengths and internal
+structure. Arbitrary strings like `'0xdeadbeef'` or `'test-key'` will fail
+validation at runtime — even if TypeScript accepts them as `string`.
+
+The `sample*` functions generate valid, well-formed test data. Use them
+everywhere you need a fixture of a specific type.
+
+---
+
+## Using sample* Functions
+
+```typescript
+import {
+  sampleCoinPublicKey,
+  sampleContractAddress,
+  sampleRawTokenType,
+  sampleSigningKey,
+  sampleEncryptionPublicKey,
+  sampleIntentHash,
+  sampleUserAddress,
+  sampleDustSecretKey,
+} from '@midnight-ntwrk/ledger-v8';
+
+// GOOD: Use sample functions for valid test data
+const pk = sampleCoinPublicKey();
+const contractAddr = sampleContractAddress();
+const rawType = sampleRawTokenType();
+const signingKey = sampleSigningKey();
+const encPk = sampleEncryptionPublicKey();
+const intentHash = sampleIntentHash();
+const userAddr = sampleUserAddress();
+const dustSk = sampleDustSecretKey();
+
+// BAD: Arbitrary strings fail validation at runtime
+// const pk = '0xdeadbeef';           // Wrong length
+// const contractAddr = 'my-contract'; // Not a valid hex string
+// const rawType = '000000';           // Wrong length
+```
+
+### Deterministic Fixtures
+
+`sample*` functions return the same value every time — they are deterministic
+stubs, not random generators. Use them freely in test setup.
+
+```typescript
+beforeEach(() => {
+  pk = sampleCoinPublicKey();
+  sk = sampleCoinSecretKey();
+  contractAddr = sampleContractAddress();
+});
+```
+
+---
+
+## Testing coinCommitment and coinNullifier
+
+### coinCommitment
+
+A coin commitment is a deterministic function of `(CoinInfo, CoinPublicKey)`.
+The same inputs always produce the same output.
+
+```typescript
+import { coinCommitment, sampleCoinPublicKey } from '@midnight-ntwrk/ledger-v8';
+
+it('should produce deterministic commitment', () => {
+  const coin = createShieldedCoinInfo(tokenType, value);
+  const pk = sampleCoinPublicKey();
+
+  const commitment1 = coinCommitment(coin, pk);
+  const commitment2 = coinCommitment(coin, pk);
+
+  expect(commitment1).toBe(commitment2);          // Deterministic
+  expect(typeof commitment1).toBe('string');       // Hex string
+  expect(commitment1.length).toBe(64);             // 32 bytes = 64 hex chars
+});
+
+it('should produce different commitments for different keys', () => {
+  const coin = createShieldedCoinInfo(tokenType, value);
+  const pk1 = sampleCoinPublicKey();
+  const pk2 = sampleCoinPublicKey(); // different sample (incremented)
+
+  const c1 = coinCommitment(coin, pk1);
+  const c2 = coinCommitment(coin, pk2);
+
+  expect(c1).not.toBe(c2);
+});
+```
+
+### coinNullifier
+
+A coin nullifier is a deterministic function of `(CoinInfo, CoinSecretKey)`.
+Once a nullifier appears on-chain, the coin is spent.
+
+```typescript
+import { coinNullifier, sampleCoinSecretKey } from '@midnight-ntwrk/ledger-v8';
+
+it('should produce deterministic nullifier', () => {
+  const coin = createShieldedCoinInfo(tokenType, value);
+  const sk = sampleCoinSecretKey();
+
+  const nullifier1 = coinNullifier(coin, sk);
+  const nullifier2 = coinNullifier(coin, sk);
+
+  expect(nullifier1).toBe(nullifier2);          // Deterministic
+  expect(typeof nullifier1).toBe('string');     // Hex string
+  expect(nullifier1.length).toBe(64);           // 32 bytes = 64 hex chars
+});
+
+it('commitment and nullifier should be different', () => {
+  const coin = createShieldedCoinInfo(tokenType, value);
+  const pk = sampleCoinPublicKey();
+  const sk = sampleCoinSecretKey();
+
+  const commitment = coinCommitment(coin, pk);
+  const nullifier = coinNullifier(coin, sk);
+
+  expect(commitment).not.toBe(nullifier);
+});
+```
+
+---
+
+## Testing Token Type Functions
+
+`@midnight-ntwrk/ledger-v8` exports functions that construct the four token
+types: Night (native), fee, shielded, and unshielded.
+
+```typescript
+import {
+  nativeToken,
+  feeToken,
+  shieldedToken,
+  unshieldedToken,
+  sampleRawTokenType,
+} from '@midnight-ntwrk/ledger-v8';
+
+it('should distinguish token types', () => {
+  const rawType = sampleRawTokenType();
+
+  const night = nativeToken();
+  const fee = feeToken();
+  const shielded = shieldedToken(rawType);
+  const unshielded = unshieldedToken(rawType);
+
+  expect(night).not.toBe(fee);
+  expect(shielded).not.toBe(unshielded);
+  expect(night).not.toBe(shielded);
+});
+
+it('nativeToken should always return the same value', () => {
+  const night1 = nativeToken();
+  const night2 = nativeToken();
+  expect(night1).toBe(night2);
+});
+
+it('shieldedToken and unshieldedToken should differ for same raw type', () => {
+  const rawType = sampleRawTokenType();
+  const shielded = shieldedToken(rawType);
+  const unshielded = unshieldedToken(rawType);
+  expect(shielded).not.toBe(unshielded);
+});
+```
+
+---
+
+## Encode/Decode Round-Trip Testing
+
+Many ledger types have `encode*` / `decode*` function pairs. Round-trip tests
+verify that encoding and decoding are inverse operations.
+
+### CoinPublicKey
+
+```typescript
+import {
+  encodeCoinPublicKey,
+  decodeCoinPublicKey,
+  sampleCoinPublicKey,
+} from '@midnight-ntwrk/ledger-v8';
+
+it('should round-trip CoinPublicKey encoding', () => {
+  const pk = sampleCoinPublicKey();
+  const encoded = encodeCoinPublicKey(pk);
+  const decoded = decodeCoinPublicKey(encoded);
+
+  expect(decoded).toBe(pk);
+});
+```
+
+### ContractAddress
+
+```typescript
+import {
+  encodeContractAddress,
+  decodeContractAddress,
+  sampleContractAddress,
+} from '@midnight-ntwrk/ledger-v8';
+
+it('should round-trip ContractAddress encoding', () => {
+  const addr = sampleContractAddress();
+  const encoded = encodeContractAddress(addr);
+  const decoded = decodeContractAddress(encoded);
+
+  expect(decoded).toBe(addr);
+});
+```
+
+### Pattern: Generic Round-Trip Helper
+
+For multiple types, extract a helper to avoid duplication:
+
+```typescript
+function roundTripTest<T>(
+  label: string,
+  sample: () => T,
+  encode: (v: T) => Uint8Array,
+  decode: (b: Uint8Array) => T,
+) {
+  it(`should round-trip ${label}`, () => {
+    const original = sample();
+    const encoded = encode(original);
+    const decoded = decode(encoded);
+    expect(decoded).toBe(original);
+  });
+}
+
+roundTripTest(
+  'CoinPublicKey',
+  sampleCoinPublicKey,
+  encodeCoinPublicKey,
+  decodeCoinPublicKey,
+);
+
+roundTripTest(
+  'ContractAddress',
+  sampleContractAddress,
+  encodeContractAddress,
+  decodeContractAddress,
+);
+```
+
+---
+
+## Testing signData and verifySignature
+
+```typescript
+import {
+  signData,
+  verifySignature,
+  sampleSigningKey,
+} from '@midnight-ntwrk/ledger-v8';
+
+it('should produce a verifiable signature', () => {
+  const signingKey = sampleSigningKey();
+  const data = new Uint8Array([1, 2, 3, 4]);
+
+  const signature = signData(signingKey, data);
+  const publicKey = signingKey.publicKey();
+
+  const valid = verifySignature(publicKey, data, signature);
+  expect(valid).toBe(true);
+});
+
+it('should reject signature for different data', () => {
+  const signingKey = sampleSigningKey();
+  const data = new Uint8Array([1, 2, 3, 4]);
+  const otherData = new Uint8Array([5, 6, 7, 8]);
+
+  const signature = signData(signingKey, data);
+  const publicKey = signingKey.publicKey();
+
+  const valid = verifySignature(publicKey, otherData, signature);
+  expect(valid).toBe(false);
+});
+
+it('should reject signature from different key', () => {
+  const signingKey1 = sampleSigningKey();
+  const signingKey2 = sampleSigningKey(); // different key
+  const data = new Uint8Array([1, 2, 3, 4]);
+
+  const signature = signData(signingKey1, data);
+  const wrongPublicKey = signingKey2.publicKey();
+
+  const valid = verifySignature(wrongPublicKey, data, signature);
+  expect(valid).toBe(false);
+});
+```
+
+---
+
+## Fixture Organisation
+
+For tests that use many crypto types, organise fixtures in a shared setup file:
+
+```typescript
+// test/fixtures/ledger-fixtures.ts
+import {
+  sampleCoinPublicKey,
+  sampleCoinSecretKey,
+  sampleContractAddress,
+  sampleRawTokenType,
+  sampleSigningKey,
+  sampleEncryptionPublicKey,
+  nativeToken,
+  feeToken,
+} from '@midnight-ntwrk/ledger-v8';
+
+export function createLedgerFixtures() {
+  return {
+    coinPk: sampleCoinPublicKey(),
+    coinSk: sampleCoinSecretKey(),
+    contractAddr: sampleContractAddress(),
+    rawTokenType: sampleRawTokenType(),
+    signingKey: sampleSigningKey(),
+    encPk: sampleEncryptionPublicKey(),
+    nightToken: nativeToken(),
+    feeToken: feeToken(),
+  };
+}
+```
+
+Then in tests:
+
+```typescript
+let fixtures: ReturnType<typeof createLedgerFixtures>;
+
+beforeEach(() => {
+  fixtures = createLedgerFixtures();
+});
+```

--- a/plugins/midnight-cq/skills/ledger-testing/references/ledger-state-patterns.md
+++ b/plugins/midnight-cq/skills/ledger-testing/references/ledger-state-patterns.md
@@ -1,0 +1,310 @@
+# Ledger State Patterns
+
+Patterns for testing `ZswapLocalState`, `DustLocalState`, and `LedgerState`
+from `@midnight-ntwrk/ledger-v8`.
+
+## Key Principle: State Is Immutable
+
+Both `ZswapLocalState` and `DustLocalState` return new instances on every
+mutation. The original object is never modified. Tests that assert on the
+original after calling a mutation method will always pass — even if the method
+is broken.
+
+```typescript
+// GOOD: Assert on the returned value
+const updated = original.spend(coinInfo);
+expect(updated.coins.length).toBe(original.coins.length - 1);
+
+// BAD: Original is unchanged — this assertion proves nothing
+// const updated = original.spend(coinInfo);
+// expect(original.coins.length).toBe(original.coins.length - 1);
+```
+
+---
+
+## ZswapLocalState Patterns
+
+### Testing spend()
+
+```typescript
+import { ZswapLocalState } from '@midnight-ntwrk/ledger-v8';
+
+it('should return new state after spend', () => {
+  const original = zswapState;
+  const updated = original.spend(coinInfo);
+
+  // New instance
+  expect(updated).not.toBe(original);
+  // Coin removed
+  expect(updated.coins.length).toBe(original.coins.length - 1);
+  // Original unchanged
+  expect(original.coins.length).toBe(initialCoinCount);
+});
+```
+
+### Testing apply()
+
+`apply()` transitions pending coins (from a submitted transaction) to confirmed.
+
+```typescript
+it('should confirm pending coins after apply', () => {
+  const withPending = zswapState.addPending(transaction);
+  const applied = withPending.apply(transaction);
+
+  expect(applied.pendingCoins.length).toBe(0);
+  expect(applied.coins.length).toBeGreaterThan(withPending.coins.length);
+});
+```
+
+### Testing applyFailed()
+
+`applyFailed()` removes pending coins for a failed transaction.
+
+```typescript
+it('should remove pending coins after failure', () => {
+  const withPending = zswapState.addPending(transaction);
+  const failed = withPending.applyFailed(transaction);
+
+  expect(failed.pendingCoins.length).toBe(0);
+  expect(failed.coins.length).toBe(zswapState.coins.length);
+});
+```
+
+### Testing revertTransaction()
+
+```typescript
+it('should revert applied transaction', () => {
+  const applied = zswapState.apply(transaction);
+  const reverted = applied.revertTransaction(transaction);
+
+  expect(reverted.coins.length).toBe(zswapState.coins.length);
+});
+```
+
+### Testing replayEvents()
+
+`replayEvents()` rebuilds state from a sequence of events. Use it to verify
+that a reconstructed state matches a state built incrementally.
+
+```typescript
+it('should rebuild state from events', () => {
+  const events = collectEvents(transactions);
+  const replayed = ZswapLocalState.empty().replayEvents(events);
+
+  expect(replayed.coins.length).toBe(expectedState.coins.length);
+});
+```
+
+### Testing watchFor()
+
+`watchFor()` registers a coin for monitoring before it is confirmed on-chain.
+
+```typescript
+it('should track watched coin after apply', () => {
+  const watching = zswapState.watchFor(coinToWatch);
+  const applied = watching.apply(transactionContainingCoin);
+
+  expect(applied.coins).toContainEqual(
+    expect.objectContaining({ commitment: coinToWatch.commitment })
+  );
+});
+```
+
+### Testing clearPending()
+
+```typescript
+it('should clear all pending coins', () => {
+  const withPending = zswapState.addPending(transaction);
+  const cleared = withPending.clearPending();
+
+  expect(cleared.pendingCoins.length).toBe(0);
+});
+```
+
+---
+
+## DustLocalState Patterns
+
+### Time Control
+
+`walletBalance()` takes a `Date` parameter. Dust balances change as TTLs
+expire. Always use a fixed date in tests.
+
+```typescript
+it('should calculate time-dependent balance', () => {
+  // GOOD: Fixed time for deterministic results
+  const fixedTime = new Date('2026-01-01T00:00:00Z');
+  const balance = dustState.walletBalance(fixedTime);
+
+  expect(balance.available).toBe(expectedAvailable);
+  expect(balance.locked).toBe(expectedLocked);
+});
+
+// BAD: Non-deterministic — result changes as real time passes
+// const balance = dustState.walletBalance(new Date());
+```
+
+### Testing Different Times
+
+```typescript
+it('should expire TTL-locked Dust after deadline', () => {
+  const beforeExpiry = new Date('2026-01-01T00:00:00Z');
+  const afterExpiry = new Date('2026-12-31T23:59:59Z');
+
+  const balanceBefore = dustState.walletBalance(beforeExpiry);
+  const balanceAfter = dustState.walletBalance(afterExpiry);
+
+  // After TTL, locked becomes available
+  expect(balanceAfter.available).toBeGreaterThan(balanceBefore.available);
+});
+```
+
+### Testing spend()
+
+```typescript
+it('should return new state after Dust spend', () => {
+  const original = dustState;
+  const updated = original.spend(dustCoin);
+
+  expect(updated).not.toBe(original);
+  // Spent Dust should no longer appear in available balance
+  const balance = updated.walletBalance(new Date('2026-01-01T00:00:00Z'));
+  expect(balance.available).toBeLessThan(
+    original.walletBalance(new Date('2026-01-01T00:00:00Z')).available
+  );
+});
+```
+
+### Testing processTtls()
+
+`processTtls()` removes Dust entries whose TTL has passed at the given time.
+
+```typescript
+it('should remove expired Dust after processTtls', () => {
+  const expiredTime = new Date('2026-12-31T23:59:59Z');
+  const processed = dustState.processTtls(expiredTime);
+
+  // Expired entries removed
+  expect(processed.entries.length).toBeLessThanOrEqual(dustState.entries.length);
+});
+```
+
+### Testing replayEvents()
+
+```typescript
+it('should rebuild Dust state from events', () => {
+  const events = collectDustEvents(dustTransactions);
+  const replayed = DustLocalState.empty().replayEvents(events);
+  const fixedTime = new Date('2026-01-01T00:00:00Z');
+
+  expect(replayed.walletBalance(fixedTime).available)
+    .toBe(expectedState.walletBalance(fixedTime).available);
+});
+```
+
+### Testing generationInfo()
+
+```typescript
+it('should return generation info for Dust', () => {
+  const info = dustState.generationInfo(dustCoin);
+
+  expect(info).toBeDefined();
+  expect(info.ttl).toBeGreaterThan(0n);
+});
+```
+
+---
+
+## Serialization Round-Trips
+
+Serialization tests verify that ledger state can be persisted and restored
+without loss. Test all state types your code persists.
+
+### ZswapLocalState Round-Trip
+
+```typescript
+it('should survive serialize/deserialize', () => {
+  const serialized = zswapState.serialize();
+  const restored = ZswapLocalState.deserialize(serialized);
+
+  expect(restored.coins.length).toBe(zswapState.coins.length);
+  expect(restored.pendingCoins.length).toBe(zswapState.pendingCoins.length);
+});
+```
+
+### DustLocalState Round-Trip
+
+```typescript
+it('should survive serialize/deserialize', () => {
+  const serialized = dustState.serialize();
+  const restored = DustLocalState.deserialize(serialized);
+  const fixedTime = new Date('2026-01-01T00:00:00Z');
+
+  expect(restored.walletBalance(fixedTime).available)
+    .toBe(dustState.walletBalance(fixedTime).available);
+});
+```
+
+### Round-Trip After Mutations
+
+Test that serialization works correctly after mutations, not just on the
+initial state.
+
+```typescript
+it('should round-trip state after mutations', () => {
+  const mutated = zswapState
+    .watchFor(newCoin)
+    .apply(transaction);
+
+  const serialized = mutated.serialize();
+  const restored = ZswapLocalState.deserialize(serialized);
+
+  expect(restored.coins.length).toBe(mutated.coins.length);
+});
+```
+
+---
+
+## LedgerState.apply() — On-Chain State Testing
+
+`LedgerState.apply()` applies a transaction to the on-chain ledger state.
+Use it to test that your transactions produce the expected on-chain effects.
+
+```typescript
+import { LedgerState } from '@midnight-ntwrk/ledger-v8';
+
+it('should update on-chain state after applying transaction', () => {
+  const initialState = LedgerState.genesis();
+  const nextState = initialState.apply(transaction);
+
+  expect(nextState).not.toBe(initialState);
+  // Check that the contract state was updated
+  expect(nextState.contractState(contractAddress)).toBeDefined();
+});
+
+it('should reject invalid transaction', () => {
+  const initialState = LedgerState.genesis();
+
+  // apply() throws or returns null for invalid transactions
+  expect(() => {
+    initialState.apply(invalidTransaction);
+  }).toThrow();
+});
+```
+
+### Testing Coin Lifecycle via LedgerState
+
+```typescript
+it('should track coin from pending to confirmed to spent', () => {
+  const withDeposit = ledgerState.apply(depositTransaction);
+
+  // Coin is now confirmed on-chain
+  const commitment = coinCommitment(coin, pk);
+  expect(withDeposit.hasCommitment(commitment)).toBe(true);
+
+  // After spend, nullifier is recorded
+  const withSpend = withDeposit.apply(spendTransaction);
+  const nullifier = coinNullifier(coin, sk);
+  expect(withSpend.hasNullifier(nullifier)).toBe(true);
+});
+```

--- a/plugins/midnight-cq/skills/ledger-testing/references/transaction-construction-patterns.md
+++ b/plugins/midnight-cq/skills/ledger-testing/references/transaction-construction-patterns.md
@@ -1,0 +1,242 @@
+# Transaction Construction Patterns
+
+Patterns for constructing and testing transactions using
+`@midnight-ntwrk/ledger-v8`.
+
+## Proof Staging Lifecycle
+
+A transaction moves through four stages, each enforced by TypeScript type
+parameters `Transaction<S, P, B>`:
+
+| Stage | Type | How to reach it |
+|-------|------|-----------------|
+| Unproven | `Transaction<SignatureEnabled, PreProof, PreBinding>` | Build via Intent |
+| Proved | `Transaction<SignatureEnabled, Proof, PreBinding>` | Call `unproven.prove(params)` |
+| Bound | `Transaction<SignatureEnabled, Proof, FiatShamirPedersen>` | Call `proved.bind(params)` |
+| Proof-erased | `Transaction<SignatureEnabled, NoProof, FiatShamirPedersen>` | Call `bound.eraseProofs()` |
+
+TypeScript enforces valid transitions — calling methods from the wrong stage
+produces a compile error.
+
+### Creating an UnprovenTransaction
+
+```typescript
+import {
+  Intent,
+  UnprovenTransaction,
+  sampleContractAddress,
+} from '@midnight-ntwrk/ledger-v8';
+
+const contractAddress = sampleContractAddress();
+const intent = Intent.empty()
+  .addCall(contractAddress, entrypoint, circuitOutput);
+
+const unproven: UnprovenTransaction = intent.toUnprovenTransaction(
+  signingKey,
+  networkId,
+  ttl,
+);
+```
+
+### Transitioning to Proved
+
+```typescript
+it('should transition from unproven to proved', async () => {
+  const proved = await unproven.prove(provingParams);
+
+  // proved has type Transaction<SignatureEnabled, Proof, PreBinding>
+  expect(proved).toBeDefined();
+
+  // Type safety — these would be compile errors:
+  // unproven.bind(params);    // Error: unproven can't be bound
+  // proved.prove(params);     // Error: already proved
+});
+```
+
+### Transitioning to Bound
+
+```typescript
+it('should bind the proved transaction', () => {
+  const bound = proved.bind(bindingParams);
+
+  // bound has type Transaction<SignatureEnabled, Proof, FiatShamirPedersen>
+  expect(bound).toBeDefined();
+});
+```
+
+### Erasing Proofs for Storage
+
+```typescript
+it('should erase proofs for storage', () => {
+  const erased = bound.eraseProofs();
+
+  // erased has type Transaction<SignatureEnabled, NoProof, FiatShamirPedersen>
+  // Proof data is removed — suitable for persisting without ZK proof bytes
+  expect(erased).toBeDefined();
+});
+```
+
+### Testing the Full Pipeline
+
+```typescript
+it('should complete full proof staging pipeline', async () => {
+  const intent = Intent.empty().addCall(addr, entrypoint, output);
+  const unproven = intent.toUnprovenTransaction(signingKey, networkId, ttl);
+  const proved = await unproven.prove(provingParams);
+  const bound = proved.bind(bindingParams);
+  const erased = bound.eraseProofs();
+
+  // Each stage should be non-null
+  expect(unproven).toBeDefined();
+  expect(proved).toBeDefined();
+  expect(bound).toBeDefined();
+  expect(erased).toBeDefined();
+});
+```
+
+---
+
+## Building Intents
+
+An Intent collects contract calls and deployments before building a transaction.
+
+### Adding a Contract Call
+
+```typescript
+import { Intent, sampleContractAddress } from '@midnight-ntwrk/ledger-v8';
+
+const addr = sampleContractAddress();
+const intent = Intent.empty().addCall(
+  addr,        // ContractAddress
+  entrypoint,  // string — the contract entrypoint name
+  output,      // CircuitOutput — the compiled circuit output
+);
+```
+
+### Adding a Contract Deployment
+
+```typescript
+const deployIntent = Intent.empty().addDeploy(
+  contractDefinition,  // ContractDefinition
+  initialState,        // InitialContractState
+);
+```
+
+### Merging Intents
+
+Multiple intents can be merged into a single transaction. The result contains
+all calls and deployments from both intents.
+
+```typescript
+it('should merge two intents', () => {
+  const intentA = Intent.empty().addCall(addrA, entrypointA, outputA);
+  const intentB = Intent.empty().addCall(addrB, entrypointB, outputB);
+  const merged = intentA.merge(intentB);
+
+  expect(merged.calls.length).toBe(2);
+});
+```
+
+---
+
+## Testing Well-Formedness
+
+`wellFormed()` checks that a transaction satisfies all ledger constraints
+(disjoint inputs/outputs, balanced token flows, valid TTL, etc.).
+
+```typescript
+import { WellFormedStrictness } from '@midnight-ntwrk/ledger-v8';
+
+it('should be well-formed', () => {
+  const result = transaction.wellFormed(WellFormedStrictness.default());
+  expect(result).toBe(true);
+});
+```
+
+### Negative Well-Formedness Testing
+
+Testing that invalid transactions are rejected is as important as testing
+valid ones. Build transactions that violate constraints deliberately.
+
+```typescript
+it('should reject transaction with overlapping inputs', () => {
+  // Build a transaction that uses the same coin as both input and output
+  const invalidTransaction = buildTransactionWithOverlappingInputs();
+  const result = invalidTransaction.wellFormed(WellFormedStrictness.default());
+  expect(result).toBe(false);
+});
+
+it('should reject transaction with imbalanced tokens', () => {
+  // Build a transaction where token inputs do not equal outputs
+  const unbalanced = buildUnbalancedTransaction();
+  const result = unbalanced.wellFormed(WellFormedStrictness.default());
+  expect(result).toBe(false);
+});
+```
+
+---
+
+## Transaction Merging
+
+Transactions (not just intents) can be merged into a single transaction that
+contains all segments from both.
+
+```typescript
+it('should merge two transactions', () => {
+  const txA = buildUnprovenTransaction(intentA);
+  const txB = buildUnprovenTransaction(intentB);
+  const merged = txA.merge(txB);
+
+  expect(merged.wellFormed(WellFormedStrictness.default())).toBe(true);
+});
+```
+
+---
+
+## Fee Calculation via CostModel
+
+`SyntheticCost` has 5 dimensions. Test each dimension that your code is
+expected to control — not just that cost is non-zero.
+
+```typescript
+import { CostModel } from '@midnight-ntwrk/ledger-v8';
+
+it('should have expected cost dimensions', () => {
+  const cost = CostModel.calculate(transaction);
+
+  // Assert specific dimensions
+  expect(cost.block_usage).toBeGreaterThan(0n);
+  expect(cost.compute_time).toBeGreaterThan(0n);
+  expect(cost.bytes_written).toBeGreaterThanOrEqual(0n);
+  expect(cost.bytes_churned).toBeGreaterThanOrEqual(0n);
+  expect(cost.read_time).toBeGreaterThanOrEqual(0n);
+});
+
+it('should stay within block usage limit', () => {
+  const cost = CostModel.calculate(transaction);
+  const BLOCK_LIMIT = 200_000n;
+  expect(cost.block_usage).toBeLessThanOrEqual(BLOCK_LIMIT);
+});
+```
+
+### Fee Formula
+
+The total fee is calculated as:
+
+```
+fee = max(read_time, compute_time, block_usage) + bytes_written + bytes_churned
+```
+
+```typescript
+it('should calculate fee correctly', () => {
+  const cost = CostModel.calculate(transaction);
+  const expectedFee =
+    BigInt(Math.max(
+      Number(cost.read_time),
+      Number(cost.compute_time),
+      Number(cost.block_usage),
+    )) + cost.bytes_written + cost.bytes_churned;
+
+  expect(CostModel.fee(cost)).toBe(expectedFee);
+});
+```

--- a/plugins/midnight-verify/.claude-plugin/plugin.json
+++ b/plugins/midnight-verify/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-verify",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Verification framework for Midnight claims — verifies Compact code by compiling and executing test contracts, SDK/TypeScript claims by type-checking and devnet E2E testing, ZKIR circuits by running through the WASM checker and inspecting compiled structure, witness implementations by cross-domain type-checking and execution against compiled contracts, or by inspecting source code. Multi-agent pipeline with explicit /verify command.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-verify/agents/source-investigator.md
+++ b/plugins/midnight-verify/agents/source-investigator.md
@@ -19,7 +19,11 @@ description: >-
   midnightntwrk/midnight-wallet for the ProtocolVersion type definition
   in packages/abstractions/src/. Uses verify-by-wallet-source for
   wallet-specific repo routing and evidence rules.
-skills: midnight-verify:verify-by-source, midnight-verify:verify-by-wallet-source
+
+  Example 5: Claim "CoinCommitment = Hash<(CoinInfo, CoinPublicKey)>" — searches
+  midnightntwrk/midnight-ledger coin-structure crate for the CoinCommitment
+  type definition. Uses verify-by-ledger-source for Rust crate-level routing.
+skills: midnight-verify:verify-by-source, midnight-verify:verify-by-wallet-source, midnight-verify:verify-by-ledger-source
 model: sonnet
 color: blue
 ---
@@ -35,5 +39,7 @@ Load the `midnight-verify:verify-by-source` skill and follow it step by step. It
 5. Report your findings with file paths, line numbers, and GitHub links
 
 **When the claim domain is wallet SDK**, load `midnight-verify:verify-by-wallet-source` instead of `midnight-verify:verify-by-source`. The wallet source skill provides wallet-specific repo routing, package hierarchy context, and strict evidence rules. The general verify-by-source skill is for Compact compiler, ledger, and DApp SDK source — not wallet SDK.
+
+**When the claim domain is ledger/protocol**, load `midnight-verify:verify-by-ledger-source` instead of `midnight-verify:verify-by-source`. The ledger source skill provides Rust crate-level routing across the 24-crate workspace, dependency graph context, and guidance on tracing WASM bindings back to Rust implementations. The general verify-by-source skill is for Compact compiler and DApp SDK source — not ledger internals.
 
 Follow the skill precisely. The source code is your evidence. Comments are supporting context, not primary evidence. Generated docs in `LFDT-Minokawa/compact/docs/` are good but not as authoritative as the code itself — note the distinction in your report.

--- a/plugins/midnight-verify/agents/verifier.md
+++ b/plugins/midnight-verify/agents/verifier.md
@@ -45,7 +45,18 @@ description: >-
   Example 9: User runs /verify "Dust balance is time-dependent" — the
   orchestrator classifies this as a wallet SDK architecture claim, dispatches
   the source-investigator only (no pre-flight needed), and reports.
-skills: midnight-verify:verify-correctness, midnight-verify:verify-compact, midnight-verify:verify-sdk, midnight-verify:verify-zkir, midnight-verify:verify-witness, midnight-verify:verify-wallet-sdk
+
+  Example 10: User runs /verify "SyntheticCost has 5 dimensions" — the
+  orchestrator classifies this as a ledger/protocol cost model claim,
+  dispatches the source-investigator (primary) to inspect the Rust source,
+  and optionally the contract-writer (secondary) to compile a contract and
+  measure its cost.
+
+  Example 11: User runs /verify "coinCommitment returns a hex string" — the
+  orchestrator classifies this as a ledger TypeScript API claim, dispatches
+  the type-checker (pre-flight) and source-investigator (primary), and
+  optionally runs ledger-v8 execution to call the function and observe output.
+skills: midnight-verify:verify-correctness, midnight-verify:verify-compact, midnight-verify:verify-sdk, midnight-verify:verify-zkir, midnight-verify:verify-witness, midnight-verify:verify-wallet-sdk, midnight-verify:verify-ledger
 model: sonnet
 color: green
 ---
@@ -62,6 +73,7 @@ You are the Midnight verification orchestrator.
    - Witness claims → load `midnight-verify:verify-witness`
    - Cross-domain → load applicable domain skills
    - Wallet SDK claims → load `midnight-verify:verify-wallet-sdk`
+   - Ledger/Protocol claims → load `midnight-verify:verify-ledger`
 3. Follow the hub skill's process exactly.
 
 ## Dispatching Sub-Agents
@@ -91,6 +103,15 @@ You are the Midnight verification orchestrator.
 - Devnet E2E (fallback) → dispatch `midnight-verify:sdk-tester` with `domain: 'wallet-sdk'` context, ONLY if source investigation returns Inconclusive
 
 **For wallet SDK claims, dispatch type-checker and source-investigator concurrently** (they are independent). Wait for source-investigator's verdict. Only dispatch sdk-tester if source-investigator returned Inconclusive.
+
+**Ledger/Protocol verification:**
+- Source investigation (primary) → dispatch `midnight-verify:source-investigator` with instruction to load `midnight-verify:verify-by-ledger-source`
+- Type-check (pre-flight, TS API claims only) → dispatch `midnight-verify:type-checker` (uses existing sdk-workspace, ledger-v8 already installed)
+- Compilation/execution (secondary) → dispatch `midnight-verify:contract-writer` with instruction to extract ledger-level evidence (cost data, well-formedness, balance checks)
+- ZKIR inspection (secondary) → dispatch `midnight-verify:zkir-checker` with instruction to inspect compiled circuit structure for VM/opcode claims
+- Ledger-v8 execution (secondary) → dispatch `midnight-verify:type-checker` in ledger execution mode to call ledger-v8 functions and observe output
+
+**For ledger claims, source investigation always runs.** Secondary methods provide corroborating evidence. Dispatch source-investigator first; dispatch secondary agents concurrently if the claim is testable.
 
 **When multiple methods are needed, dispatch agents concurrently.** They are independent and can run in parallel.
 

--- a/plugins/midnight-verify/skills/verify-by-execution/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-by-execution/SKILL.md
@@ -223,3 +223,48 @@ rm -rf .midnight-expert/verify/compact-workspace/jobs/$JOB_ID
 ```
 
 Do NOT remove the base workspace — it's shared across jobs.
+
+## Ledger Execution Mode
+
+When dispatched for a ledger/protocol claim, you compile and execute a Compact contract as usual, but after execution you extract **ledger-level evidence** — cost data, transaction properties, well-formedness results — in addition to the normal runtime output.
+
+**When to use this mode:** The verifier dispatches you with a ledger claim that is testable via compilation. Examples:
+- "Fee calculation uses max(read, compute, block) + write + churn" → compile a contract, compute its cost
+- "Well-formedness rejects overlapping inputs" → build a transaction with overlapping inputs, check wellFormed() rejects
+- "Counter increment costs N bytes of block usage" → compile counter, measure SyntheticCost.block_usage
+
+**What to extract after compilation and execution:**
+
+| Claim type | What to extract | How |
+|---|---|---|
+| Cost model claims | SyntheticCost breakdown | Import CostModel from ledger-v8, call `cost()` on the compiled transaction |
+| Well-formedness claims | Acceptance/rejection | Call `wellFormed()` on the transaction, capture result |
+| Balance claims | Per-segment per-token balance | Inspect transaction structure after construction |
+| Transaction structure | Intent/offer properties | Read compiled transaction fields |
+| Proof staging | Stage transitions | Construct UnprovenTransaction, call `prove()`, observe state change |
+
+**Extended runner script pattern:**
+
+After the normal circuit execution (Step 5), add ledger-level evidence extraction:
+
+```javascript
+import { CostModel, WellFormedStrictness } from '@midnight-ntwrk/ledger';
+
+// ... normal circuit execution from Step 5 ...
+
+// Extract cost data
+const cost = transaction.cost();
+console.log(JSON.stringify({
+  circuitResult: result,
+  cost: {
+    read_time: cost.read_time?.toString(),
+    compute_time: cost.compute_time?.toString(),
+    block_usage: cost.block_usage?.toString(),
+    bytes_written: cost.bytes_written?.toString(),
+    bytes_churned: cost.bytes_churned?.toString(),
+  },
+  wellFormed: transaction.wellFormed(WellFormedStrictness.default()),
+}));
+```
+
+**Include the ledger-level evidence in your report** alongside the normal execution report. The verifier orchestrator uses both to synthesize the verdict.

--- a/plugins/midnight-verify/skills/verify-by-ledger-source/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-by-ledger-source/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: midnight-verify:verify-by-ledger-source
+description: >-
+  Verification by source code inspection of the Midnight ledger Rust codebase.
+  Searches and reads the actual Rust implementation to verify claims about
+  transaction structure, token mechanics, cost model, on-chain VM, contract
+  execution, and cryptographic primitives. Routes claims to specific crates
+  within the 24-crate workspace. Uses octocode-mcp for quick lookups, falls
+  back to local cloning for deep investigation. Loaded by the source-investigator
+  agent when the claim domain is ledger/protocol.
+version: 0.1.0
+---
+
+# Verify by Ledger Source Code Inspection
+
+You are verifying a claim about the Midnight ledger protocol by reading the actual Rust source code. Follow these steps in order.
+
+## Critical Rule
+
+**Source code is evidence. Everything else is a hint.**
+
+| Source | Role | Rule |
+|---|---|---|
+| Rust source code (function definitions, type definitions, implementations) | Primary evidence | Always the target. Verdicts must cite Rust source. |
+| Test files in the repo | Navigation aid | Follow test imports to find the right source code. Can be run as a last resort (clone to /tmp, `cargo test`), but realistically never needed. |
+| `spec/` documents (13 specification files) | Hints only | Useful for orienting where to look. Never evidence on their own. Any claim derived from specs must be corroborated by Rust source inspection. |
+| `docs/api/` generated TypeScript docs | Navigation aid | Useful for finding what's exported via WASM, then trace back to Rust source. |
+
+## Step 1: Determine Where to Look
+
+**Crate routing — match the claim to the right crate and path:**
+
+| Claim About | Crate | Key Paths |
+|---|---|---|
+| Coin types, commitments, nullifiers, token types | `coin-structure` | `src/coin.rs`, `src/contract.rs`, `src/transfer.rs` |
+| NIGHT constant, ShieldedTokenType, UnshieldedTokenType | `coin-structure` | `src/coin.rs` |
+| Hashing (persistent, transient, Poseidon) | `base-crypto` | `src/hash.rs` |
+| Signatures (Schnorr/Secp256k1, BIP340) | `base-crypto` | `src/signatures.rs` |
+| FAB encoding (field-aligned binary) | `base-crypto` | `src/fab/` |
+| Pedersen commitments, value commitments | `transient-crypto` | `src/commitment.rs` |
+| Encryption (Poseidon CTR, ECDH) | `transient-crypto` | `src/encryption.rs` |
+| Merkle trees | `transient-crypto` | `src/merkle_tree.rs` |
+| Curve operations (Fr, embedded curve) | `transient-crypto` | `src/curve.rs` |
+| ZK proof structures, prover traits | `transient-crypto` | `src/proofs.rs` |
+| VM opcodes, instruction execution | `onchain-vm` | `src/ops.rs`, `src/vm.rs` |
+| VM cost model (per-instruction costs) | `onchain-vm` | `src/cost_model.rs` |
+| StateValue types (Null, Cell, Map, Array, BoundedMerkleTree) | `onchain-state` | `src/` |
+| Contract state, runtime context, transcripts | `onchain-runtime` | `src/context.rs`, `src/transcript.rs` |
+| Communication commitment | `onchain-runtime` | `src/` (re-exported) |
+| Transaction structure, assembly, well-formedness | `ledger` | `src/structure.rs`, `src/construct.rs`, `src/semantics.rs` |
+| Transaction proving and verification | `ledger` | `src/prove.rs`, `src/verify.rs` |
+| Dust operations (spend, registration, generation) | `ledger` | `src/dust.rs` |
+| Intent structure, replay protection | `ledger` | `src/structure.rs` |
+| Zswap offers, inputs, outputs, transients | `zswap` | `src/` |
+| Zswap local state, chain state | `zswap` | `src/` |
+| Fee token, cost model at ledger level | `ledger` | `src/structure.rs` (FEE_TOKEN) |
+| Serialization format | `serialize` | `src/` |
+| Storage (MPT, delta tracking) | `storage`, `storage-core` | `src/` |
+| WASM bindings (ledger-v8 JS API) | `ledger-wasm` | `src/lib.rs`, `src/crypto.rs`, `src/tx.rs`, `src/zswap_wasm.rs`, `src/dust.rs` |
+| WASM bindings (onchain-runtime JS API) | `onchain-runtime-wasm` | `src/` |
+| ZKIR v2 checker/prover | `zkir` | `src/ir.rs`, `src/ir_vm.rs` |
+| Precompiled circuits | `zkir-precompiles` | `dust/`, `zswap/`, `token-vault/`, etc. |
+| Proof server HTTP API | `proof-server` | `src/main.rs` |
+
+**Crate dependency graph:**
+
+```
+base-crypto → transient-crypto → coin-structure → onchain-state → onchain-vm → onchain-runtime
+                                                                                      ↓
+                                                              zswap ← ledger ← ledger-wasm (WASM)
+```
+
+Supporting: `serialize`, `storage-core`, `storage`. Proofs: `zkir`, `zkir-v3`.
+
+## Step 2: Search with octocode-mcp
+
+Start with targeted lookups using the `octocode-mcp` tools:
+
+1. **`githubSearchCode`** — search for specific function names, type names, implementations in `midnightntwrk/midnight-ledger`
+2. **`githubGetFileContent`** — read a specific file once you know the path
+3. **`githubViewRepoStructure`** — understand crate layout if unsure
+
+**Search strategy:**
+
+- For crypto primitive claims: start in `base-crypto/src/` or `transient-crypto/src/`
+- For transaction/protocol claims: start in `ledger/src/` then trace to `zswap/`, `coin-structure/`
+- For VM/runtime claims: start in `onchain-vm/src/` then `onchain-runtime/`
+- For TypeScript API claims: start in `ledger-wasm/src/` to find the WASM binding, then trace to the underlying Rust implementation
+- Start narrow (exact function/type name), broaden if no results
+- Verify you're on the default branch
+
+## Step 3: Clone Locally if Needed
+
+If octocode-mcp results are insufficient — tracing cross-crate dependencies, following trait implementations across crates, or understanding the full call chain:
+
+```bash
+CLONE_DIR=$(mktemp -d)
+git clone --depth 1 git@github.com:midnightntwrk/midnight-ledger.git "$CLONE_DIR/midnight-ledger"
+```
+
+Always use SSH protocol (`git@github.com:`), not HTTPS.
+
+After investigation, clean up:
+
+```bash
+rm -rf "$CLONE_DIR"
+```
+
+## Step 4: Read and Interpret Source
+
+**What counts as evidence (ordered by strength):**
+
+1. **Rust function/type/trait definitions** — strong evidence. If the source defines a struct with field X, that's definitive.
+2. **Rust test files** — navigation aid. Follow test imports to pinpoint source. Not evidence themselves.
+3. **`spec/` documents** — hints for where to look. The 13 spec files (preliminaries, intents-transactions, zswap, dust, night, contracts, cost-model, field-aligned-binary, onchain-runtime, properties, storage-io-cost-modeling, cardano-system-transactions) describe intended behavior but must be corroborated by Rust source.
+4. **`docs/api/` TypeScript docs** — navigation aid. Generated from WASM bindings. Trace back to Rust.
+
+**Watch for:**
+
+- The workspace has 24 crates. A type defined in `coin-structure` may be re-exported through `ledger` and appear via WASM in `ledger-wasm`. Trace to the original definition.
+- `#[wasm_bindgen]` functions in `*-wasm` crates are thin wrappers. The real implementation is in the underlying Rust crate.
+- Feature flags control what's compiled: `proof-verifying` (default), `proving`, `test-utilities`, `mock-verify`. Some code only exists behind features.
+- The `static` crate provides version identifiers via proc macro.
+
+## Step 5: Report
+
+**Your report must include:**
+
+1. **The claim as received** — verbatim
+2. **Where you looked** — crate name, file path(s), line numbers
+3. **What the source shows** — quote or summarize the relevant Rust code
+4. **GitHub links** — full URLs to exact files/lines (e.g., `https://github.com/midnightntwrk/midnight-ledger/blob/main/coin-structure/src/coin.rs#L42`)
+5. **Your interpretation** — does the source confirm, refute, or leave the claim inconclusive?
+
+**Report format:**
+
+```
+### Source Investigation Report
+
+**Claim:** [verbatim]
+
+**Searched:** [crate(s) and method — octocode-mcp search / local clone]
+
+**Found:**
+- Crate: [crate-name]
+- File: [path/to/file.rs:line-range]
+- Link: [full GitHub URL]
+- Content: [relevant Rust code snippet or summary]
+
+**Interpretation:** [Confirmed / Refuted / Inconclusive] — [explanation]
+```
+
+If inconclusive, explain:
+- What you searched and why it wasn't definitive
+- Whether compilation/execution might resolve it (the verifier orchestrator decides whether to dispatch contract-writer or zkir-checker)

--- a/plugins/midnight-verify/skills/verify-by-type-check/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-by-type-check/SKILL.md
@@ -149,6 +149,49 @@ If `npm ls` reports errors, run `npm install` to repair.
 - `domain: 'wallet-sdk'` → use `.midnight-expert/verify/wallet-sdk-workspace/`
 - Otherwise → use `.midnight-expert/verify/sdk-workspace/` (existing behavior)
 
+## Ledger API Execution Mode
+
+When the verifier passes `domain: 'ledger'` context and the claim is about behavioral output of a `@midnight-ntwrk/ledger-v8` function (not just its type signature), go beyond type-checking — write a script that calls the function and observes the output.
+
+**This uses the existing sdk-workspace** (ledger-v8 is already installed there). No separate workspace needed.
+
+**When to use this mode:**
+- Claim is about what a ledger-v8 function *returns* (not just its signature)
+- Examples: "nativeToken() returns [0,0,...,0]", "coinCommitment produces a 64-char hex string", "CostModel.initialCostModel() has specific default values"
+
+**Script pattern:**
+
+```bash
+cat > .midnight-expert/verify/sdk-workspace/jobs/$JOB_ID/ledger-exec.mjs << 'EXEC_EOF'
+// Import the specific function being tested
+import { nativeToken, coinCommitment, CostModel } from '@midnight-ntwrk/ledger';
+
+// Call the function and capture output
+const result = nativeToken();
+
+// Output structured JSON for interpretation
+console.log(JSON.stringify({
+  result: typeof result === 'bigint' ? result.toString() : result,
+  type: typeof result
+}));
+EXEC_EOF
+```
+
+Run it:
+
+```bash
+cd .midnight-expert/verify/sdk-workspace/jobs/$JOB_ID
+node ledger-exec.mjs
+```
+
+**Report this as "ledger-v8 execution" evidence**, not as type-checking evidence. Include the script source, output, and interpretation in your report.
+
+**Mode selection summary:**
+- `domain: 'wallet-sdk'` → use `.midnight-expert/verify/wallet-sdk-workspace/`
+- `domain: 'ledger'` + behavioral claim → use sdk-workspace + ledger execution script
+- `domain: 'ledger'` + type claim → use sdk-workspace + normal tsc type assertions
+- Otherwise → use `.midnight-expert/verify/sdk-workspace/` (existing behavior)
+
 ## Step 2: Determine the Mode
 
 **Claim mode** — you received a natural language claim about the SDK (e.g., "deployContract returns DeployedContract"). Go to Step 3A.

--- a/plugins/midnight-verify/skills/verify-correctness/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-correctness/SKILL.md
@@ -27,6 +27,7 @@ Determine what domain the claim belongs to:
 | **Witness** | Witness implementation, WitnessContext, private state, `[PrivateState, T]` return tuple, `.compact` + `.ts` file pair, witness declarations, type mappings | Load `midnight-verify:verify-witness` |
 | **Cross-domain** | Spans Compact and SDK, Compact and ZKIR, Witness and ZKIR, or protocol/architecture | Load applicable domain skills |
 | **Wallet SDK** | @midnight-ntwrk/wallet-sdk-* packages, WalletFacade, WalletBuilder, WalletRuntime, RuntimeVariant, DApp Connector API (ConnectedAPI, InitialAPI, window.midnight), HD derivation, Bech32m addresses, branded types (ProtocolVersion, WalletSeed), three-wallet architecture, capabilities (Balancer, ProvingService, SubmissionService) | Load `midnight-verify:verify-wallet-sdk` |
+| **Ledger/Protocol** | Transaction structure (intents, segments, offers, binding), token mechanics (Night UTXO, Zswap commitment/nullifier, Dust generation), cost model (SyntheticCost, fee pricing, block limits), on-chain VM (opcodes, StateValue, stack machine), contract execution (deployment, calls, effects, transcripts), cryptographic primitives (Pedersen, Fiat-Shamir, signatures, Merkle trees), @midnight-ntwrk/ledger-v8 API, well-formedness rules, FAB encoding, formal security properties | Load `midnight-verify:verify-ledger` |
 
 ### 2. Load the Domain Skill
 
@@ -52,6 +53,15 @@ Based on the domain skill's routing:
 - Devnet E2E (fallback, only if source is Inconclusive) → dispatch `midnight-verify:sdk-tester` agent with `domain: 'wallet-sdk'` context
 
 **For wallet SDK claims, dispatch type-checker and source-investigator concurrently.** Wait for source-investigator. Only dispatch sdk-tester if source returned Inconclusive.
+
+**Ledger/Protocol verification:**
+- Source investigation (primary, always runs) → dispatch `midnight-verify:source-investigator` agent with instruction to load `midnight-verify:verify-by-ledger-source`
+- Type-check (pre-flight, TS API claims only) → dispatch `midnight-verify:type-checker` agent (uses existing sdk-workspace)
+- Compilation/execution (secondary) → dispatch `midnight-verify:contract-writer` agent with instruction to extract ledger-level evidence
+- ZKIR inspection (secondary) → dispatch `midnight-verify:zkir-checker` agent for VM/opcode claims
+- Ledger-v8 execution (secondary) → dispatch `midnight-verify:type-checker` agent in ledger execution mode
+
+**For ledger claims, source investigation always runs.** Secondary methods provide corroborating evidence and are dispatched concurrently when the claim is testable.
 
 - **Multiple methods needed** → dispatch applicable agents **concurrently** (they are independent and can run in parallel)
 
@@ -103,6 +113,12 @@ Collect the sub-agent report(s) and produce the final verdict.
 | **Refuted** | (source-verified) | Source contradicts the wallet SDK claim |
 | **Refuted** | (type-checked + source-verified) | Type-check failed and source confirms it's wrong (wallet SDK domain) |
 | **Inconclusive** | (source insufficient, devnet unavailable) | Couldn't confirm via source, devnet not running (wallet SDK domain) |
+| **Confirmed** | (source-verified) | Rust source confirms the ledger/protocol claim |
+| **Confirmed** | (source-verified + tested) | Rust source confirmed, compilation/execution also confirms (ledger domain) |
+| **Confirmed** | (tested) | Compilation/execution directly confirms (e.g., cost model output, well-formedness check) (ledger domain) |
+| **Refuted** | (source-verified) | Rust source contradicts the ledger/protocol claim |
+| **Refuted** | (tested) | Compilation/execution contradicts the claim (ledger domain) |
+| **Inconclusive** | — | Source investigation insufficient, no execution path available (ledger domain) |
 
 **Critical rule for wallet SDK claims:** Type-checking is a fast pre-flight only. It NEVER produces a standalone verdict for wallet SDK claims. Every wallet SDK verdict must come from source investigation (or devnet E2E as a fallback). There is no `Confirmed (type-checked)` for wallet SDK claims.
 

--- a/plugins/midnight-verify/skills/verify-ledger/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-ledger/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: midnight-verify:verify-ledger
+description: >-
+  Ledger/protocol claim classification and method routing. Determines what kind
+  of ledger claim is being verified and which verification methods apply:
+  source investigation (primary), type-checking (pre-flight for TypeScript API),
+  compilation/execution (secondary for testable claims), or ledger-v8 execution
+  (secondary for API behavioral claims). Handles claims about transaction
+  structure, token mechanics (Night/Zswap/Dust), cost model, on-chain VM,
+  contract execution, cryptographic primitives, well-formedness rules, and the
+  @midnight-ntwrk/ledger-v8 TypeScript API. Loaded by the verifier agent
+  alongside the hub skill.
+version: 0.1.0
+---
+
+# Ledger/Protocol Claim Classification
+
+This skill classifies ledger and protocol claims and determines which verification method to use. The verifier (orchestrator) agent loads this alongside the hub skill (`verify-correctness`).
+
+## Verification Flow
+
+Ledger claims have a richer verification hierarchy than other domains because the ledger crates produce the compiled output that the contract-writer and zkir-checker already work with.
+
+1. **Type-check (pre-flight)** — for TypeScript API claims only. Dispatch type-checker against the existing sdk-workspace (ledger-v8 is already installed). Pre-flight only, never a standalone verdict.
+2. **Source investigation (primary)** — always runs for protocol claims. Dispatch source-investigator, which loads `verify-by-ledger-source` for Rust crate-level routing.
+3. **Compilation/execution (secondary)** — for claims testable via Compact contracts. Dispatch contract-writer (compile + execute, extract ledger-level evidence) or zkir-checker (inspect compiled circuits).
+4. **Ledger-v8 execution (secondary)** — for claims about TypeScript API behavioral output. Write a script that calls ledger-v8 functions and observes output.
+
+## Claim Type → Method Routing
+
+### Claims About Protocol Structure
+
+| Claim Type | Example | Pre-flight | Primary | Secondary |
+|---|---|---|---|---|
+| Transaction format | "Transactions contain intents, offers, and binding randomness" | — | source-investigator | — |
+| Segment ordering | "Segment 0 is guaranteed, executes first" | — | source-investigator | contract-writer (negative test) |
+| Causal precedence | "Contract A calling B means A causally precedes B" | — | source-investigator | — |
+| Replay protection | "Intent hashes stored in TimeFilterMap" | — | source-investigator | — |
+| Well-formedness | "Disjoint check prevents input/output overlap" | — | source-investigator | contract-writer (build invalid tx) |
+| Proof staging | "UnprovenTransaction transitions to Proven via prove()" | — | source-investigator | ledger-v8 execution |
+
+### Claims About Token Mechanics
+
+| Claim Type | Example | Pre-flight | Primary | Secondary |
+|---|---|---|---|---|
+| Night UTXO | "UTXO uniqueness from (intent_hash, output_no)" | — | source-investigator | — |
+| Zswap commitments | "CoinCommitment = Hash<(CoinInfo, CoinPublicKey)>" | — | source-investigator | ledger-v8 execution (call coinCommitment) |
+| Zswap nullifiers | "CoinNullifier = Hash<(CoinInfo, CoinSecretKey)>" | — | source-investigator | ledger-v8 execution (call coinNullifier) |
+| Zswap transients | "Transients use ephemeral single-leaf Merkle tree" | — | source-investigator | — |
+| Dust generation | "Dust generates proportional to backing Night value" | — | source-investigator | — |
+| Dust spending | "Dust spend requires ZK proof of generation chain" | — | source-investigator | — |
+| Token types | "NIGHT is TokenType::Unshielded with raw [0u8; 32]" | — | source-investigator | ledger-v8 execution (call nativeToken) |
+
+### Claims About Cost Model
+
+| Claim Type | Example | Pre-flight | Primary | Secondary |
+|---|---|---|---|---|
+| Cost dimensions | "SyntheticCost has 5 dimensions: read, compute, block, write, churn" | — | source-investigator | — |
+| Fee formula | "Fee = max(read, compute, block) + write + churn" | — | source-investigator | contract-writer (compile, measure cost) |
+| Block limits | "Block usage limit is 200,000 bytes" | — | source-investigator | — |
+| Price adjustment | "Per-dimension price targets 50% block fullness" | — | source-investigator | — |
+| Guaranteed limits | "Guaranteed section has separate cost bounds" | — | source-investigator | — |
+
+### Claims About On-Chain VM
+
+| Claim Type | Example | Pre-flight | Primary | Secondary |
+|---|---|---|---|---|
+| Opcode semantics | "idx loads from Map by key" | — | source-investigator | zkir-checker (inspect compiled) |
+| StateValue types | "5 types: Null, Cell, Map, Array, BoundedMerkleTree" | — | source-investigator | — |
+| Stack machine | "VM is a stack machine, always exactly 1 item initially" | — | source-investigator | — |
+| Cached reads | "idxc requires value to be cached in memory" | — | source-investigator | — |
+
+### Claims About Contract Execution
+
+| Claim Type | Example | Pre-flight | Primary | Secondary |
+|---|---|---|---|---|
+| Contract address | "ContractAddress = Hash<ContractDeploy>" | — | source-investigator | — |
+| Effects system | "Effects declare claimed nullifiers, commitments, calls" | — | source-investigator | contract-writer (compile + execute) |
+| Caller determination | "Caller is calling contract, then single UTXO owner, then None" | — | source-investigator | — |
+| Transcripts | "Guaranteed transcript executes before fees are taken" | — | source-investigator | — |
+
+### Claims About Cryptographic Primitives
+
+| Claim Type | Example | Pre-flight | Primary | Secondary |
+|---|---|---|---|---|
+| Pedersen commitments | "Value commitment = g*r + h*v where h = hash(type, segment)" | — | source-investigator | — |
+| Fiat-Shamir binding | "Binding uses challenge c = hash(ErasedIntent, g*r, g*s)" | — | source-investigator | — |
+| Signatures | "Schnorr over Secp256k1 per BIP 340" | — | source-investigator | — |
+| Hashing | "field::hash uses Poseidon" | — | source-investigator | — |
+| Merkle trees | "Commitment tree uses persistent Merkle tree" | — | source-investigator | — |
+
+### Claims About Ledger TypeScript API
+
+| Claim Type | Example | Pre-flight | Primary | Secondary |
+|---|---|---|---|---|
+| Type/export existence | "ledger-v8 exports Transaction class" | type-checker | source-investigator | — |
+| Function signature | "coinCommitment takes (coin, coinPublicKey)" | type-checker | source-investigator | — |
+| Function behavior | "nativeToken() returns the NIGHT raw token type" | type-checker | source-investigator | ledger-v8 execution |
+| Class API | "ZswapLocalState has spend() method" | type-checker | source-investigator | — |
+| CostModel API | "CostModel.initialCostModel() returns default fee config" | type-checker | source-investigator | ledger-v8 execution |
+
+### Claims About Formal Properties
+
+| Claim Type | Example | Pre-flight | Primary | Secondary |
+|---|---|---|---|---|
+| Balance preservation | "Total funds preserved except mints, dust, and treasury" | — | source-investigator | — |
+| Transaction binding | "Assembled transaction cannot be disassembled" | — | source-investigator | — |
+| Infragility | "Defensively-created tx survives malicious merge" | — | source-investigator | — |
+| Causality | "Contract call A → B implies A success ⟹ B success" | — | source-investigator | — |
+| Self-determination | "User cannot spend another user's funds" | — | source-investigator | — |
+
+### Routing Rules
+
+**When in doubt:**
+- Protocol structure, token mechanics, crypto primitives → source-investigator (Rust source is authoritative)
+- TypeScript API surface → type-checker pre-flight + source-investigator (trace WASM binding to Rust)
+- Testable behavior (cost, well-formedness, token operations) → source-investigator + contract-writer or ledger-v8 execution as secondary
+- Formal properties → source-investigator only (these are about the proof structure in code)
+
+**Source investigation is always primary.** Secondary methods (compilation, execution) provide corroborating evidence but are not required for a verdict.
+
+## Hints from Existing Skills
+
+The verifier or sub-agents may consult these skills for context. They are **hints only** — never cite them as evidence.
+
+- `compact-core:compact-standard-library` — stdlib functions that map to ledger primitives
+- `compact-core:compact-compilation` — how Compact compiles to ZKIR (relevant for VM claims)
+- `midnight-tooling:compact-cli` — compiler behavior and flags


### PR DESCRIPTION
## Summary

- Add ledger/protocol verification domain to `midnight-verify` plugin — new `verify-ledger` routing skill and `verify-by-ledger-source` method skill with 24-crate Rust routing table, plus updates to the verifier orchestrator, verify-correctness hub, source-investigator (ledger crate routing), type-checker (Ledger API Execution Mode), and contract-writer (Ledger Execution Mode for cost/well-formedness extraction)
- Add `ledger-testing` skill to `midnight-cq` — testing guide for code using `@midnight-ntwrk/ledger-v8` and `@midnight-ntwrk/onchain-runtime`, covering proof staging lifecycle, ZswapLocalState/DustLocalState management, time-dependent Dust assertions, CostModel fee calculations, crypto fixture generation via `sample*` functions, and serialization round-trips
- Bump versions: marketplace 0.12.0, midnight-verify 0.6.0, midnight-cq 0.2.0

## Test plan

- [ ] Verify `verify-ledger` domain skill loads correctly via `/verify "SyntheticCost has 5 dimensions"`
- [ ] Verify `verify-by-ledger-source` routes source-investigator to correct Rust crates in `midnightntwrk/midnight-ledger`
- [ ] Verify Ledger API Execution Mode calls ledger-v8 functions (e.g., `/verify "nativeToken() returns the NIGHT raw token type"`)
- [ ] Verify Ledger Execution Mode extracts cost data from compiled contracts
- [ ] Verify ledger-testing skill triggers on "test proof staging"
- [ ] Verify cq-reviewer recognizes ledger projects via package.json deps

Generated with [Claude Code](https://claude.com/claude-code)