### PR TITLE
fix(compact-examples): verify and fix OpenZeppelin modules (Unit 5)

### DIFF
--- a/plugins/compact-examples/skills/openzeppelin/examples/AccessControlledToken.compact
+++ b/plugins/compact-examples/skills/openzeppelin/examples/AccessControlledToken.compact
@@ -9,9 +9,9 @@
 pragma language_version >= 0.22.0;
 
 import CompactStandardLibrary;
-import "./compact-contracts/node_modules/@openzeppelin-compact/contracts/src/access/AccessControl"
+import "./modules/access/AccessControl"
   prefix AccessControl_;
-import "./compact-contracts/node_modules/@openzeppelin-compact/contracts/src/token/FungibleToken"
+import "./modules/token/FungibleToken"
   prefix FungibleToken_;
 
 export sealed ledger MINTER_ROLE: Bytes<32>;

--- a/plugins/compact-examples/skills/openzeppelin/examples/FungibleTokenMintablePausableOwnable.compact
+++ b/plugins/compact-examples/skills/openzeppelin/examples/FungibleTokenMintablePausableOwnable.compact
@@ -9,11 +9,11 @@
 pragma language_version >= 0.22.0;
 
 import CompactStandardLibrary;
-import "./compact-contracts/node_modules/@openzeppelin-compact/contracts/src/access/Ownable"
+import "./modules/access/Ownable"
   prefix Ownable_;
-import "./compact-contracts/node_modules/@openzeppelin-compact/contracts/src/security/Pausable"
+import "./modules/security/Pausable"
   prefix Pausable_;
-import "./compact-contracts/node_modules/@openzeppelin-compact/contracts/src/token/FungibleToken"
+import "./modules/token/FungibleToken"
   prefix FungibleToken_;
 
 constructor(

--- a/plugins/compact-examples/skills/openzeppelin/examples/MultiTokenTwoTypes.compact
+++ b/plugins/compact-examples/skills/openzeppelin/examples/MultiTokenTwoTypes.compact
@@ -9,7 +9,7 @@
 pragma language_version >= 0.22.0;
 
 import CompactStandardLibrary;
-import "./compact-contracts/node_modules/@openzeppelin-compact/contracts/src/token/MultiToken"
+import "./modules/token/MultiToken"
   prefix MultiToken_;
 
 constructor(

--- a/plugins/compact-examples/skills/openzeppelin/examples/SimpleNonFungibleToken.compact
+++ b/plugins/compact-examples/skills/openzeppelin/examples/SimpleNonFungibleToken.compact
@@ -9,7 +9,7 @@
 pragma language_version >= 0.22.0;
 
 import CompactStandardLibrary;
-import "./compact-contracts/node_modules/@openzeppelin-compact/contracts/src/token/NonFungibleToken"
+import "./modules/token/NonFungibleToken"
   prefix NonFungibleToken_;
 
 constructor(

--- a/plugins/compact-examples/skills/openzeppelin/references/initializable-pausable.md
+++ b/plugins/compact-examples/skills/openzeppelin/references/initializable-pausable.md
@@ -26,7 +26,7 @@ export circuit doSomethingBeforeInitialized(): [] {
 
 export circuit setFieldAfterDeployment(f: Field): [] {
   Initializable_initialize();
-  _fieldAfterDeployment = f;
+  _fieldAfterDeployment = disclose(f);
 }
 
 export circuit checkFieldAfterDeployment(): Field {


### PR DESCRIPTION
## Summary

- Verified all 22 standalone `.compact` files in `plugins/compact-examples/skills/openzeppelin/` compile against Compact compiler v0.30.0 (language version 0.22.0)
- Fixed import paths in 4 composed contract examples from unresolvable npm paths to local relative paths
- Fixed missing `disclose()` call in `initializable-pausable.md` code example
- Verified 13 complete contract code blocks extracted from 11 markdown files compile correctly

## Results

### Standalone .compact files: 22 checked / 22 passed / 0 failed / 5 fixed

**Base modules (all passed without changes):**
- Utils.compact, Pausable.compact, Initializable.compact
- Ownable.compact, AccessControl.compact, ZOwnablePK.compact
- FungibleToken.compact, MultiToken.compact, NonFungibleToken.compact

**Mocks (all passed without changes):**
- MockUtils, MockPausable, MockInitializable, MockOwnable, MockAccessControl, MockZOwnablePK
- MockFungibleToken, MockMultiToken, MockNonFungibleToken

**Composed contracts (4 fixed, 1 fixed in markdown):**
- `FungibleTokenMintablePausableOwnable.compact`: changed imports to local relative paths
- `AccessControlledToken.compact`: changed imports to local relative paths
- `MultiTokenTwoTypes.compact`: changed imports to local relative paths
- `SimpleNonFungibleToken.compact`: changed imports to local relative paths

### Markdown code blocks: 20 found / 13 complete contracts compiled / 7 fragments skipped

**Fixed:** `references/initializable-pausable.md` line 29: `_fieldAfterDeployment = f` -> `_fieldAfterDeployment = disclose(f)` (witness-value disclosure error)

**All 13 complete contracts compiled successfully** (via symlinked npm path resolution)

## Test plan

- [x] All 22 `.compact` files compile with `compact compile -- --skip-zk`
- [x] All 13 complete contract code blocks in markdown compile
- [x] No changes to non-Compact content in markdown files

Generated with [Claude Code](https://claude.com/claude-code)