### PR TITLE
fix(compact-core): fix language reference code blocks for Compact v0.30.0

### DIFF
--- a/plugins/compact-core/skills/compact-language-ref/references/control-flow.md
+++ b/plugins/compact-core/skills/compact-language-ref/references/control-flow.md
@@ -258,8 +258,8 @@ Curly braces create nested scopes. Constants declared inside a block are not vis
 circuit blockExample(): Field {
   const x = 1;
   {
-    const y = x + 10;  // y is only visible in this block
     const x = 99;      // shadows outer x inside this block
+    const y = x + 10;  // y is only visible in this block; uses shadowed x (99)
   }
   // y is not accessible here
   return x;  // returns 1, not 99

--- a/plugins/compact-core/skills/compact-language-ref/references/operators-and-expressions.md
+++ b/plugins/compact-core/skills/compact-language-ref/references/operators-and-expressions.md
@@ -195,14 +195,14 @@ Because arithmetic widens the result type, you must cast before assigning to a f
 ```compact
 export ledger balances: Map<Bytes<32>, Uint<64>>;
 
-export circuit transfer(from: Bytes<32>, to: Bytes<32>, amount: Uint<64>): [] {
-  const d_from = disclose(from);
-  const d_to = disclose(to);
+export circuit transfer(sender: Bytes<32>, receiver: Bytes<32>, amount: Uint<64>): [] {
+  const d_sender = disclose(sender);
+  const d_receiver = disclose(receiver);
   const d_amount = disclose(amount);
-  const from_bal = balances.lookup(d_from);
-  const to_bal = balances.lookup(d_to);
-  balances.insert(d_from, (from_bal - d_amount) as Uint<64>);
-  balances.insert(d_to, (to_bal + d_amount) as Uint<64>);
+  const sender_bal = balances.lookup(d_sender);
+  const receiver_bal = balances.lookup(d_receiver);
+  balances.insert(d_sender, (sender_bal - d_amount) as Uint<64>);
+  balances.insert(d_receiver, (receiver_bal + d_amount) as Uint<64>);
 }
 ```
 

--- a/plugins/compact-core/skills/compact-language-ref/references/stdlib-functions.md
+++ b/plugins/compact-core/skills/compact-language-ref/references/stdlib-functions.md
@@ -217,9 +217,9 @@ Aborts the transaction (fails the circuit proof) if the condition evaluates to f
 
 ```compact
 export circuit withdraw(amount: Uint<64>): [] {
-  assert(amount > 0, "Amount must be positive");
-  assert(disclose(caller == owner), "Not authorized");
-  balance = (balance - amount) as Uint<64>;
+  const d_amount = disclose(amount);
+  assert(d_amount > 0, "Amount must be positive");
+  balance = (balance - d_amount) as Uint<64>;
 }
 ```
 


### PR DESCRIPTION
## Summary
- Fix block-scoping example in control-flow.md — reorder variable declarations so shadowed variable is declared before use
- Rename `from`/`to` to `sender`/`receiver` in operators-and-expressions.md since `from` is a reserved keyword in Compact
- Fix withdraw example in stdlib-functions.md — replace undeclared `caller`/`owner`, add proper `disclose()` on amount

## Files Changed
- `plugins/compact-core/skills/compact-language-ref/references/control-flow.md`
- `plugins/compact-core/skills/compact-language-ref/references/operators-and-expressions.md`
- `plugins/compact-core/skills/compact-language-ref/references/stdlib-functions.md`

## Test plan
- [x] All fixed code blocks verified by compilation with `compact compile -- --skip-zk`

Generated with [Claude Code](https://claude.com/claude-code)