### PR TITLE
fix(dapp-connector): correct signData/Signature types for API v4.0.1

### DIFF
--- a/plugins/midnight-dapp-dev/skills/dapp-connector/references/connector-api-types.md
+++ b/plugins/midnight-dapp-dev/skills/dapp-connector/references/connector-api-types.md
@@ -158,10 +158,10 @@ interface WalletConnectedAPI {
 
   /**
    * Sign arbitrary data with the unshielded signing key.
-   * @param data - Data to sign
-   * @param options - Signing options
+   * @param data - Data to sign, encoded as specified by `options.encoding`
+   * @param options - Signing options (encoding + key type)
    */
-  signData(data: Uint8Array, options: SignDataOptions): Promise<Signature>;
+  signData(data: string, options: SignDataOptions): Promise<Signature>;
 
   /**
    * Get a proving provider that delegates ZK proof generation to the wallet.
@@ -302,15 +302,34 @@ interface IntentOptions {
 
 ```typescript
 interface Signature {
-  /** The signature bytes */
-  signature: Uint8Array;
+  /**
+   * The data that was signed (echoed back from the input, in the original encoding).
+   * Useful for verifying what was signed without re-parsing the request.
+   */
+  data: string;
 
-  /** The public key that produced the signature */
-  publicKey: Uint8Array;
+  /**
+   * The signature over `midnight_signed_message:<byte_length>:<data_bytes>`.
+   * The wallet prepends this prefix to all signed data to prevent accidental
+   * transaction signing.
+   */
+  signature: string;
+
+  /** The verifying key corresponding to the signing key used. */
+  verifyingKey: string;
 }
 
 interface SignDataOptions {
-  /** Which key to sign with */
+  /**
+   * How the `data` argument is encoded.
+   * - `"hex"` / `"base64"`: binary data encoded in that format — the wallet decodes
+   *   to raw bytes before signing.
+   * - `"text"`: sign the string as UTF-8 bytes (JS strings are UTF-16; the wallet
+   *   handles the conversion).
+   */
+  encoding: "hex" | "base64" | "text";
+
+  /** Which key to use for signing. Currently only `"unshielded"` is supported. */
   keyType: "unshielded";
 }
 ```
@@ -375,11 +394,33 @@ import type { InitialAPI } from "@midnight-ntwrk/dapp-connector-api";
 declare global {
   interface Window {
     midnight?: {
-      mnLace?: InitialAPI;
+      /**
+       * Per the DApp Connector API v4 spec (CAIP-372 compatible), each wallet
+       * installs its InitialAPI under a freshly-generated UUIDv4 key.
+       * Always enumerate `Object.values(window.midnight)` and match by
+       * `name` / `rdns` — do not assume a fixed key.
+       *
+       * Note: Lace also exposes a convenience alias under `mnLace` for
+       * backwards compatibility, but this is Lace-specific and not part of
+       * the normative spec. Other wallets (e.g. 1AM) only use UUIDv4 keys.
+       */
       [walletId: string]: InitialAPI | undefined;
     };
   }
 }
 ```
 
-This provides autocompletion and type checking for `window.midnight.mnLace` throughout the project.
+**Detection pattern** — enumerate and match by identity, not by key:
+
+```typescript
+function findWallets(): InitialAPI[] {
+  if (typeof window === "undefined" || !window.midnight) return [];
+  return Object.values(window.midnight).filter(
+    (entry): entry is InitialAPI =>
+      entry != null &&
+      typeof entry === "object" &&
+      typeof (entry as InitialAPI).connect === "function" &&
+      typeof (entry as InitialAPI).apiVersion === "string",
+  );
+}
+```


### PR DESCRIPTION
## Summary

Corrects three type errors in `connector-api-types.md` that cause DApp code
generated from this skill to fail at runtime. All changes are verified against
the authoritative source: the published `@midnight-ntwrk/dapp-connector-api@4.0.1`
package (`dist/api.d.ts`) and the official
[SPECIFICATION.md](https://github.com/midnightntwrk/midnight-dapp-connector-api/blob/main/SPECIFICATION.md).

## What was wrong

| Type | Skill said | Real API (`@4.0.1`) |
|------|-----------|----------------------|
| `signData` data arg | `Uint8Array` | `string` |
| `SignDataOptions` | `{ keyType }` only | `{ encoding: "hex"\|"base64"\|"text"; keyType }` |
| `Signature` | `{ signature: Uint8Array; publicKey: Uint8Array }` | `{ data: string; signature: string; verifyingKey: string }` |
| Window augmentation | fixed `mnLace?` key | `[walletId: string]` only (UUIDv4 per spec) |

## Key Changes

- **`signData` data arg** — changed from `Uint8Array` to `string`. The real
  API takes an encoded string; the wallet decodes it according to the
  `encoding` option before signing.

- **`SignDataOptions`** — added the missing `encoding: "hex" | "base64" | "text"`
  field. Without it, authors omit encoding and calls fail at runtime.

- **`Signature`** — replaced `{ signature, publicKey: Uint8Array }` with
  `{ data, signature, verifyingKey: string }`. Also documents the
  `midnight_signed_message:<byte_length>:<data_bytes>` prefix the wallet
  applies before signing (anti-transaction-forgery, per the spec).

- **Window type augmentation** — removed the fixed `mnLace?` key. Per the v4
  spec (CAIP-372 compatible), every wallet injects its `InitialAPI` under a
  freshly-generated UUIDv4 key. `mnLace` is a Lace-specific backwards-compat
  alias, not the normative pattern — relying on it breaks detection for 1AM
  and any future wallet. Replaced the snippet with an enumerate-and-match
  pattern that works for all wallets.

## Verification

Checked against:
- `@midnight-ntwrk/dapp-connector-api@4.0.1` → `dist/api.d.ts` (installed locally)
- `github.com/midnightntwrk/midnight-dapp-connector-api` → `SPECIFICATION.md` and `src/api.ts`

Real-world impact confirmed: a DApp integration written following the skill's
types passed `Uint8Array` to `signData`, read `.publicKey` from the result (both
`undefined` at runtime), and broke multi-wallet detection by hardcoding
`window.midnight.mnLace`. All three issues were resolved by aligning with the
actual package types.