### PR TITLE
fix(midnight-tooling): fact-check 165 claims, fix 4 errors

### DIFF
--- a/plugins/midnight-tooling/skills/devnet/references/compose-structure.md
+++ b/plugins/midnight-tooling/skills/devnet/references/compose-structure.md
@@ -88,7 +88,7 @@ indexer:
 | `APP__INFRA__NODE__URL` | WebSocket connection to the node. Uses Docker internal DNS name `node` (the service name), not `localhost`. |
 | `APP__INFRA__STORAGE__PASSWORD`, `PUB_SUB__PASSWORD`, `LEDGER_STATE_STORAGE__PASSWORD` | Internal service passwords. These are dev defaults — all set to `indexer`. Only relevant inside the container. |
 | `APP__INFRA__SECRET` | Internal encryption secret for the indexer. Dev default — hex-encoded bytes. |
-| `healthcheck` | Checks for the existence of `/var/run/indexer-standalone/running` — a file the indexer creates once it's finished startup and is actively indexing. Longer `interval` (10s) and `start_period` (10s) because the indexer takes longer to initialize than the node. |
+| `healthcheck` | Checks for the existence of `/var/run/indexer-standalone/running` — a process-presence sentinel file created by the entrypoint script before launching the indexer binary, and removed on container exit. Its presence indicates the container is alive and the indexer process has been started. Longer `interval` (10s) and `start_period` (10s) because the indexer takes longer to initialize than the node. |
 | `depends_on` | Waits for the node's healthcheck to pass before starting. This ensures the node's RPC endpoint is ready before the indexer tries to connect. |
 
 ### Proof Server (`midnight-proof-server`)

--- a/plugins/midnight-tooling/skills/troubleshooting/references/environment-tooling.md
+++ b/plugins/midnight-tooling/skills/troubleshooting/references/environment-tooling.md
@@ -137,10 +137,9 @@ mise env
    compact --version
    ```
 4. **Open a new terminal** if environment tool configurations were changed during the switch.
-5. Reinstall the desired compiler version:
+5. Reinstall the desired compiler version and set it as default:
    ```bash
-   compact install <version>
-   compact use <version>
+   compact update <version>
    ```
 
 ## Claude Code Settings for COMPACT_DIRECTORY

--- a/plugins/midnight-tooling/skills/troubleshooting/references/err-unsupported-dir-import.md
+++ b/plugins/midnight-tooling/skills/troubleshooting/references/err-unsupported-dir-import.md
@@ -9,7 +9,7 @@ This error occurs when Node.js attempts to import a directory instead of a speci
 - **Stale terminal environment** after updating `~/.zshrc`, `~/.bashrc`, or similar shell config
 - **Node version switch** without opening a new terminal (e.g., after `nvm install` or `nvm alias default`)
 - **Environment variable changes** that haven't taken effect in the current shell session
-- **Incorrect Node version** - Midnight requires Node 18+
+- **Incorrect Node version** - Midnight requires Node 22+
 
 ## Fix
 
@@ -19,7 +19,7 @@ Do **not** just run `source ~/.zshrc` - this does not fully reset the shell envi
 
 ### 2. Verify the Node Version
 
-Midnight requires Node 18 or later.
+Midnight requires Node 22 or later.
 
 ```bash
 node --version
@@ -31,11 +31,11 @@ If a `.nvmrc` file exists in the project, use it:
 nvm use
 ```
 
-If the version is below 18, install and switch:
+If the version is below 22, install and switch:
 
 ```bash
-nvm install 18
-nvm use 18
+nvm install 22
+nvm use 22
 ```
 
 ### 3. Clear Module Caches


### PR DESCRIPTION
## Summary

- Fast-checked the `midnight-tooling` plugin (33 files, 165 claims extracted, 19 source-verified)
- Fixed 4 refuted claims across 3 files:
  - **Node.js version**: 18+ → 22+ (per `midnight-js` `engines: { node: ">=22" }`)
  - **`compact install <version>`**: nonexistent subcommand → `compact update <version>`
  - **`compact use <version>`**: nonexistent subcommand → `compact update <version>`
  - **Indexer healthcheck description**: "once it finishes startup" → process-presence sentinel (file is created *before* binary launches)

## Test plan

- [ ] Verify `err-unsupported-dir-import.md` references Node 22 consistently
- [ ] Verify `environment-tooling.md` uses `compact update` instead of `compact install`/`compact use`
- [ ] Verify `compose-structure.md` healthcheck description matches `entrypoint.sh` behavior

Generated with [Claude Code](https://claude.com/claude-code)