### PR TITLE
docs(midnight-node): update to node 1.0.0 GA (tx_version 3, TransactionExtension, throttle, config/boot validation)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-expert",
   "metadata": {
-    "version": "0.30.0",
+    "version": "0.31.0",
     "description": "AI agent plugins for the Midnight data-protection blockchain. Covers Compact smart contract development, privacy-preserving patterns, DApp frontend design, and Midnight toolchain management."
   },
   "owner": {

--- a/plugins/midnight-node/.claude-plugin/plugin.json
+++ b/plugins/midnight-node/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-node",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Technical reference for the Midnight node \u2014 Substrate-based architecture, runtime pallets, RPC interface, configuration, operations, and governance",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-node/skills/node-architecture/SKILL.md
+++ b/plugins/midnight-node/skills/node-architecture/SKILL.md
@@ -6,9 +6,9 @@ version: 0.1.0
 
 # Node Architecture
 
-The Midnight node is a Substrate-based blockchain client built on Polkadot SDK (polkadot-stable2509) and the Cardano Partner Chain framework (v1.8.1). It produces blocks, finalizes them, verifies ZK proofs, manages ledger state, and bridges to the Cardano mainchain.
+The Midnight node is a Substrate-based blockchain client built on Polkadot SDK (polkadot-stable2603) and the Cardano Partner Chain framework (v1.8.1). It produces blocks, finalizes them, verifies ZK proofs, manages ledger state, and bridges to the Cardano mainchain.
 
-**Current version:** node-0.22.0 — These version identifiers track upstream releases and may change with new Midnight releases.
+**Current version:** node-1.0.0 (mainnet GA) — runtime `spec_version` 1_000_000, `transaction_version` 3. These version identifiers track upstream releases and may change with new Midnight releases.
 
 ## Source Layout
 
@@ -68,7 +68,7 @@ The runtime composes approximately 28 pallets organized by function. The exact c
 | `pallet_node_version` | On-chain node version tracking and compatibility checks |
 | `pallet_cnight_observation` | cNIGHT cross-chain observation and validation |
 | `pallet_system_parameters` | On-chain governance parameters — D-parameter, Terms & Conditions |
-| `pallet_throttle` | Transaction rate limiting — max bytes over a sliding window |
+| `pallet_throttle` | Per-account transaction rate limiting — max bytes and max transaction count over a sliding window |
 
 ### Governance
 
@@ -166,10 +166,10 @@ The node implements multi-layer transaction filtering to protect against spam an
 | Layer | Mechanism | Purpose |
 |-------|-----------|---------|
 | `FilteringTransactionPool` | Custom transaction pool implementation | Rejects transactions before they enter the pool |
-| `CheckCallFilter` | Signed extension | Validates transaction calls against allow/deny rules |
-| `pallet_throttle` | Runtime pallet | Rate-limits transaction throughput by total bytes over a sliding window |
+| `CheckCallFilter` | Transaction extension | Validates transaction calls against allow/deny rules |
+| `pallet_throttle` | Runtime pallet | Rate-limits each account by both total bytes and transaction count over a sliding window |
 
-The Throttle pallet enforces a configurable maximum number of transaction bytes within a rolling window, preventing any single block or burst from overwhelming the network.
+The Throttle pallet enforces, per account, a configurable maximum number of transaction bytes (`MaxBytes`) and a maximum transaction count (`MaxTxs`) within a rolling block window (`WindowSize`), preventing any single account from overwhelming the network. Per-account usage is tracked in `AccountUsage` as a `UsageStats` record (`bytes_used`, `txs_used`, `window_start`).
 
 ## Cardano Integration
 

--- a/plugins/midnight-node/skills/node-architecture/SKILL.md
+++ b/plugins/midnight-node/skills/node-architecture/SKILL.md
@@ -68,7 +68,7 @@ The runtime composes approximately 28 pallets organized by function. The exact c
 | `pallet_node_version` | On-chain node version tracking and compatibility checks |
 | `pallet_cnight_observation` | cNIGHT cross-chain observation and validation |
 | `pallet_system_parameters` | On-chain governance parameters — D-parameter, Terms & Conditions |
-| `pallet_throttle` | Per-account transaction rate limiting — max bytes and max transaction count over a sliding window |
+| `pallet_throttle` | Per-account transaction rate limiting — max bytes and max transaction count over a rolling block window |
 
 ### Governance
 
@@ -167,7 +167,7 @@ The node implements multi-layer transaction filtering to protect against spam an
 |-------|-----------|---------|
 | `FilteringTransactionPool` | Custom transaction pool implementation | Rejects transactions before they enter the pool |
 | `CheckCallFilter` | Transaction extension | Validates transaction calls against allow/deny rules |
-| `pallet_throttle` | Runtime pallet | Rate-limits each account by both total bytes and transaction count over a sliding window |
+| `pallet_throttle` | Runtime pallet | Rate-limits each account by both total bytes and transaction count over a rolling block window |
 
 The Throttle pallet enforces, per account, a configurable maximum number of transaction bytes (`MaxBytes`) and a maximum transaction count (`MaxTxs`) within a rolling block window (`WindowSize`), preventing any single account from overwhelming the network. Per-account usage is tracked in `AccountUsage` as a `UsageStats` record (`bytes_used`, `txs_used`, `window_start`).
 

--- a/plugins/midnight-node/skills/node-configuration/SKILL.md
+++ b/plugins/midnight-node/skills/node-configuration/SKILL.md
@@ -33,7 +33,8 @@ SHOW_CONFIG=1 midnight-node --chain preview
 | `validator` | `--validator` | `false` | Run as a block-producing validator node |
 | `cardano_security_parameter` | Config file | Network-specific | Cardano security parameter (k) for finality assumptions |
 | `block_stability_margin` | Config file | Network-specific | Number of blocks before a Cardano block is considered stable |
-| `allow_non_ssl` | Config file | `false` | Allow non-SSL connections to Cardano db-sync PostgreSQL |
+| `ssl_root_cert` | Config file | (optional) | Path to the SSL root certificate for Cardano db-sync PostgreSQL connections. When set, connections use full certificate + hostname validation (`PgSslMode::VerifyFull`); when absent, connections are encrypted but unverified (`PgSslMode::Require`) |
+| `allow_non_ssl` | Config file | `false` | **Deprecated and ignored.** Plaintext database connections are no longer permitted — all connections now use TLS. The flag is retained for backward compatibility and will be removed in a future release |
 | `memory_threshold` | Config file | (optional) | Memory usage percentage that triggers graceful shutdown |
 | `storage_cache_size` | `--db-cache` | `1024` | Database cache size in MiB |
 | `trie_cache_size` | `--trie-cache-size` | `67108864` (64 MiB) | State trie cache size in bytes |
@@ -81,6 +82,19 @@ The node loads multiple configuration files that define the chain's genesis stat
 | `ics-config.json` | Inter-chain staking configuration |
 | `federated-authority-config.json` | Initial governance body membership (Council + TechnicalCommittee) |
 | `system-parameters-config.json` | Initial system parameters — D-parameter, Terms & Conditions |
+
+## File Safety and Boot Validation
+
+The node validates the configuration and genesis files it reads on startup. Misconfigured files fail loudly rather than being silently accepted.
+
+| Option / Behavior | Config Key | Default | Description |
+|-------------------|------------|---------|-------------|
+| Symlink rejection | `unsafe_allow_symlinks` | `false` | Config and genesis files that are symlinks are rejected. Set `true` to allow symlinks (accepting the associated symlink-attack risk) |
+| File size limit | `safe_read_max_size` | `10485760` (10 MB) | Maximum size in bytes for a config/genesis file read; larger files are rejected |
+| Regular-file check | (automatic) | — | Files that are not regular files (e.g. directories, devices) are rejected |
+| Network ID validation | (automatic) | — | On boot the node validates that the genesis state's network ID matches the configured chainspec network ID; a mismatch fails startup with `genesis state network id != configured chainspec network id` |
+
+`show_config` (the `SHOW_CONFIG=1` mechanism above) and `show_secrets` are also meta-configuration keys that control how resolved configuration is displayed on startup.
 
 ## Network-Specific Presets
 

--- a/plugins/midnight-node/skills/node-configuration/SKILL.md
+++ b/plugins/midnight-node/skills/node-configuration/SKILL.md
@@ -34,7 +34,7 @@ SHOW_CONFIG=1 midnight-node --chain preview
 | `cardano_security_parameter` | Config file | Network-specific | Cardano security parameter (k) for finality assumptions |
 | `block_stability_margin` | Config file | Network-specific | Number of blocks before a Cardano block is considered stable |
 | `ssl_root_cert` | Config file | (optional) | Path to the SSL root certificate for Cardano db-sync PostgreSQL connections. When set, connections use full certificate + hostname validation (`PgSslMode::VerifyFull`); when absent, connections are encrypted but unverified (`PgSslMode::Require`) |
-| `allow_non_ssl` | Config file | `false` | **Deprecated and ignored.** Plaintext database connections are no longer permitted — all connections now use TLS. The flag is retained for backward compatibility and will be removed in a future release |
+| `allow_non_ssl` | Config file | `false` | **Deprecated and ignored.** Plaintext database connections are no longer permitted — all connections now use TLS. The flag is retained for backward compatibility and will be removed in a future release. Setting it to `true` emits a startup warning but does not change connection behavior. |
 | `memory_threshold` | Config file | (optional) | Memory usage percentage that triggers graceful shutdown |
 | `storage_cache_size` | `--db-cache` | `1024` | Database cache size in MiB |
 | `trie_cache_size` | `--trie-cache-size` | `67108864` (64 MiB) | State trie cache size in bytes |

--- a/plugins/midnight-node/skills/node-governance/SKILL.md
+++ b/plugins/midnight-node/skills/node-governance/SKILL.md
@@ -67,7 +67,7 @@ on-chain   votes     reached     approved
 | **Propose** | A member of either body submits a motion (a callable dispatch) |
 | **Vote** | Members of the originating body cast Aye or Nay votes |
 | **Approve** | The motion passes if it reaches a 2/3 supermajority |
-| **Close** | After both bodies approve, the motion is executed within a 5-day voting window |
+| **Close** | After both bodies approve, the motion is executed within a 5-day voting window. The `motion_close` extrinsic can be called by anyone and takes a `proposal_weight_bound` argument that caps the weight the dispatched call may consume; it runs as an `Operational` dispatch |
 
 ### Voting Rules
 


### PR DESCRIPTION
## What changed
Revalidated against the **node 1.0.0 GA** release (plugin previously documented `node-0.22.0`).

- **node-architecture**: version -> `node-1.0.0` (mainnet GA), `spec_version 1_000_000`, `transaction_version 3`, Substrate SDK `polkadot-stable2603`; `CheckCallFilter` is now a `TransactionExtension` (was "signed extension"); throttle pallet documents per-account `MaxTxs` + `UsageStats {bytes_used, txs_used, window_start}`.
- **node-configuration**: added `ssl_root_cert`; deprecated `allow_non_ssl` (all DB connections now TLS); new *File Safety & Boot Validation* section (`unsafe_allow_symlinks`, 10 MB `safe_read_max_size`, regular-file enforcement, networkId-vs-genesis boot check).
- **node-governance**: `motion_close(motion_hash, proposal_weight_bound)` callable by anyone, `DispatchClass::Operational`.

Node numeric error codes (212-250) were already accurate -- left unchanged.

**Source:** midnightntwrk/midnight-node `node-1.0.0` GA (`node/Cargo.toml`, `runtime/src/lib.rs`, `pallets/*`).
**Verification:** confirmed against the cloned GA source; independent reviewer verdict: clean.
**Note:** Devnet Docker image tags (still `0.22.x`) intentionally kept (node software is distinct from the local devnet image). Left unmerged for review.

🤖 Part of the 2026-06-02 Midnight Expert upstream revalidation sweep.

Generated with [Claude Code](https://claude.com/claude-code)