### PR TITLE
fix(compact-core): fix disclosure and type errors in pattern references

### DIFF
--- a/plugins/compact-core/skills/compact-patterns/references/access-control-patterns.md
+++ b/plugins/compact-core/skills/compact-patterns/references/access-control-patterns.md
@@ -117,8 +117,8 @@ constructor() {
 // Guard: require caller to have a specific role
 circuit requireRole(required: Role): [] {
   const sk = local_secret_key();
-  const caller = get_public_key(sk);
-  assert(disclose(roles.member(caller)), "No role assigned");
+  const caller = disclose(get_public_key(sk));
+  assert(roles.member(caller), "No role assigned");
   assert(disclose(roles.lookup(caller) == required), "Insufficient permissions");
 }
 

--- a/plugins/compact-core/skills/compact-patterns/references/commitment-patterns.md
+++ b/plugins/compact-core/skills/compact-patterns/references/commitment-patterns.md
@@ -192,14 +192,14 @@ export circuit submitBid(bidAmount: Uint<64>): [] {
   assert(auctionPhase == AuctionPhase.bidding, "Bidding closed");
   assert(blockTimeLt(bidDeadline), "Bid deadline passed");
   const sk = local_secret_key();
-  const pk = get_public_key(sk);
-  assert(disclose(!bidCommitments.member(pk)), "Already submitted a bid");
+  const pk = disclose(get_public_key(sk));
+  assert(!bidCommitments.member(pk), "Already submitted a bid");
   const salt = get_randomness();
   // Do NOT disclose bidAmount here — the hash hides it
   const amountBytes = (bidAmount as Field) as Bytes<32>;
   const commitment = persistentHash<Vector<2, Bytes<32>>>([amountBytes, salt]);
   storeBidOpening(salt, bidAmount);
-  bidCommitments.insert(disclose(pk), disclose(commitment));
+  bidCommitments.insert(pk, disclose(commitment));
 }
 
 // Advance to reveal phase (anyone can call after deadline)
@@ -214,16 +214,16 @@ export circuit revealBid(): [] {
   assert(auctionPhase == AuctionPhase.revealing, "Not in reveal phase");
   assert(blockTimeLt(revealDeadline), "Reveal deadline passed");
   const sk = local_secret_key();
-  const pk = get_public_key(sk);
-  assert(disclose(bidCommitments.member(pk)), "No bid commitment found");
-  assert(disclose(!revealedBids.member(pk)), "Already revealed");
+  const pk = disclose(get_public_key(sk));
+  assert(bidCommitments.member(pk), "No bid commitment found");
+  assert(!revealedBids.member(pk), "Already revealed");
   const opening = getBidOpening();
   const salt = opening[0];
   const amount = opening[1];
   const amountBytes = (disclose(amount) as Field) as Bytes<32>;
   const expected = persistentHash<Vector<2, Bytes<32>>>([amountBytes, salt]);
   assert(disclose(expected == bidCommitments.lookup(pk)), "Bid commitment mismatch");
-  revealedBids.insert(disclose(pk), disclose(amount));
+  revealedBids.insert(pk, disclose(amount));
   // Track highest bid
   if (disclose(amount) > highestBid) {
     highestBid = disclose(amount);

--- a/plugins/compact-core/skills/compact-patterns/references/governance-patterns.md
+++ b/plugins/compact-core/skills/compact-patterns/references/governance-patterns.md
@@ -45,8 +45,8 @@ constructor(requiredApprovals: Uint<64>) {
 
 circuit requireSigner(): Bytes<32> {
   const sk = local_secret_key();
-  const pk = get_public_key(sk);
-  assert(disclose(signers.member(pk)), "Not an authorized signer");
+  const pk = disclose(get_public_key(sk));
+  assert(signers.member(pk), "Not an authorized signer");
   return pk;
 }
 
@@ -71,8 +71,8 @@ export circuit propose(data: Bytes<32>): [] {
 export circuit approve(): [] {
   const pk = requireSigner();
   assert(proposalActive, "No active proposal");
-  assert(disclose(!approvals.member(pk)), "Already approved");
-  approvals.insert(disclose(pk), true);
+  assert(!approvals.member(pk), "Already approved");
+  approvals.insert(pk, true);
   approvalCount.increment(1);
 }
 

--- a/plugins/compact-core/skills/compact-patterns/references/identity-membership-patterns.md
+++ b/plugins/compact-core/skills/compact-patterns/references/identity-membership-patterns.md
@@ -43,8 +43,8 @@ circuit requireAdmin(): [] {
 // Guard: require caller to be on the allowlist
 circuit requireAllowlisted(): [] {
   const sk = local_secret_key();
-  const pk = get_public_key(sk);
-  assert(disclose(allowlist.member(pk)), "Not on allowlist");
+  const pk = disclose(get_public_key(sk));
+  assert(allowlist.member(pk), "Not on allowlist");
 }
 
 // Admin adds an address to the allowlist
@@ -114,15 +114,15 @@ import CompactStandardLibrary;
 export ledger credentialCommitment: Bytes<32>;
 export ledger isCredentialSet: Boolean;
 
-witness getCredentialValue(): Field;
+witness getCredentialValue(): Uint<64>;
 witness getCredentialSalt(): Bytes<32>;
-witness storeCredential(value: Field, salt: Bytes<32>): [];
+witness storeCredential(value: Uint<64>, salt: Bytes<32>): [];
 
 // Issue a credential: commit the value on-chain, store value off-chain
-export circuit issueCredential(value: Field): [] {
+export circuit issueCredential(value: Uint<64>): [] {
   assert(!isCredentialSet, "Credential already issued");
   const salt = getCredentialSalt();
-  const commitment = persistentCommit<Field>(value, salt);
+  const commitment = persistentCommit<Uint<64>>(value, salt);
   storeCredential(value, salt);
   credentialCommitment = disclose(commitment);
   isCredentialSet = true;
@@ -130,13 +130,13 @@ export circuit issueCredential(value: Field): [] {
 
 // Verify: prove the credential value meets a threshold
 // Only the boolean result is disclosed — NOT the actual value
-export circuit verifyThreshold(threshold: Field): Boolean {
+export circuit verifyThreshold(threshold: Uint<64>): Boolean {
   assert(isCredentialSet, "No credential issued");
   const value = getCredentialValue();
   const salt = getCredentialSalt();
 
   // Verify the witness value matches the on-chain commitment
-  const expected = persistentCommit<Field>(value, salt);
+  const expected = persistentCommit<Uint<64>>(value, salt);
   assert(disclose(expected == credentialCommitment), "Invalid credential");
 
   // Disclose only the boolean result, NOT the value
@@ -144,11 +144,11 @@ export circuit verifyThreshold(threshold: Field): Boolean {
 }
 
 // Verify: prove the credential value is within a range
-export circuit verifyRange(minimum: Field, maximum: Field): Boolean {
+export circuit verifyRange(minimum: Uint<64>, maximum: Uint<64>): Boolean {
   assert(isCredentialSet, "No credential issued");
   const value = getCredentialValue();
   const salt = getCredentialSalt();
-  const expected = persistentCommit<Field>(value, salt);
+  const expected = persistentCommit<Uint<64>>(value, salt);
   assert(disclose(expected == credentialCommitment), "Invalid credential");
 
   // Disclose the combined range check as a single boolean
@@ -330,11 +330,11 @@ export circuit memberAction(): [] {
   assert(members.checkRoot(disclose(digest)), "Not a member");
 
   // Step 4: Nullifier prevents reuse
-  const nul = persistentHash<Vector<2, Bytes<32>>>([
+  const nul = disclose(persistentHash<Vector<2, Bytes<32>>>([
     pad(32, "myapp:member:act-nul:"), sk
-  ]);
-  assert(disclose(!usedNullifiers.member(nul)), "Already acted");
-  usedNullifiers.insert(disclose(nul));
+  ]));
+  assert(!usedNullifiers.member(nul), "Already acted");
+  usedNullifiers.insert(nul);
 
   // ... perform the action
 }

--- a/plugins/compact-core/skills/compact-patterns/references/privacy-patterns.md
+++ b/plugins/compact-core/skills/compact-patterns/references/privacy-patterns.md
@@ -121,42 +121,42 @@ import CompactStandardLibrary;
 
 export ledger credentialCommitment: Bytes<32>;
 
-witness getCredentialValue(): Field;
+witness getCredentialValue(): Uint<64>;
 witness getCredentialSalt(): Bytes<32>;
 
 // Verify the witness value matches the on-chain commitment,
 // then disclose ONLY the boolean result of the comparison
-circuit verifyCredential(): Field {
+circuit verifyCredential(): Uint<64> {
   const value = getCredentialValue();
   const salt = getCredentialSalt();
-  const expected = persistentCommit<Field>(value, salt);
+  const expected = persistentCommit<Uint<64>>(value, salt);
   assert(disclose(expected == credentialCommitment), "Invalid credential");
   return value;
 }
 
 // Threshold check: prove value >= threshold
-export circuit meetsThreshold(threshold: Field): Boolean {
+export circuit meetsThreshold(threshold: Uint<64>): Boolean {
   const value = verifyCredential();
   // ONLY the boolean result is disclosed, NOT the value
   return disclose(value >= threshold);
 }
 
 // Range check: prove value is within bounds
-export circuit withinRange(minimum: Field, maximum: Field): Boolean {
+export circuit withinRange(minimum: Uint<64>, maximum: Uint<64>): Boolean {
   const value = verifyCredential();
   return disclose(value >= minimum && value <= maximum);
 }
 
 // Equality check: prove value equals a specific target
-export circuit equalsValue(target: Field): Boolean {
+export circuit equalsValue(target: Uint<64>): Boolean {
   const value = verifyCredential();
   return disclose(value == target);
 }
 
 // Selective field disclosure from a multi-field profile
-witness getProfile(): [Bytes<32>, Field, Field];
+witness getProfile(): [Bytes<32>, Uint<64>, Uint<64>];
 
-export circuit proveAgeAbove(minAge: Field): Boolean {
+export circuit proveAgeAbove(minAge: Uint<64>): Boolean {
   const profile = getProfile();
   // profile[0] = name (NOT disclosed)
   // profile[1] = age (comparison result disclosed)
@@ -164,7 +164,7 @@ export circuit proveAgeAbove(minAge: Field): Boolean {
   return disclose(profile[1] >= minAge);
 }
 
-export circuit proveIncomeInRange(minIncome: Field, maxIncome: Field): Boolean {
+export circuit proveIncomeInRange(minIncome: Uint<64>, maxIncome: Uint<64>): Boolean {
   const profile = getProfile();
   // Only the income range check is disclosed
   return disclose(profile[2] >= minIncome && profile[2] <= maxIncome);


### PR DESCRIPTION
## Summary
- Fix disclosure placement in 5 compact-patterns reference files — `disclose()` must wrap witness-derived values before passing to ledger operations (`member()`, `lookup()`, `insert()`), not wrap the ledger operation result
- Change `Field` to `Uint<64>` for credential/profile values that use relational operators (`>=`, `<=`) since Compact's `Field` type does not support relational comparisons

## Files Changed
- `plugins/compact-core/skills/compact-patterns/references/access-control-patterns.md`
- `plugins/compact-core/skills/compact-patterns/references/commitment-patterns.md`
- `plugins/compact-core/skills/compact-patterns/references/governance-patterns.md`
- `plugins/compact-core/skills/compact-patterns/references/identity-membership-patterns.md`
- `plugins/compact-core/skills/compact-patterns/references/privacy-patterns.md`

## Test plan
- [x] All complete Compact code blocks in these files verified by compilation with `compact compile -- --skip-zk`
- [x] Fixes preserve pedagogical intent of documentation

Generated with [Claude Code](https://claude.com/claude-code)