### PR TITLE
feat: add Compact CLI tooling verification domain

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-expert",
   "metadata": {
-    "version": "0.12.0",
+    "version": "0.13.0",
     "description": "AI agent plugins for the Midnight data-protection blockchain. Covers Compact smart contract development, privacy-preserving patterns, DApp frontend design, and Midnight toolchain management."
   },
   "owner": {

--- a/docs/superpowers/plans/2026-03-31-tooling-verification.md
+++ b/docs/superpowers/plans/2026-03-31-tooling-verification.md
@@ -1,0 +1,677 @@
+# Tooling Verification — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Compact CLI verification domain to the midnight-verify plugin with a dedicated cli-tester agent.
+
+**Architecture:** One new domain skill (routing table), one new method skill (CLI execution workflow), one new agent (cli-tester). Three modifications to existing components (verifier orchestrator, verify-correctness hub, source-investigator). All files in the midnight-verify plugin.
+
+**Tech Stack:** Markdown skill/agent files following existing midnight-verify patterns. No runtime code.
+
+**Spec:** `docs/superpowers/specs/2026-03-31-tooling-verification-design.md`
+
+---
+
+## File Map
+
+### midnight-verify plugin (`plugins/midnight-verify/`)
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `skills/verify-tooling/SKILL.md` | Domain skill — claim classification and routing for Compact CLI claims |
+| Create | `skills/verify-by-cli-execution/SKILL.md` | Method skill — CLI execution workflow (run command, check output) |
+| Create | `agents/cli-tester.md` | New agent — runs Compact CLI commands and interprets output |
+| Modify | `agents/verifier.md` | Add tooling domain, dispatch rules, examples |
+| Modify | `skills/verify-correctness/SKILL.md` | Add Tooling to domain classification, verdict qualifiers |
+| Modify | `agents/source-investigator.md` | Add tooling example |
+
+---
+
+## Important Context for Implementers
+
+### Plugin path
+
+All files are relative to `plugins/midnight-verify/`.
+
+### Existing patterns
+
+**Skill files** use YAML frontmatter (`name`, `description`, `version`) then markdown body.
+
+**Agent files** use YAML frontmatter (`name`, `description`, `skills`, `model`, `color`) then markdown body with instructions. The `tools` field is optional — only include it if the agent needs specific tools beyond the defaults.
+
+### Key distinction
+
+**verify-tooling** handles claims about the CLI tool ("--skip-zk skips PLONK key generation"). **verify-compact** handles claims about the Compact language ("tuples are 0-indexed"). If the claim is about what the language allows, it's Compact. If it's about what the CLI does when you run it, it's tooling.
+
+### Compact CLI commands
+
+- `compact` — CLI wrapper (shell script)
+- `compact compile` — invokes `compactc` (the compiler binary)
+- `compact compile --skip-zk` — compile without generating PLONK keys
+- `compact compile --language-version` — print the current language version
+- `compact --version` — print CLI version
+- `compactc` — the underlying compiler binary (can be run directly)
+
+---
+
+## Task 1: Create verify-tooling domain skill
+
+**Files:**
+- Create: `plugins/midnight-verify/skills/verify-tooling/SKILL.md`
+
+- [ ] **Step 1: Create the skill directory**
+
+```bash
+mkdir -p plugins/midnight-verify/skills/verify-tooling
+```
+
+- [ ] **Step 2: Write the domain skill file**
+
+Create `plugins/midnight-verify/skills/verify-tooling/SKILL.md` with this exact content:
+
+```markdown
+---
+name: midnight-verify:verify-tooling
+description: >-
+  Compact CLI tooling claim classification and method routing. Determines what
+  kind of CLI claim is being verified and which verification method applies:
+  CLI execution (primary for behavioral claims) or source investigation
+  (for internal/architectural claims). Handles claims about compact compile
+  flags, compactc behavior, compiler output structure, error messages, exit
+  codes, version management, and CLI installation. Loaded by the verifier
+  agent alongside the hub skill.
+version: 0.1.0
+---
+
+# Tooling Claim Classification
+
+This skill classifies Compact CLI tooling claims and determines which verification method to use. The verifier (orchestrator) agent loads this alongside the hub skill (`verify-correctness`).
+
+## Distinction from verify-compact
+
+- **verify-compact** handles claims about the Compact *language* — syntax, types, stdlib, disclosure rules, patterns
+- **verify-tooling** handles claims about the CLI *tool* — flags, output structure, error messages, versions, installation
+
+**Routing rule:** If the claim is about what the language allows/disallows, route to verify-compact. If the claim is about what the CLI does when you run it, route here.
+
+**Overlap:** "The compiler rejects X" could be either. If the claim is about a language rule ("you can't assign Field to Uint<8>"), it's Compact. If the claim is about CLI behavior ("the compiler exits with code 1 on syntax errors"), it's tooling.
+
+## Verification Flow
+
+CLI execution is the default. Source investigation is for when you genuinely can't run a command to answer the question.
+
+1. **CLI execution (primary)** — dispatch cli-tester. Run the command, observe stdout/stderr/exit code/filesystem. This is the most authoritative evidence for behavioral claims.
+2. **Source investigation (secondary)** — dispatch source-investigator (uses existing `verify-by-source`). For internal/architectural claims about how the compiler works under the hood.
+
+## Claim Type → Method Routing
+
+| Claim Type | Example | Primary | Secondary |
+|---|---|---|---|
+| Flag existence | "--skip-zk is a valid flag" | cli-tester (run --help, check output) | — |
+| Flag behavior | "--skip-zk skips PLONK key generation" | cli-tester (compile with/without, compare output dirs) | source-investigator |
+| Output structure | "Compilation produces build/contract/index.js" | cli-tester (compile, inspect filesystem) | — |
+| Error messages | "Undeclared variables produce 'not in scope' error" | cli-tester (feed bad input, check stderr) | source-investigator |
+| Exit codes | "Compilation errors exit with non-zero" | cli-tester (run, check $?) | — |
+| Version info | "--language-version returns the current version" | cli-tester (run, parse output) | — |
+| Installation | "compact is installed via npm" | cli-tester (check which compact) | source-investigator |
+| CLI vs compactc | "compact compile invokes compactc" | cli-tester (run both, compare) | source-investigator |
+| Compiler internals | "The compiler is written in Scheme" | source-investigator | — |
+| CLI wrapper internals | "compact is a shell script wrapper" | source-investigator | cli-tester (file type check) |
+
+### Routing Rules
+
+**When in doubt:**
+- If you can answer the question by running a command → cli-tester
+- If you need to read source code to understand internal behavior → source-investigator
+- If both apply → dispatch both concurrently
+
+**CLI execution is preferred whenever possible.** The command ran and produced this output — that's more authoritative than reading source code about what the output *should* be.
+
+## Hints from Existing Skills
+
+The cli-tester may consult this skill for context. It is a **hint only** — never cite it as evidence.
+
+- `midnight-tooling:compact-cli` — expected flags, compilation patterns, version management
+```
+
+- [ ] **Step 3: Verify the file was created correctly**
+
+```bash
+head -5 plugins/midnight-verify/skills/verify-tooling/SKILL.md
+```
+
+Expected: YAML frontmatter with `name: midnight-verify:verify-tooling`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-tooling/SKILL.md
+git commit -m "feat(midnight-verify): add verify-tooling domain skill
+
+Routing table for Compact CLI tooling claims. Routes behavioral claims
+to cli-tester (CLI execution) and internal claims to source-investigator.
+Clear boundary with verify-compact: language vs tool.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Create verify-by-cli-execution method skill
+
+**Files:**
+- Create: `plugins/midnight-verify/skills/verify-by-cli-execution/SKILL.md`
+
+- [ ] **Step 1: Create the skill directory**
+
+```bash
+mkdir -p plugins/midnight-verify/skills/verify-by-cli-execution
+```
+
+- [ ] **Step 2: Write the method skill file**
+
+Create `plugins/midnight-verify/skills/verify-by-cli-execution/SKILL.md` with this exact content:
+
+```markdown
+---
+name: midnight-verify:verify-by-cli-execution
+description: >-
+  Verification by running Compact CLI commands and observing output. Checks
+  CLI availability, runs commands, captures stdout/stderr/exit code, inspects
+  filesystem changes, and interprets results. Covers flag existence, flag
+  behavior, output structure, error messages, exit codes, version info,
+  and CLI-vs-compactc comparisons. Loaded by the cli-tester agent.
+version: 0.1.0
+---
+
+# Verify by CLI Execution
+
+You are verifying a Compact CLI claim by running the actual command and observing what happens. Follow these steps in order.
+
+## Critical Rule
+
+**CLI output is primary evidence.** The command ran and produced this output — that's definitive for behavioral claims. Source code is secondary evidence for internal claims that can't be observed via CLI.
+
+## Using midnight-tooling Skills as Hints
+
+You may consult `midnight-tooling:compact-cli` to understand what flags exist and how the CLI works. This is a **hint only** — the CLI output is your evidence, not the skill content.
+
+## Step 1: Check CLI Availability
+
+```bash
+compact --version 2>&1
+compactc --version 2>&1
+```
+
+If **both** commands fail (command not found), report **Inconclusive (cli unavailable)** and stop:
+
+```
+The Compact CLI is not installed or not on PATH. Install it via
+midnight-tooling:install-cli and retry.
+```
+
+If only one is available, note which one and proceed — some claims are about `compact` specifically vs `compactc`.
+
+## Step 2: Determine the Test Approach
+
+Based on the claim, choose the appropriate test:
+
+### Flag Existence
+
+Check if a flag appears in help output:
+
+```bash
+compact compile --help 2>&1 | grep -i '<flag-name>'
+```
+
+If found → flag exists. If not found → flag does not exist.
+
+### Flag Behavior
+
+Compile a minimal contract with and without the flag, compare results:
+
+```bash
+# Get language version
+LANG_VER=$(compact compile --language-version 2>&1)
+
+# Create job directory
+JOB_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+mkdir -p .midnight-expert/verify/compact-workspace/jobs/$JOB_ID
+
+# Write minimal contract
+cat > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test.compact << COMPACT_EOF
+pragma language_version $LANG_VER;
+import CompactStandardLibrary;
+
+export circuit test(): Field {
+  0
+}
+COMPACT_EOF
+
+# Compile WITHOUT the flag
+compact compile .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test.compact \
+  > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/stdout-without.txt 2>&1
+ls -R .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test/build/ \
+  > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/listing-without.txt 2>&1
+
+# Clean compiled output
+rm -rf .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test/
+
+# Compile WITH the flag
+compact compile --skip-zk .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test.compact \
+  > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/stdout-with.txt 2>&1
+ls -R .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test/build/ \
+  > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/listing-with.txt 2>&1
+```
+
+Compare the two directory listings to identify what the flag changed.
+
+### Output Structure
+
+Compile a minimal contract and inspect the build directory:
+
+```bash
+# After compilation
+find .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test/build/ -type f | sort
+```
+
+Compare the actual file tree against the claimed structure.
+
+### Error Messages
+
+Feed invalid input and capture stderr:
+
+```bash
+# Write intentionally invalid contract
+cat > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/bad.compact << 'COMPACT_EOF'
+<intentionally invalid code targeting the claimed error>
+COMPACT_EOF
+
+compact compile .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/bad.compact 2>&1
+echo "Exit code: $?"
+```
+
+Check that stderr contains the claimed error message (or doesn't, if refuting).
+
+### Exit Codes
+
+Run the command and capture the exit code:
+
+```bash
+compact compile <args> 2>&1
+echo "Exit code: $?"
+```
+
+### Version Info
+
+```bash
+compact --version 2>&1
+compact compile --language-version 2>&1
+compactc --version 2>&1
+```
+
+Parse and compare against the claim.
+
+### CLI vs compactc
+
+Run both and compare behavior:
+
+```bash
+# Via wrapper
+compact compile <args> > stdout-compact.txt 2>&1
+echo "compact exit: $?"
+
+# Via compactc directly
+compactc <args> > stdout-compactc.txt 2>&1
+echo "compactc exit: $?"
+
+# Compare
+diff stdout-compact.txt stdout-compactc.txt
+```
+
+## Step 3: Interpret and Report
+
+Compare the actual output against the claim.
+
+**Report format:**
+
+```
+### CLI Execution Report
+
+**Claim:** [verbatim]
+
+**Command(s) run:**
+\`\`\`bash
+[exact commands with arguments]
+\`\`\`
+
+**Exit code:** [0 / non-zero value]
+
+**stdout:**
+\`\`\`
+[captured output — full, not truncated]
+\`\`\`
+
+**stderr:**
+\`\`\`
+[captured output — full, not truncated]
+\`\`\`
+
+**Filesystem changes:** [new files/directories created, or "N/A" if not relevant]
+
+**Interpretation:** [Confirmed / Refuted / Inconclusive] — [explanation of how the output matches or contradicts the claim]
+```
+
+## Step 4: Clean Up
+
+Remove the job directory if one was created:
+
+```bash
+rm -rf .midnight-expert/verify/compact-workspace/jobs/$JOB_ID
+```
+
+Do NOT remove the base compact-workspace — it is shared across jobs.
+```
+
+- [ ] **Step 3: Verify the file was created correctly**
+
+```bash
+head -5 plugins/midnight-verify/skills/verify-by-cli-execution/SKILL.md
+```
+
+Expected: YAML frontmatter with `name: midnight-verify:verify-by-cli-execution`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-by-cli-execution/SKILL.md
+git commit -m "feat(midnight-verify): add verify-by-cli-execution method skill
+
+CLI execution workflow: check availability, run commands, capture
+stdout/stderr/exit code, inspect filesystem, interpret results.
+Covers flags, output structure, errors, versions, and CLI vs compactc.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Create cli-tester agent
+
+**Files:**
+- Create: `plugins/midnight-verify/agents/cli-tester.md`
+
+- [ ] **Step 1: Write the agent file**
+
+Create `plugins/midnight-verify/agents/cli-tester.md` with this exact content:
+
+```markdown
+---
+name: cli-tester
+description: >-
+  Use this agent to verify Compact CLI tooling claims by running commands
+  and observing output. Checks CLI availability, runs compact/compactc
+  commands, captures stdout/stderr/exit codes, inspects filesystem changes,
+  and interprets results. Dispatched by the verifier orchestrator agent.
+
+  Example 1: Claim "--skip-zk skips PLONK key generation" — compiles a
+  minimal contract with and without --skip-zk, compares output directories
+  (no keys/ directory when --skip-zk is used).
+
+  Example 2: Claim "compact compile --language-version returns the current
+  version" — runs the command, captures stdout, confirms it outputs a
+  version string.
+
+  Example 3: Claim "compactc rejects undeclared variables with exit code 1"
+  — writes a contract with an undeclared variable, compiles with compactc,
+  checks exit code is non-zero and stderr contains the expected error.
+skills: midnight-verify:verify-by-cli-execution
+model: sonnet
+color: orange
+---
+
+You are a Compact CLI tester.
+
+Load the `midnight-verify:verify-by-cli-execution` skill and follow it step by step. It tells you exactly how to:
+
+1. Check CLI availability (compact and compactc)
+2. Determine the test approach based on claim type
+3. Run the command(s) and capture all output
+4. Interpret the results
+5. Clean up
+
+Follow the skill precisely. The CLI output is your evidence. Do not guess what a command does — run it and observe.
+
+You may load `midnight-tooling:compact-cli` as a hint for understanding CLI flags, compilation patterns, and version management. But the CLI output is your evidence, not the skill content.
+
+**Important:** Always capture full stdout, stderr, and exit code for every command you run. Partial output is not acceptable — the verifier needs the complete picture to synthesize a verdict.
+```
+
+- [ ] **Step 2: Verify the file was created correctly**
+
+```bash
+head -5 plugins/midnight-verify/agents/cli-tester.md
+```
+
+Expected: YAML frontmatter with `name: cli-tester`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/midnight-verify/agents/cli-tester.md
+git commit -m "feat(midnight-verify): add cli-tester agent
+
+New agent for verifying Compact CLI claims by running commands and
+observing output. Uses sonnet model, loads verify-by-cli-execution skill.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Update verifier orchestrator agent
+
+**Files:**
+- Modify: `plugins/midnight-verify/agents/verifier.md`
+
+- [ ] **Step 1: Add tooling examples to the description**
+
+In the YAML frontmatter `description` field, after the existing Example 11 about ledger TypeScript API (the line containing "optionally runs ledger-v8 execution to call the function and observe output."), add:
+
+```yaml
+
+  Example 12: User runs /verify "--skip-zk skips PLONK key generation" — the
+  orchestrator classifies this as a tooling claim, dispatches the cli-tester
+  agent to compile with and without --skip-zk and compare output directories.
+
+  Example 13: User runs /verify "The Compact compiler is written in Scheme" —
+  the orchestrator classifies this as an internal tooling claim, dispatches
+  the source-investigator to search the LFDT-Minokawa/compact repository.
+```
+
+- [ ] **Step 2: Add verify-tooling to the skills list**
+
+Append `, midnight-verify:verify-tooling` to the end of the `skills:` line.
+
+- [ ] **Step 3: Add tooling to the domain routing in the body**
+
+In the body's domain routing list (under "Based on the claim domain:"), after "Ledger/Protocol claims → load `midnight-verify:verify-ledger`", add:
+
+```markdown
+   - Tooling claims → load `midnight-verify:verify-tooling`
+```
+
+- [ ] **Step 4: Add tooling dispatch rules to the body**
+
+In "## Dispatching Sub-Agents", after the ledger/protocol verification subsection (ending with "Dispatch source-investigator first; dispatch secondary agents concurrently if the claim is testable.") and BEFORE "**When multiple methods are needed...**", add:
+
+```markdown
+**Tooling verification:**
+- CLI execution (primary) → dispatch `midnight-verify:cli-tester` for behavioral claims (flags, output, errors, versions)
+- Source investigation (secondary) → dispatch `midnight-verify:source-investigator` for internal/architectural claims about the compiler or CLI wrapper
+
+**For tooling claims, prefer CLI execution whenever possible.** The CLI is on the machine — running the command is more authoritative than reading source code. Use source investigation only for claims about internals that can't be observed via CLI output.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/midnight-verify/agents/verifier.md
+git commit -m "feat(midnight-verify): add tooling domain to verifier orchestrator
+
+Add tooling dispatch rules, examples, and skill reference. Tooling
+claims dispatch cli-tester as primary and source-investigator for
+internal claims.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Update verify-correctness hub skill
+
+**Files:**
+- Modify: `plugins/midnight-verify/skills/verify-correctness/SKILL.md`
+
+- [ ] **Step 1: Add Tooling to the domain classification table**
+
+In "### 1. Classify the Domain", add a new row to the table after the "Ledger/Protocol" row:
+
+```markdown
+| **Tooling** | Compact CLI commands (compact compile, compactc), CLI flags (--skip-zk, --language-version, --help), compiler output structure, compiler error messages, exit codes, CLI version/installation, CLI wrapper vs compactc distinction | Load `midnight-verify:verify-tooling` |
+```
+
+- [ ] **Step 2: Add tooling dispatch rules to section 3**
+
+In "### 3. Dispatch Sub-Agents", after the ledger/protocol verification subsection and before "**Multiple methods needed**" or the line starting with "- **Multiple methods needed**", add:
+
+```markdown
+**Tooling verification:**
+- CLI execution (primary) → dispatch `midnight-verify:cli-tester` agent for behavioral claims
+- Source investigation (secondary) → dispatch `midnight-verify:source-investigator` agent for internal/architectural claims
+
+**For tooling claims, prefer CLI execution.** Running the command is more authoritative than reading source.
+```
+
+- [ ] **Step 3: Add tooling verdict qualifiers to section 4**
+
+In "### 4. Synthesize the Verdict", in the verdict options table, after the ledger domain rows, add:
+
+```markdown
+| **Confirmed** | (cli-tested) | Ran the CLI command, output matches the claim (tooling domain) |
+| **Confirmed** | (cli-tested + source-verified) | CLI output and source code both confirm (tooling domain) |
+| **Confirmed** | (source-verified) | Internal claim verified via source, not testable via CLI (tooling domain) |
+| **Refuted** | (cli-tested) | Ran the CLI command, output contradicts the claim (tooling domain) |
+| **Refuted** | (source-verified) | Source contradicts the internal claim (tooling domain) |
+| **Inconclusive** | (cli unavailable) | Compact CLI not installed or not on PATH (tooling domain) |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/midnight-verify/skills/verify-correctness/SKILL.md
+git commit -m "feat(midnight-verify): add tooling domain to verify-correctness hub
+
+Add Tooling to domain classification table, dispatch rules, and
+verdict qualifiers including Confirmed (cli-tested) and Inconclusive
+(cli unavailable).
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Update source-investigator agent
+
+**Files:**
+- Modify: `plugins/midnight-verify/agents/source-investigator.md`
+
+- [ ] **Step 1: Add tooling example to description**
+
+In the YAML frontmatter `description` field, after the existing Example 5 about ledger CoinCommitment (the line containing "Uses verify-by-ledger-source for Rust crate-level routing."), add:
+
+```yaml
+
+  Example 6: Claim "The Compact compiler is written in Scheme" — searches
+  LFDT-Minokawa/compact for the compiler source code, examines file
+  extensions and directory structure. Uses the general verify-by-source
+  skill (tooling source claims route to existing repos).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add plugins/midnight-verify/agents/source-investigator.md
+git commit -m "feat(midnight-verify): add tooling example to source-investigator
+
+Tooling internal claims use existing verify-by-source routing to
+LFDT-Minokawa/compact and midnightntwrk/compact repos.
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Bump version and final verification
+
+- [ ] **Step 1: Bump midnight-verify plugin version**
+
+In `plugins/midnight-verify/.claude-plugin/plugin.json`, change `"version": "0.6.0"` to `"version": "0.7.0"`.
+
+- [ ] **Step 2: Bump marketplace version**
+
+In `.claude-plugin/marketplace.json`, change `"version": "0.12.0"` to `"version": "0.13.0"`.
+
+- [ ] **Step 3: Commit version bumps**
+
+```bash
+git add plugins/midnight-verify/.claude-plugin/plugin.json .claude-plugin/marketplace.json
+git commit -m "chore: bump versions for tooling verification release
+
+midnight-verify 0.6.0 → 0.7.0
+marketplace 0.12.0 → 0.13.0
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>"
+```
+
+- [ ] **Step 4: Verify all new files exist**
+
+```bash
+echo "=== New files ==="
+ls -la plugins/midnight-verify/skills/verify-tooling/SKILL.md
+ls -la plugins/midnight-verify/skills/verify-by-cli-execution/SKILL.md
+ls -la plugins/midnight-verify/agents/cli-tester.md
+```
+
+Expected: all 3 files exist.
+
+- [ ] **Step 5: Verify YAML frontmatter**
+
+```bash
+for f in \
+  plugins/midnight-verify/skills/verify-tooling/SKILL.md \
+  plugins/midnight-verify/skills/verify-by-cli-execution/SKILL.md \
+  plugins/midnight-verify/agents/cli-tester.md; do
+  echo "--- $f ---"
+  head -3 "$f"
+  echo ""
+done
+```
+
+Expected: each starts with `---` and has a `name:` field.
+
+- [ ] **Step 6: Count agents**
+
+```bash
+ls plugins/midnight-verify/agents/
+```
+
+Expected: 8 agent files (7 existing + cli-tester.md).
+
+- [ ] **Step 7: Verify git status is clean**
+
+```bash
+git status
+```
+
+Expected: clean working tree.

--- a/docs/superpowers/specs/2026-03-31-tooling-verification-design.md
+++ b/docs/superpowers/specs/2026-03-31-tooling-verification-design.md
@@ -1,0 +1,197 @@
+# Tooling Verification — Design Spec
+
+**Date:** 2026-03-31
+**Status:** Approved
+**Scope:** Add tooling verification domain to midnight-verify plugin for Compact CLI claims
+
+## Overview
+
+The Compact CLI (`compact` wrapper + `compactc` compiler binary) is the most frequently referenced tool in the Midnight ecosystem. Claims about CLI flags, compiler behavior, output structure, error messages, and version management are common and frequently wrong in training data because CLI behavior changes with every release. This spec adds a tooling verification domain that verifies these claims by actually running the CLI and observing the output.
+
+## Design Decisions
+
+- **Compact CLI only**: This domain covers `compact` (the CLI wrapper) and `compactc` (the underlying compiler, invoked via `compact compile`). Devnet, proof server, release notes, and troubleshooting are out of scope — their claims are better handled by existing source investigation.
+- **CLI execution primary**: Running the command and observing the output is the most authoritative evidence for behavioral claims. Source investigation is the fallback for internal/architectural claims that can't be tested by running a command.
+- **New method skill**: `verify-by-cli-execution` defines the CLI execution workflow (run binary, check exit code, parse stdout/stderr, inspect filesystem). This is fundamentally different from contract execution (verify-by-execution) and warrants its own skill.
+- **New agent**: `cli-tester` is a dedicated agent for running CLI commands. The contract-writer's job is writing and executing Compact contracts — asking it to also run CLI diagnostic commands stretches its purpose. The cli-tester keeps responsibilities clean.
+- **No new workspace**: CLI execution reuses the existing compact-workspace for job isolation when compilation is needed.
+- **No midnight-cq changes**: Tooling testing is too niche for a testing guide — users don't write code that wraps the CLI.
+
+## Part 1: verify-tooling Domain Skill
+
+**Purpose:** Classify Compact CLI claims and route them to the correct verification methods.
+
+**Domain indicators:**
+- Compact CLI commands (`compact compile`, `compact --version`, `compactc`)
+- CLI flags (`--skip-zk`, `--language-version`, `--help`)
+- Compiler output structure (build directories, file layout)
+- Compiler error messages and exit codes
+- CLI installation and version management
+- Compiler behavior (what happens when you run a command)
+
+**Distinction from verify-compact:** verify-compact handles claims about the Compact *language* ("tuples are 0-indexed"). verify-tooling handles claims about the CLI *tool* ("--skip-zk skips PLONK key generation"). Routing rule: if the claim is about what the language allows/disallows, it's Compact. If it's about what the CLI does when you run it, it's tooling.
+
+**Verification flow:**
+
+| Claim Category | Primary | Secondary |
+|---|---|---|
+| CLI flag existence/behavior | cli-tester (run command, observe) | source-investigator (check CLI source) |
+| Compiler output structure | cli-tester (compile, inspect filesystem) | — |
+| Compiler error messages | cli-tester (feed bad input, check stderr) | source-investigator (check error definitions) |
+| CLI version/installation | cli-tester (run --version) | — |
+| Compilation behavior | cli-tester (compile test contract, observe) | contract-writer (if claim overlaps with contract correctness) |
+| Internal compiler architecture | source-investigator | — |
+| CLI wrapper vs compactc distinction | cli-tester (run both, compare) | source-investigator |
+
+**Verdict qualifiers:**
+- `Confirmed (cli-tested)` — ran the command, output matches the claim
+- `Confirmed (cli-tested + source-verified)` — both CLI execution and source agree
+- `Confirmed (source-verified)` — internal claim verified via source (can't be CLI tested)
+- `Refuted (cli-tested)` — ran the command, output contradicts the claim
+- `Refuted (source-verified)` — source contradicts
+- `Inconclusive (cli unavailable)` — Compact CLI not installed or not on PATH
+
+## Part 2: verify-by-cli-execution Method Skill
+
+**Purpose:** Run Compact CLI commands and interpret results. Loaded by the cli-tester agent.
+
+**Workflow:**
+
+### Step 1: Check CLI Availability
+
+Run `compact --version` and `compactc --version`. If neither is available, report `Inconclusive (cli unavailable)` and stop.
+
+### Step 2: Determine Test Approach
+
+| Claim Type | Approach |
+|---|---|
+| Flag exists | Run `compact compile --help`, check flag appears in output |
+| Flag behavior | Compile a minimal contract with and without the flag, compare output directories |
+| Output structure | Compile a minimal contract, inspect the build directory layout |
+| Error message | Feed invalid input, capture stderr, match against claimed message |
+| Exit code | Run command, check `$?` |
+| Version info | Run `--version` or `--language-version`, parse output |
+| CLI vs compactc | Run both, compare behavior |
+
+### Step 3: Write Minimal Test Contract if Needed
+
+Some claims require compilation. Use the compact-workspace at `.midnight-expert/verify/compact-workspace/` with a job directory for isolation:
+
+```bash
+JOB_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+mkdir -p .midnight-expert/verify/compact-workspace/jobs/$JOB_ID
+```
+
+Write a minimal `.compact` file targeting the specific claim. Get the current language version with `compact compile --language-version`.
+
+### Step 4: Run the Command
+
+Capture stdout, stderr, and exit code. Also inspect filesystem changes (new directories, file counts, file types) when relevant.
+
+```bash
+compact compile <args> > stdout.txt 2> stderr.txt
+echo $? > exit_code.txt
+```
+
+### Step 5: Interpret and Report
+
+Compare observed output against the claim.
+
+**Report format:**
+
+```
+### CLI Execution Report
+
+**Claim:** [verbatim]
+
+**Command(s) run:**
+\`\`\`bash
+[exact commands]
+\`\`\`
+
+**Exit code:** [0 / non-zero]
+
+**stdout:**
+\`\`\`
+[captured output]
+\`\`\`
+
+**stderr:**
+\`\`\`
+[captured output]
+\`\`\`
+
+**Filesystem changes:** [new files/directories created, if relevant]
+
+**Interpretation:** [Confirmed / Refuted / Inconclusive] — [explanation]
+```
+
+### Step 6: Clean Up
+
+```bash
+rm -rf .midnight-expert/verify/compact-workspace/jobs/$JOB_ID
+```
+
+**Evidence rules:** CLI output is primary evidence. The command ran and produced this output — that's definitive for behavioral claims. Source code is secondary for internal claims that can't be observed via CLI.
+
+**Hint skills:** The cli-tester may consult `midnight-tooling:compact-cli` as a hint for what flags exist and how the CLI works. This is a hint only — the CLI output is the evidence.
+
+## Part 3: cli-tester Agent
+
+**Purpose:** Run Compact CLI commands and interpret output to verify tooling claims.
+
+**Frontmatter:**
+- `name: cli-tester`
+- `model: sonnet`
+- `color: orange`
+- `skills: midnight-verify:verify-by-cli-execution`
+- `tools: Bash, Read, Glob, Grep`
+
+**Instructions:**
+- Load `verify-by-cli-execution` and follow it step by step
+- May load `midnight-tooling:compact-cli` as a hint, but CLI output is evidence
+- Always check CLI availability first
+- Capture full stdout, stderr, and exit code for every command
+- Use job directory under compact-workspace for compilation-dependent claims
+- Clean up after yourself
+
+**Examples:**
+1. Claim "--skip-zk skips PLONK key generation" → compiles with and without `--skip-zk`, compares output directories (no `keys/` dir when skipped)
+2. Claim "compact compile --language-version returns the current version" → runs the command, captures output
+3. Claim "compactc rejects undeclared variables with exit code 1" → writes a contract with an undeclared variable, compiles, checks exit code and stderr
+
+## Part 4: Changes to Existing Components
+
+**verifier agent (`agents/verifier.md`):**
+- Add tooling domain to description with examples
+- Add `midnight-verify:verify-tooling` to skills list
+- Add tooling dispatch rules: cli-tester (primary for behavioral claims), source-investigator (for internal claims)
+
+**verify-correctness hub skill (`skills/verify-correctness/SKILL.md`):**
+- Add "Tooling" row to domain classification table with indicators
+- Add tooling dispatch rules to section 3
+- Add tooling verdict qualifiers to section 4
+
+**source-investigator agent (`agents/source-investigator.md`):**
+- Add tooling example to description (e.g., "Compact CLI wrapper is a shell script" → search `midnightntwrk/compact`)
+- No new method skill needed — existing verify-by-source already routes to `midnightntwrk/compact` for CLI releases and `LFDT-Minokawa/compact` for compiler source
+
+## File Inventory
+
+### New files (3)
+
+| File | Purpose |
+|---|---|
+| `skills/verify-tooling/SKILL.md` | Domain skill — routing table for Compact CLI claims |
+| `skills/verify-by-cli-execution/SKILL.md` | Method skill — CLI execution workflow |
+| `agents/cli-tester.md` | New agent — runs CLI commands, interprets output |
+
+### Modified files (3)
+
+| File | Change |
+|---|---|
+| `agents/verifier.md` | Add tooling domain, dispatch rules, examples |
+| `skills/verify-correctness/SKILL.md` | Add Tooling to domain classification, verdict qualifiers |
+| `agents/source-investigator.md` | Add tooling example |
+
+### Total: 3 new files, 3 modified files, 1 new agent.

--- a/plugins/midnight-verify/.claude-plugin/plugin.json
+++ b/plugins/midnight-verify/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-verify",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Verification framework for Midnight claims — verifies Compact code by compiling and executing test contracts, SDK/TypeScript claims by type-checking and devnet E2E testing, ZKIR circuits by running through the WASM checker and inspecting compiled structure, witness implementations by cross-domain type-checking and execution against compiled contracts, or by inspecting source code. Multi-agent pipeline with explicit /verify command.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-verify/agents/cli-tester.md
+++ b/plugins/midnight-verify/agents/cli-tester.md
@@ -1,0 +1,39 @@
+---
+name: cli-tester
+description: >-
+  Use this agent to verify Compact CLI tooling claims by running commands
+  and observing output. Checks CLI availability, runs compact/compactc
+  commands, captures stdout/stderr/exit codes, inspects filesystem changes,
+  and interprets results. Dispatched by the verifier orchestrator agent.
+
+  Example 1: Claim "--skip-zk skips PLONK key generation" — compiles a
+  minimal contract with and without --skip-zk, compares output directories
+  (no keys/ directory when --skip-zk is used).
+
+  Example 2: Claim "compact compile --language-version returns the current
+  version" — runs the command, captures stdout, confirms it outputs a
+  version string.
+
+  Example 3: Claim "compactc rejects undeclared variables with exit code 1"
+  — writes a contract with an undeclared variable, compiles with compactc,
+  checks exit code is non-zero and stderr contains the expected error.
+skills: midnight-verify:verify-by-cli-execution
+model: sonnet
+color: orange
+---
+
+You are a Compact CLI tester.
+
+Load the `midnight-verify:verify-by-cli-execution` skill and follow it step by step. It tells you exactly how to:
+
+1. Check CLI availability (compact and compactc)
+2. Determine the test approach based on claim type
+3. Run the command(s) and capture all output
+4. Interpret the results
+5. Clean up
+
+Follow the skill precisely. The CLI output is your evidence. Do not guess what a command does — run it and observe.
+
+You may load `midnight-tooling:compact-cli` as a hint for understanding CLI flags, compilation patterns, and version management. But the CLI output is your evidence, not the skill content.
+
+**Important:** Always capture full stdout, stderr, and exit code for every command you run. Partial output is not acceptable — the verifier needs the complete picture to synthesize a verdict.

--- a/plugins/midnight-verify/agents/source-investigator.md
+++ b/plugins/midnight-verify/agents/source-investigator.md
@@ -23,6 +23,11 @@ description: >-
   Example 5: Claim "CoinCommitment = Hash<(CoinInfo, CoinPublicKey)>" — searches
   midnightntwrk/midnight-ledger coin-structure crate for the CoinCommitment
   type definition. Uses verify-by-ledger-source for Rust crate-level routing.
+
+  Example 6: Claim "The Compact compiler is written in Scheme" — searches
+  LFDT-Minokawa/compact for the compiler source code, examines file
+  extensions and directory structure. Uses the general verify-by-source
+  skill (tooling source claims route to existing repos).
 skills: midnight-verify:verify-by-source, midnight-verify:verify-by-wallet-source, midnight-verify:verify-by-ledger-source
 model: sonnet
 color: blue

--- a/plugins/midnight-verify/agents/verifier.md
+++ b/plugins/midnight-verify/agents/verifier.md
@@ -56,7 +56,15 @@ description: >-
   orchestrator classifies this as a ledger TypeScript API claim, dispatches
   the type-checker (pre-flight) and source-investigator (primary), and
   optionally runs ledger-v8 execution to call the function and observe output.
-skills: midnight-verify:verify-correctness, midnight-verify:verify-compact, midnight-verify:verify-sdk, midnight-verify:verify-zkir, midnight-verify:verify-witness, midnight-verify:verify-wallet-sdk, midnight-verify:verify-ledger
+
+  Example 12: User runs /verify "--skip-zk skips PLONK key generation" — the
+  orchestrator classifies this as a tooling claim, dispatches the cli-tester
+  agent to compile with and without --skip-zk and compare output directories.
+
+  Example 13: User runs /verify "The Compact compiler is written in Scheme" —
+  the orchestrator classifies this as an internal tooling claim, dispatches
+  the source-investigator to search the LFDT-Minokawa/compact repository.
+skills: midnight-verify:verify-correctness, midnight-verify:verify-compact, midnight-verify:verify-sdk, midnight-verify:verify-zkir, midnight-verify:verify-witness, midnight-verify:verify-wallet-sdk, midnight-verify:verify-ledger, midnight-verify:verify-tooling
 model: sonnet
 color: green
 ---
@@ -74,6 +82,7 @@ You are the Midnight verification orchestrator.
    - Cross-domain → load applicable domain skills
    - Wallet SDK claims → load `midnight-verify:verify-wallet-sdk`
    - Ledger/Protocol claims → load `midnight-verify:verify-ledger`
+   - Tooling claims → load `midnight-verify:verify-tooling`
 3. Follow the hub skill's process exactly.
 
 ## Dispatching Sub-Agents
@@ -112,6 +121,12 @@ You are the Midnight verification orchestrator.
 - Ledger-v8 execution (secondary) → dispatch `midnight-verify:type-checker` in ledger execution mode to call ledger-v8 functions and observe output
 
 **For ledger claims, source investigation always runs.** Secondary methods provide corroborating evidence. Dispatch source-investigator first; dispatch secondary agents concurrently if the claim is testable.
+
+**Tooling verification:**
+- CLI execution (primary) → dispatch `midnight-verify:cli-tester` for behavioral claims (flags, output, errors, versions)
+- Source investigation (secondary) → dispatch `midnight-verify:source-investigator` for internal/architectural claims about the compiler or CLI wrapper
+
+**For tooling claims, prefer CLI execution whenever possible.** The CLI is on the machine — running the command is more authoritative than reading source code. Use source investigation only for claims about internals that can't be observed via CLI output.
 
 **When multiple methods are needed, dispatch agents concurrently.** They are independent and can run in parallel.
 

--- a/plugins/midnight-verify/skills/verify-by-cli-execution/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-by-cli-execution/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: midnight-verify:verify-by-cli-execution
+description: >-
+  Verification by running Compact CLI commands and observing output. Checks
+  CLI availability, runs commands, captures stdout/stderr/exit code, inspects
+  filesystem changes, and interprets results. Covers flag existence, flag
+  behavior, output structure, error messages, exit codes, version info,
+  and CLI-vs-compactc comparisons. Loaded by the cli-tester agent.
+version: 0.1.0
+---
+
+# Verify by CLI Execution
+
+You are verifying a Compact CLI claim by running the actual command and observing what happens. Follow these steps in order.
+
+## Critical Rule
+
+**CLI output is primary evidence.** The command ran and produced this output — that's definitive for behavioral claims. Source code is secondary evidence for internal claims that can't be observed via CLI.
+
+## Using midnight-tooling Skills as Hints
+
+You may consult `midnight-tooling:compact-cli` to understand what flags exist and how the CLI works. This is a **hint only** — the CLI output is your evidence, not the skill content.
+
+## Step 1: Check CLI Availability
+
+```bash
+compact --version 2>&1
+compactc --version 2>&1
+```
+
+If **both** commands fail (command not found), report **Inconclusive (cli unavailable)** and stop:
+
+```
+The Compact CLI is not installed or not on PATH. Install it via
+midnight-tooling:install-cli and retry.
+```
+
+If only one is available, note which one and proceed — some claims are about `compact` specifically vs `compactc`.
+
+## Step 2: Determine the Test Approach
+
+Based on the claim, choose the appropriate test:
+
+### Flag Existence
+
+Check if a flag appears in help output:
+
+```bash
+compact compile --help 2>&1 | grep -i '<flag-name>'
+```
+
+If found → flag exists. If not found → flag does not exist.
+
+### Flag Behavior
+
+Compile a minimal contract with and without the flag, compare results:
+
+```bash
+# Get language version
+LANG_VER=$(compact compile --language-version 2>&1)
+
+# Create job directory
+JOB_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+mkdir -p .midnight-expert/verify/compact-workspace/jobs/$JOB_ID
+
+# Write minimal contract
+cat > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test.compact << COMPACT_EOF
+pragma language_version $LANG_VER;
+import CompactStandardLibrary;
+
+export circuit test(): Field {
+  0
+}
+COMPACT_EOF
+
+# Compile WITHOUT the flag
+compact compile .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test.compact \
+  > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/stdout-without.txt 2>&1
+ls -R .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test/build/ \
+  > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/listing-without.txt 2>&1
+
+# Clean compiled output
+rm -rf .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test/
+
+# Compile WITH the flag
+compact compile --skip-zk .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test.compact \
+  > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/stdout-with.txt 2>&1
+ls -R .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test/build/ \
+  > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/listing-with.txt 2>&1
+```
+
+Compare the two directory listings to identify what the flag changed.
+
+### Output Structure
+
+Compile a minimal contract and inspect the build directory:
+
+```bash
+# After compilation
+find .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test/build/ -type f | sort
+```
+
+Compare the actual file tree against the claimed structure.
+
+### Error Messages
+
+Feed invalid input and capture stderr:
+
+```bash
+# Write intentionally invalid contract
+cat > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/bad.compact << 'COMPACT_EOF'
+<intentionally invalid code targeting the claimed error>
+COMPACT_EOF
+
+compact compile .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/bad.compact 2>&1
+echo "Exit code: $?"
+```
+
+Check that stderr contains the claimed error message (or doesn't, if refuting).
+
+### Exit Codes
+
+Run the command and capture the exit code:
+
+```bash
+compact compile <args> 2>&1
+echo "Exit code: $?"
+```
+
+### Version Info
+
+```bash
+compact --version 2>&1
+compact compile --language-version 2>&1
+compactc --version 2>&1
+```
+
+Parse and compare against the claim.
+
+### CLI vs compactc
+
+Run both and compare behavior:
+
+```bash
+# Via wrapper
+compact compile <args> > stdout-compact.txt 2>&1
+echo "compact exit: $?"
+
+# Via compactc directly
+compactc <args> > stdout-compactc.txt 2>&1
+echo "compactc exit: $?"
+
+# Compare
+diff stdout-compact.txt stdout-compactc.txt
+```
+
+## Step 3: Interpret and Report
+
+Compare the actual output against the claim.
+
+**Report format:**
+
+```
+### CLI Execution Report
+
+**Claim:** [verbatim]
+
+**Command(s) run:**
+\`\`\`bash
+[exact commands with arguments]
+\`\`\`
+
+**Exit code:** [0 / non-zero value]
+
+**stdout:**
+\`\`\`
+[captured output — full, not truncated]
+\`\`\`
+
+**stderr:**
+\`\`\`
+[captured output — full, not truncated]
+\`\`\`
+
+**Filesystem changes:** [new files/directories created, or "N/A" if not relevant]
+
+**Interpretation:** [Confirmed / Refuted / Inconclusive] — [explanation of how the output matches or contradicts the claim]
+```
+
+## Step 4: Clean Up
+
+Remove the job directory if one was created:
+
+```bash
+rm -rf .midnight-expert/verify/compact-workspace/jobs/$JOB_ID
+```
+
+Do NOT remove the base compact-workspace — it is shared across jobs.

--- a/plugins/midnight-verify/skills/verify-correctness/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-correctness/SKILL.md
@@ -28,6 +28,7 @@ Determine what domain the claim belongs to:
 | **Cross-domain** | Spans Compact and SDK, Compact and ZKIR, Witness and ZKIR, or protocol/architecture | Load applicable domain skills |
 | **Wallet SDK** | @midnight-ntwrk/wallet-sdk-* packages, WalletFacade, WalletBuilder, WalletRuntime, RuntimeVariant, DApp Connector API (ConnectedAPI, InitialAPI, window.midnight), HD derivation, Bech32m addresses, branded types (ProtocolVersion, WalletSeed), three-wallet architecture, capabilities (Balancer, ProvingService, SubmissionService) | Load `midnight-verify:verify-wallet-sdk` |
 | **Ledger/Protocol** | Transaction structure (intents, segments, offers, binding), token mechanics (Night UTXO, Zswap commitment/nullifier, Dust generation), cost model (SyntheticCost, fee pricing, block limits), on-chain VM (opcodes, StateValue, stack machine), contract execution (deployment, calls, effects, transcripts), cryptographic primitives (Pedersen, Fiat-Shamir, signatures, Merkle trees), @midnight-ntwrk/ledger-v8 API, well-formedness rules, FAB encoding, formal security properties | Load `midnight-verify:verify-ledger` |
+| **Tooling** | Compact CLI commands (compact compile, compactc), CLI flags (--skip-zk, --language-version, --help), compiler output structure, compiler error messages, exit codes, CLI version/installation, CLI wrapper vs compactc distinction | Load `midnight-verify:verify-tooling` |
 
 ### 2. Load the Domain Skill
 
@@ -62,6 +63,12 @@ Based on the domain skill's routing:
 - Ledger-v8 execution (secondary) → dispatch `midnight-verify:type-checker` agent in ledger execution mode
 
 **For ledger claims, source investigation always runs.** Secondary methods provide corroborating evidence and are dispatched concurrently when the claim is testable.
+
+**Tooling verification:**
+- CLI execution (primary) → dispatch `midnight-verify:cli-tester` agent for behavioral claims
+- Source investigation (secondary) → dispatch `midnight-verify:source-investigator` agent for internal/architectural claims
+
+**For tooling claims, prefer CLI execution.** Running the command is more authoritative than reading source.
 
 - **Multiple methods needed** → dispatch applicable agents **concurrently** (they are independent and can run in parallel)
 
@@ -119,6 +126,12 @@ Collect the sub-agent report(s) and produce the final verdict.
 | **Refuted** | (source-verified) | Rust source contradicts the ledger/protocol claim |
 | **Refuted** | (tested) | Compilation/execution contradicts the claim (ledger domain) |
 | **Inconclusive** | — | Source investigation insufficient, no execution path available (ledger domain) |
+| **Confirmed** | (cli-tested) | Ran the CLI command, output matches the claim (tooling domain) |
+| **Confirmed** | (cli-tested + source-verified) | CLI output and source code both confirm (tooling domain) |
+| **Confirmed** | (source-verified) | Internal claim verified via source, not testable via CLI (tooling domain) |
+| **Refuted** | (cli-tested) | Ran the CLI command, output contradicts the claim (tooling domain) |
+| **Refuted** | (source-verified) | Source contradicts the internal claim (tooling domain) |
+| **Inconclusive** | (cli unavailable) | Compact CLI not installed or not on PATH (tooling domain) |
 
 **Critical rule for wallet SDK claims:** Type-checking is a fast pre-flight only. It NEVER produces a standalone verdict for wallet SDK claims. Every wallet SDK verdict must come from source investigation (or devnet E2E as a fallback). There is no `Confirmed (type-checked)` for wallet SDK claims.
 

--- a/plugins/midnight-verify/skills/verify-tooling/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-tooling/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: midnight-verify:verify-tooling
+description: >-
+  Compact CLI tooling claim classification and method routing. Determines what
+  kind of CLI claim is being verified and which verification method applies:
+  CLI execution (primary for behavioral claims) or source investigation
+  (for internal/architectural claims). Handles claims about compact compile
+  flags, compactc behavior, compiler output structure, error messages, exit
+  codes, version management, and CLI installation. Loaded by the verifier
+  agent alongside the hub skill.
+version: 0.1.0
+---
+
+# Tooling Claim Classification
+
+This skill classifies Compact CLI tooling claims and determines which verification method to use. The verifier (orchestrator) agent loads this alongside the hub skill (`verify-correctness`).
+
+## Distinction from verify-compact
+
+- **verify-compact** handles claims about the Compact *language* — syntax, types, stdlib, disclosure rules, patterns
+- **verify-tooling** handles claims about the CLI *tool* — flags, output structure, error messages, versions, installation
+
+**Routing rule:** If the claim is about what the language allows/disallows, route to verify-compact. If the claim is about what the CLI does when you run it, route here.
+
+**Overlap:** "The compiler rejects X" could be either. If the claim is about a language rule ("you can't assign Field to Uint<8>"), it's Compact. If the claim is about CLI behavior ("the compiler exits with code 1 on syntax errors"), it's tooling.
+
+## Verification Flow
+
+CLI execution is the default. Source investigation is for when you genuinely can't run a command to answer the question.
+
+1. **CLI execution (primary)** — dispatch cli-tester. Run the command, observe stdout/stderr/exit code/filesystem. This is the most authoritative evidence for behavioral claims.
+2. **Source investigation (secondary)** — dispatch source-investigator (uses existing `verify-by-source`). For internal/architectural claims about how the compiler works under the hood.
+
+## Claim Type → Method Routing
+
+| Claim Type | Example | Primary | Secondary |
+|---|---|---|---|
+| Flag existence | "--skip-zk is a valid flag" | cli-tester (run --help, check output) | — |
+| Flag behavior | "--skip-zk skips PLONK key generation" | cli-tester (compile with/without, compare output dirs) | source-investigator |
+| Output structure | "Compilation produces build/contract/index.js" | cli-tester (compile, inspect filesystem) | — |
+| Error messages | "Undeclared variables produce 'not in scope' error" | cli-tester (feed bad input, check stderr) | source-investigator |
+| Exit codes | "Compilation errors exit with non-zero" | cli-tester (run, check $?) | — |
+| Version info | "--language-version returns the current version" | cli-tester (run, parse output) | — |
+| Installation | "compact is installed via npm" | cli-tester (check which compact) | source-investigator |
+| CLI vs compactc | "compact compile invokes compactc" | cli-tester (run both, compare) | source-investigator |
+| Compiler internals | "The compiler is written in Scheme" | source-investigator | — |
+| CLI wrapper internals | "compact is a shell script wrapper" | source-investigator | cli-tester (file type check) |
+
+### Routing Rules
+
+**When in doubt:**
+- If you can answer the question by running a command → cli-tester
+- If you need to read source code to understand internal behavior → source-investigator
+- If both apply → dispatch both concurrently
+
+**CLI execution is preferred whenever possible.** The command ran and produced this output — that's more authoritative than reading source code about what the output *should* be.
+
+## Hints from Existing Skills
+
+The cli-tester may consult this skill for context. It is a **hint only** — never cite it as evidence.
+
+- `midnight-tooling:compact-cli` — expected flags, compilation patterns, version management


### PR DESCRIPTION
## Summary

- Add tooling verification domain to `midnight-verify` plugin — new `verify-tooling` routing skill, `verify-by-cli-execution` method skill, and `cli-tester` agent that runs Compact CLI commands and observes output (stdout, stderr, exit code, filesystem changes)
- Update verifier orchestrator, verify-correctness hub, and source-investigator with tooling domain routing, dispatch rules, and verdict qualifiers
- New `cli-tested` verdict qualifier for claims verified by running the actual CLI
- Bump versions: midnight-verify 0.7.0, marketplace 0.13.0

## Test plan

- [ ] Verify `verify-tooling` domain skill loads via `/verify "--skip-zk skips PLONK key generation"`
- [ ] Verify `cli-tester` agent runs `compact compile --help` and parses flag existence
- [ ] Verify `cli-tester` compiles with/without `--skip-zk` and compares output directories
- [ ] Verify `Inconclusive (cli unavailable)` returned when Compact CLI not on PATH
- [ ] Verify internal claims like "compiler is written in Scheme" route to source-investigator
- [ ] Verify 8 agents listed: 7 existing + cli-tester

Generated with [Claude Code](https://claude.com/claude-code)