### PR TITLE
Clarify exported circuit args are private by default

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-expert",
   "metadata": {
-    "version": "0.28.0",
+    "version": "0.29.0",
     "description": "AI agent plugins for the Midnight data-protection blockchain. Covers Compact smart contract development, privacy-preserving patterns, DApp frontend design, and Midnight toolchain management."
   },
   "owner": {

--- a/plugins/compact-core/.claude-plugin/plugin.json
+++ b/plugins/compact-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compact-core",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Core knowledge for writing Midnight Compact smart contracts \u2014 contract structure, data types, ledger declarations, circuits, witnesses, and common patterns.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/compact-core/skills/compact-language-ref/references/troubleshooting.md
+++ b/plugins/compact-core/skills/compact-language-ref/references/troubleshooting.md
@@ -134,7 +134,7 @@ export circuit check(guess: Field): Boolean {
 
 ### Ledger Write Disclosure
 
-Circuit parameters are witness values (provided by the caller/prover). Writing them to the ledger makes them public, so the compiler requires `disclose()`:
+Circuit parameters are tagged as witness data by the compiler — their taint propagates like witness function returns. The parameters themselves are PLONK private inputs to the proof and are not in the public transcript. Writing one to the ledger, however, crosses a public boundary, which is why the compiler requires `disclose()` at the write site (not at the parameter site):
 
 ```compact
 // Wrong -- potential witness-value disclosure must be declared

--- a/plugins/compact-core/skills/compact-privacy-disclosure/SKILL.md
+++ b/plugins/compact-core/skills/compact-privacy-disclosure/SKILL.md
@@ -14,6 +14,17 @@ Privacy is the default in Compact. All witness-derived data is private unless ex
 
 `disclose()` is a compiler annotation, not a runtime operation. It does not encrypt, hash, or transform the value. Placing `disclose(x)` simply marks `x` as "okay to make public." The programmer is asserting: "I understand this value will be visible on-chain, and that is intentional."
 
+## Visibility vs. Taint (Two Different Properties)
+
+These are routinely conflated and must be kept separate:
+
+- **Witness taint** (compile-time concept). The compiler tags every value returned from a `witness` function, every exported circuit parameter, and every constructor parameter as "potentially private." Taint propagates through arithmetic, struct construction, circuit calls, casts, lambda captures. The compiler enforces taint at every public boundary, where `disclose()` is the only way to clear it.
+- **Public transcript visibility** (on-chain reality). A value only enters the public transaction transcript if the source code crosses a public boundary with that value while it is still tainted (or via an unprotected return / ledger write / cross-contract call / public conditional). Values that are not disclosed remain PLONK *private inputs* to the proof and are never observable on-chain.
+
+**Exported circuit parameters are private by default.** They are PLONK private inputs. They become publicly visible only when the circuit body crosses a public boundary with them. A parameter that is consumed only by witness calls, commitments, internal hashes, or private asserts is never observable on-chain. Verified empirically: a contract with `export circuit addPrivately(amount, rand) { lastHash = persistentCommit(amount, rand); }` produces a transaction whose `publicTranscript` contains only the 32-byte commitment hash — the raw `amount` value is absent.
+
+The corollary: a value being "tagged with witness taint" does NOT mean it is publicly visible — it means the compiler is watching it. Tagging is a safety mechanism; visibility is what actually reaches the chain.
+
 ## Privacy Decision Tree
 
 | What to Protect | Approach | Key Primitives |
@@ -47,6 +58,7 @@ Privacy is the default in Compact. All witness-derived data is private unless ex
 | Internal circuit calls | `helper(witness_val)` | Non-exported, stays in proof |
 | Intermediate variables | `const x = a + b` | No public boundary crossed |
 | Commitment inputs | `persistentCommit<Field>(secret, rand)` | Commitment cryptographically hides input |
+| Exported circuit parameter used only internally | `lastHash = persistentCommit(amount, rand)` where `amount` is a circuit param | Param is a PLONK private input; raw value never enters the public transcript unless disclosed at a boundary |
 
 ## Safe Stdlib Routines
 

--- a/plugins/compact-core/skills/compact-privacy-disclosure/references/disclosure-mechanics.md
+++ b/plugins/compact-core/skills/compact-privacy-disclosure/references/disclosure-mechanics.md
@@ -52,6 +52,8 @@ Witness data enters a circuit from three sources. Any value derived from these s
 
 Because witness functions are implemented off-chain in TypeScript, not in the Compact source, their return values are inherently untrusted. The compiler treats all witness outputs as potentially private data that must be explicitly disclosed before crossing a public boundary.
 
+> **Note: tagging is not visibility.** "Witness data" in this table means the compiler tags these values for taint tracking — it does NOT mean they are publicly visible. All three sources (witness returns, exported circuit parameters, constructor parameters) start their lives as PLONK *private inputs* to the proof. They only enter the public transaction transcript if the source code crosses a public boundary while the value is still tainted (i.e., via `disclose()` at a ledger write, a return from an exported circuit, a public conditional, or a cross-contract call). An exported circuit parameter consumed only by an internal commitment, hash, or private assert never appears on-chain. Empirically confirmed via `compact compile` + ZKIR inspection: PLONK private inputs include every untouched parameter; the public transcript reflects only the disclosed boundary points.
+
 ## The Witness Protection Program
 
 The Witness Protection Program is the compiler's abstract interpreter. Instead of evaluating a program with actual runtime values, it evaluates using abstract values that track whether each value contains witness data.

--- a/plugins/compact-core/skills/compact-review/references/architecture-review.md
+++ b/plugins/compact-core/skills/compact-review/references/architecture-review.md
@@ -258,7 +258,9 @@ Check the division of logic between circuit (on-chain verification) and witness 
   }
   ```
 
-- [ ] **Private data never passed directly to circuit parameters.** Circuits receive their private inputs through witness functions. If a circuit parameter appears to be a secret (e.g., a secret key), verify it arrives through a witness call within the circuit body, not as an `export circuit` parameter visible to the caller.
+- [ ] **Long-lived secrets fetched via `witness()` rather than passed as exported circuit parameters (clarity recommendation, NOT a privacy rule).** Both witness return values and exported circuit parameters are private by default — the compiler tags them with witness taint and they end up as PLONK private inputs to the proof. Neither is included in the public transaction transcript unless the circuit body explicitly crosses a public boundary with that value (`disclose()` to a ledger ADT, return from an exported circuit, public conditional, cross-contract call). Preferring `witness()` for long-lived secrets like a user's secret key is a *style* recommendation: it keeps the circuit's public API free of secret-looking parameter names and makes the data flow obvious to reviewers. It is NOT a privacy fix.
+
+  ⚠ **Common false positive to avoid.** Do not flag an exported circuit parameter as a privacy leak solely because the parameter *looks* private (e.g., `acceptGame(x1: Field, x2: Field)` taking ship coordinates). Identify the actual public-boundary crossings inside the circuit body. If the value is only consumed internally (passed to a witness, used as a commitment input, hashed for a nullifier, compared inside a private assert), it stays inside the ZK proof as a private input and is not observable on-chain. Verified empirically: contract-writer + zkir-checker confirm args are PLONK private inputs by default; raw values enter `publicTranscript` only at explicit disclosure points.
 
 ## State Initialization Checklist
 

--- a/plugins/compact-core/skills/compact-review/references/privacy-review.md
+++ b/plugins/compact-core/skills/compact-review/references/privacy-review.md
@@ -48,6 +48,10 @@ Check every `disclose()` call in the contract for necessity and placement.
 
 Check for private witness data escaping the zero-knowledge proof boundary.
 
+- [ ] **Before flagging an exported circuit parameter as a leak, identify the actual public-boundary crossing in the circuit body.** Exported circuit parameters are tagged as witness data by the compiler, but they are PLONK *private inputs* to the proof and are not observable on-chain unless the circuit body explicitly crosses a public boundary with them. A finding is only valid if the parameter flows to one of: a ledger write (the compiler enforces `disclose()` here), a return from the exported circuit, a public conditional, or a cross-contract call. A parameter consumed only by a witness call, a commitment input, an internal hash, or a private assert stays inside the proof and is NOT a privacy issue.
+
+  This rule guards against a common false positive: flagging private-looking parameters (e.g., `acceptGame(x1, x2)` taking ship coordinates) without checking whether the circuit body actually leaks them. Verified empirically — contract-writer + zkir-checker confirm that parameters not reached by `disclose()` never enter the public transcript; the verifier sees only PLONK public inputs the source code declared public.
+
 - [ ] **Witness-derived values written to public ledger without `disclose()`.** The compiler catches this as an error, but review the intent. If the developer added `disclose()` solely to silence the compiler without considering whether the value should actually be public, that is a privacy bug even though the code compiles.
 
 > **Tool:** `COMPILE_RESULT` shows `implicit disclosure of witness value` errors for these cases.


### PR DESCRIPTION
The privacy-review and architecture-review checklists conflated compile-time witness taint with on-chain transcript visibility, leading the reviewer agent to flag private-looking exported circuit parameters as privacy leaks. Verified empirically (contract-writer + zkir-checker): exported circuit args are PLONK private inputs by default and only enter the public transcript when the source explicitly crosses a public boundary with disclose().

- architecture-review: drop "visible to the caller", reframe as clarity rule, add false-positive callout
- privacy-disclosure SKILL: add Visibility vs. Taint section; add table row for pure-internal use of a parameter
- disclosure-mechanics: clarify tagging is not visibility
- privacy-review: add lead counter-check requiring reviewers to identify the actual public-boundary crossing before flagging a parameter
- language-ref troubleshooting: tighten ledger-write disclosure wording

Bumps compact-core to 0.5.0 and marketplace to 0.29.0.