### PR TITLE
fix(midnight-mcp): fix mcp-simulate example contracts for Compact v0.30.0

### DIFF
--- a/plugins/midnight-mcp/skills/mcp-simulate/examples/access-control-contract.md
+++ b/plugins/midnight-mcp/skills/mcp-simulate/examples/access-control-contract.md
@@ -10,13 +10,17 @@ import CompactStandardLibrary;
 export ledger owner: Bytes<32>;
 export ledger data: Counter;
 
+witness local_secret_key(): Bytes<32>;
+
 export circuit transferOwnership(newOwner: Bytes<32>): [] {
-  assert(caller == owner, "caller must be owner");
-  owner = newOwner;
+  const caller_id = disclose(local_secret_key());
+  assert(caller_id == owner, "caller must be owner");
+  owner = disclose(newOwner);
 }
 
 export circuit restricted(): [] {
-  assert(caller == owner, "caller must be owner");
+  const caller_id = disclose(local_secret_key());
+  assert(caller_id == owner, "caller must be owner");
   data.increment(1);
 }
 

--- a/plugins/midnight-mcp/skills/mcp-simulate/examples/token-contract.md
+++ b/plugins/midnight-mcp/skills/mcp-simulate/examples/token-contract.md
@@ -10,22 +10,29 @@ import CompactStandardLibrary;
 export ledger balances: Map<Bytes<32>, Uint<64>>;
 export ledger owner: Bytes<32>;
 
+witness local_secret_key(): Bytes<32>;
+
 export circuit mint(amount: Uint<64>): [] {
-  assert(caller == owner, "only owner can mint");
-  const current = balances.lookup(disclose(caller)).with_default(0);
-  balances.insert(disclose(caller), current + amount);
+  const caller_id = disclose(local_secret_key());
+  assert(caller_id == owner, "only owner can mint");
+  const disclosed_amount = disclose(amount);
+  const current = balances.lookup(caller_id);
+  balances.insert(caller_id, (current + disclosed_amount) as Uint<64>);
 }
 
 export circuit transfer(amount: Uint<64>, to: Bytes<32>): [] {
-  const senderBalance = balances.lookup(disclose(caller)).with_default(0);
-  assert(senderBalance >= amount, "insufficient balance");
-  balances.insert(disclose(caller), senderBalance - amount);
-  const receiverBalance = balances.lookup(to).with_default(0);
-  balances.insert(to, receiverBalance + amount);
+  const caller_id = disclose(local_secret_key());
+  const disclosed_amount = disclose(amount);
+  const disclosed_to = disclose(to);
+  const senderBalance = balances.lookup(caller_id);
+  assert(senderBalance >= disclosed_amount, "insufficient balance");
+  balances.insert(caller_id, (senderBalance - disclosed_amount) as Uint<64>);
+  const receiverBalance = balances.lookup(disclosed_to);
+  balances.insert(disclosed_to, (receiverBalance + disclosed_amount) as Uint<64>);
 }
 
 export circuit getBalance(user: Bytes<32>): Uint<64> {
-  return balances.lookup(user).with_default(0);
+  return balances.lookup(disclose(user));
 }
 ```
 

--- a/plugins/midnight-mcp/skills/mcp-simulate/examples/voting-contract.md
+++ b/plugins/midnight-mcp/skills/mcp-simulate/examples/voting-contract.md
@@ -13,18 +13,23 @@ export ledger voters: Map<Bytes<32>, Boolean>;
 export ledger votingOpen: Boolean;
 export ledger owner: Bytes<32>;
 
+witness local_secret_key(): Bytes<32>;
+
 export circuit openVoting(): [] {
-  assert(caller == owner, "only owner can open voting");
+  const caller_id = disclose(local_secret_key());
+  assert(caller_id == owner, "only owner can open voting");
   votingOpen = true;
 }
 
 export circuit vote(option: Uint<64>): [] {
   assert(votingOpen == true, "voting is closed");
-  const hasVoted = voters.lookup(disclose(caller)).with_default(false);
+  const caller_id = disclose(local_secret_key());
+  const hasVoted = voters.lookup(caller_id);
   assert(hasVoted == false, "already voted");
-  voters.insert(disclose(caller), true);
-  assert(option == 0 || option == 1, "invalid option");
-  if option == 0 {
+  voters.insert(caller_id, true);
+  const disclosed_option = disclose(option);
+  assert(disclosed_option == 0 || disclosed_option == 1, "invalid option");
+  if (disclosed_option == 0) {
     votesA.increment(1);
   } else {
     votesB.increment(1);
@@ -32,7 +37,8 @@ export circuit vote(option: Uint<64>): [] {
 }
 
 export circuit closeVoting(): [] {
-  assert(caller == owner, "only owner can close voting");
+  const caller_id = disclose(local_secret_key());
+  assert(caller_id == owner, "only owner can close voting");
   votingOpen = false;
 }
 


### PR DESCRIPTION
## Summary
- Replace non-existent `caller` built-in with `local_secret_key()` witness pattern and proper `disclose()` wrapping in 3 mcp-simulate example contracts
- Remove `.with_default()` calls (not a Map method in current Compact)
- Add `as Uint<64>` casts for arithmetic results
- Fix `if` syntax to use parentheses around conditions

## Files Changed
- `plugins/midnight-mcp/skills/mcp-simulate/examples/access-control-contract.md`
- `plugins/midnight-mcp/skills/mcp-simulate/examples/token-contract.md`
- `plugins/midnight-mcp/skills/mcp-simulate/examples/voting-contract.md`

## Test plan
- [x] All 3 contracts verified by compilation with `compact compile -- --skip-zk`

Generated with [Claude Code](https://claude.com/claude-code)