### PR TITLE
fix(core-concepts): verify and fix all Compact code compilation

### DIFF
--- a/plugins/core-concepts/skills/data-models/examples/token-handling.compact
+++ b/plugins/core-concepts/skills/data-models/examples/token-handling.compact
@@ -33,7 +33,7 @@
 //                  recipient: Either<ContractAddress, UserAddress>): []
 //   mintShieldedToken(domainSep: Bytes<32>, amount: Uint<64>,
 //                     nonce: Bytes<32>,
-//                     recipient: Either<ZswapCoinPublicKey, ContractAddress>): CoinInfo
+//                     recipient: Either<ZswapCoinPublicKey, ContractAddress>): ShieldedCoinInfo
 //   mintUnshieldedToken(domainSep: Bytes<32>, amount: Uint<64>,
 //                       recipient: Either<ContractAddress, UserAddress>): Bytes<32>
 //   nativeToken(): Bytes<32>
@@ -91,7 +91,7 @@ witness get_token_color(): Bytes<32>;
 // receiveShielded() adds the coin to the Zswap state as a shielded output.
 export circuit receivePayment(): [] {
   const coin = get_coin();
-  receiveShielded(coin);
+  receiveShielded(disclose(coin));
   received_count.increment(1);
 }
 
@@ -105,9 +105,9 @@ export circuit receivePayment(): [] {
 export circuit sendReward(amount: Uint<128>): ShieldedSendResult {
   const input = get_shielded_input();
   const recipientKey = get_recipient_key();
-  const recipient = left<ZswapCoinPublicKey, ContractAddress>(recipientKey);
+  const recipient = left<ZswapCoinPublicKey, ContractAddress>(disclose(recipientKey));
 
-  return sendShielded(input, recipient, disclose(amount));
+  return disclose(sendShielded(disclose(input), recipient, disclose(amount)));
 }
 
 // =============================================================================
@@ -131,7 +131,7 @@ export circuit receiveUnshieldedPayment(color: Bytes<32>, amount: Uint<128>): []
 // The color, amount, and recipient are all publicly visible on-chain.
 export circuit sendUnshieldedReward(color: Bytes<32>, amount: Uint<128>): [] {
   const userAddr = get_user_address();
-  const recipient = right<ContractAddress, UserAddress>(userAddr);
+  const recipient = right<ContractAddress, UserAddress>(disclose(userAddr));
 
   sendUnshielded(disclose(color), disclose(amount), recipient);
 }
@@ -157,9 +157,9 @@ export circuit sendUnshieldedToSelf(color: Bytes<32>, amount: Uint<128>): [] {
 export circuit mintShielded(
   amount: Uint<64>,
   domain_separator: Bytes<32>
-): CoinInfo {
+): ShieldedCoinInfo {
   const recipientKey = get_recipient_key();
-  const recipient = left<ZswapCoinPublicKey, ContractAddress>(recipientKey);
+  const recipient = left<ZswapCoinPublicKey, ContractAddress>(disclose(recipientKey));
   const nonce = get_nonce();
 
   const newCoin = mintShieldedToken(
@@ -184,7 +184,7 @@ export circuit mintUnshielded(
   domain_separator: Bytes<32>
 ): Bytes<32> {
   const userAddr = get_user_address();
-  const recipient = right<ContractAddress, UserAddress>(userAddr);
+  const recipient = right<ContractAddress, UserAddress>(disclose(userAddr));
 
   const tokenId = mintUnshieldedToken(
     disclose(domain_separator),

--- a/plugins/core-concepts/skills/privacy-patterns/examples/auth-patterns.compact
+++ b/plugins/core-concepts/skills/privacy-patterns/examples/auth-patterns.compact
@@ -151,6 +151,13 @@ export ledger memberActionNullifiers: Set<Bytes<32>>;
 witness getAdminPath(pk: Bytes<32>): MerkleTreePath<8, Bytes<32>>;
 witness getMemberPath(pk: Bytes<32>): MerkleTreePath<16, Bytes<32>>;
 
+// Derive a public key from a secret key for role-based access
+circuit get_public_key(sk: Bytes<32>): Bytes<32> {
+  return persistentHash<Vector<2, Bytes<32>>>([
+    pad(32, "roles:pk:"), sk
+  ]);
+}
+
 // Internal circuit to verify admin role
 circuit requireAdmin(): [] {
   const sk = local_secret_key();


### PR DESCRIPTION
## Summary

- Verified all 6 standalone `.compact` files and 11 complete code blocks from 10 markdown files in `plugins/core-concepts/skills/` against the Compact compiler (v0.30.0, language v0.22.0)
- Fixed 2 compilation errors in standalone `.compact` files; remaining 4 files and all markdown code blocks compiled without changes
- 60+ markdown code block fragments (no pragma) were correctly classified and skipped

## Fixes

**`data-models/examples/token-handling.compact`** (2 issues):
1. Changed return type `CoinInfo` to `ShieldedCoinInfo` on `mintShielded()` -- `CoinInfo` is not a valid stdlib type; `mintShieldedToken()` returns `ShieldedCoinInfo`
2. Added missing `disclose()` calls on witness-derived values passed to `receiveShielded`, `sendShielded`, `sendUnshielded`, and `mintUnshieldedToken` stdlib functions

**`privacy-patterns/examples/auth-patterns.compact`** (1 issue):
1. Added missing `get_public_key()` helper circuit -- Pattern 3 (role-based access) referenced this function but it was never defined in the file

## Verification Results

| Category | Total | Passed | Fixed | Skipped |
|----------|-------|--------|-------|---------|
| Standalone .compact files | 6 | 4 | 2 | 0 |
| Markdown complete contracts | 11 | 11 | 0 | 0 |
| Markdown fragments | 60+ | -- | -- | 60+ (no pragma) |

## Test plan

- [x] All 6 standalone `.compact` files compile with `compact compile -- --skip-zk`
- [x] All 11 complete markdown code blocks compile with `compact compile -- --skip-zk`
- [x] No non-Compact content modified in any file

Generated with [Claude Code](https://claude.com/claude-code)