### PR TITLE
fix(compact-core): rename reserved keyword in token balance pattern

### DIFF
--- a/plugins/compact-core/skills/compact-structure/references/patterns.md
+++ b/plugins/compact-core/skills/compact-structure/references/patterns.md
@@ -260,16 +260,16 @@ export circuit mint(to: Bytes<32>, amount: Uint<64>): [] {
 
 export circuit transfer(to: Bytes<32>, amount: Uint<64>): [] {
   const sk = local_secret_key();
-  const from = get_public_key(sk);
-  const d_from = disclose(from);
+  const sender = get_public_key(sk);
+  const d_sender = disclose(sender);
   const d_to = disclose(to);
   const d_amount = disclose(amount);
 
-  assert(balances.member(d_from), "No balance");
-  const senderBalance = balances.lookup(d_from);
+  assert(balances.member(d_sender), "No balance");
+  const senderBalance = balances.lookup(d_sender);
   assert(senderBalance >= d_amount, "Insufficient balance");
 
-  balances.insert(d_from, (senderBalance - d_amount) as Uint<64>);
+  balances.insert(d_sender, (senderBalance - d_amount) as Uint<64>);
 
   if (balances.member(d_to)) {
     const receiverBalance = balances.lookup(d_to);


### PR DESCRIPTION
## Summary
- Renamed variable `from` to `sender` (and `d_from` to `d_sender`) in the Token Balance Pattern code block in `plugins/compact-core/skills/compact-structure/references/patterns.md`
- `from` is a reserved keyword in Compact, causing a parse error: `found keyword "from" looking for a const binding`

## Verification Results (Unit 7 — compact-core Structure & Ledger)

**Scope:** 10 markdown files across `compact-structure/` and `compact-ledger/` skills

| Metric | Count |
|--------|-------|
| Total Compact code blocks found | 133 |
| Complete contracts (with pragma) | 8 compiled |
| Complete contracts skipped (include/intentional errors) | 3 |
| Fragments (no pragma) | 122 |
| Compilation failures found | 1 |
| Fixes applied | 1 |

### Compiled contracts (all pass):
1. `compact-structure/SKILL.md` — Contract anatomy example
2. `compact-structure/references/patterns.md` — Authentication pattern
3. `compact-structure/references/patterns.md` — Commit-Reveal pattern
4. `compact-structure/references/patterns.md` — Access Control with Roles
5. `compact-structure/references/patterns.md` — Merkle Tree Membership Proof
6. `compact-structure/references/patterns.md` — State Machine pattern
7. `compact-structure/references/patterns.md` — Token Balance pattern (FIXED)
8. `compact-structure/SKILL.md` — Pragma+import (trivial, compiles)

### Skipped complete contracts:
- `circuits-and-witnesses.md` module organization example (uses `include` with nonexistent files)
- `common-mistakes.md` pragma format examples (intentionally broken)

## Test plan
- [x] All 8 complete contracts compile with `compact compile -- --skip-zk`
- [x] Fixed token balance contract verified post-fix
- [x] No non-Compact content modified
- [x] Surrounding documentation text preserved

Generated with [Claude Code](https://claude.com/claude-code)