### PR TITLE
docs(midnight-status-codes): rewrite zk-errors for zkir-crate removal; add midnight-js 4.1.1 IndexerError hierarchy

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-expert",
   "metadata": {
-    "version": "0.31.0",
+    "version": "0.32.0",
     "description": "AI agent plugins for the Midnight data-protection blockchain. Covers Compact smart contract development, privacy-preserving patterns, DApp frontend design, and Midnight toolchain management."
   },
   "owner": {

--- a/plugins/midnight-status-codes/.claude-plugin/plugin.json
+++ b/plugins/midnight-status-codes/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-status-codes",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Catalog and lookup for all Midnight ecosystem error codes, status codes, and error types across the node, ledger, indexer, wallet, SDK, compiler, compact runtime, proof server, and DApp connector.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-status-codes/skills/status-codes-lookup/scripts/codes.json
+++ b/plugins/midnight-status-codes/skills/status-codes-lookup/scripts/codes.json
@@ -8665,6 +8665,36 @@
       }
     },
     {
+      "code": "IndexerError",
+      "name": "IndexerError",
+      "source": "midnight-js",
+      "category": "midnight-js-indexer-error",
+      "group": {
+        "name": "midnight-js-indexer-public-data-provider errors",
+        "description": "Errors from @midnight-ntwrk/midnight-js-indexer-public-data-provider."
+      },
+      "description": "Abstract base class (added in v4.1.1) for all errors raised by the indexer public data provider. Catch with `instanceof IndexerError` to handle any indexer error; narrow to a subclass (IndexerFormattedError, IndexerQueryError, IndexerDataError, IndexerSubscriptionDataError, IndexerProviderConfigError) for specifics.",
+      "fixes": [
+        "Narrow to the specific subclass to determine the correct remediation"
+      ],
+      "aliases": [],
+      "severity": "error",
+      "see_also": [
+        "IndexerFormattedError",
+        "IndexerQueryError",
+        "IndexerDataError",
+        "IndexerSubscriptionDataError",
+        "IndexerProviderConfigError"
+      ],
+      "verified_against": {
+        "source_repo": "midnightntwrk/midnight-js",
+        "ref": "main",
+        "anchor": "packages/indexer-public-data-provider/src/errors.ts",
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
+      }
+    },
+    {
       "code": "IndexerFormattedError",
       "name": "IndexerFormattedError",
       "source": "midnight-js",
@@ -8673,20 +8703,126 @@
         "name": "midnight-js-indexer-public-data-provider errors",
         "description": "Errors from @midnight-ntwrk/midnight-js-indexer-public-data-provider."
       },
-      "description": "GraphQL errors received from the Midnight indexer, surfaced as a wrapped class-based error.",
+      "description": "GraphQL errors received from the Midnight indexer, surfaced as a class-based error extending IndexerError. As of v4.1.1 the GraphQL error array is exposed via the `errors` field (readonly GraphQLFormattedError[]) — renamed from `cause` (BREAKING).",
       "fixes": [
-        "Inspect cause (readonly GraphQLFormattedError[]) for the underlying GraphQL errors"
+        "Inspect `errors` (readonly GraphQLFormattedError[]) for the underlying GraphQL errors — this field was named `cause` before v4.1.1"
       ],
       "aliases": [],
       "severity": "error",
-      "see_also": [],
+      "see_also": [
+        "IndexerError"
+      ],
       "verified_against": {
         "source_repo": "midnightntwrk/midnight-js",
         "ref": "main",
-        "anchor": "packages/contracts/src/errors.ts",
-        "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "anchor": "packages/indexer-public-data-provider/src/errors.ts",
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
+      }
+    },
+    {
+      "code": "IndexerQueryError",
+      "name": "IndexerQueryError",
+      "source": "midnight-js",
+      "category": "midnight-js-indexer-error",
+      "group": {
+        "name": "midnight-js-indexer-public-data-provider errors",
+        "description": "Errors from @midnight-ntwrk/midnight-js-indexer-public-data-provider."
+      },
+      "description": "Raised (v4.1.1+) when an Apollo query or fetch fails at the transport layer (network failure, malformed response, Apollo client error) — distinct from IndexerFormattedError. Preserves the original Apollo error via the standard `Error.cause`.",
+      "fixes": [
+        "Check network connectivity and the indexer URL; inspect `cause` for the underlying transport error"
+      ],
+      "aliases": [],
+      "severity": "error",
+      "see_also": [
+        "IndexerError",
+        "IndexerFormattedError"
+      ],
+      "verified_against": {
+        "source_repo": "midnightntwrk/midnight-js",
+        "ref": "main",
+        "anchor": "packages/indexer-public-data-provider/src/errors.ts",
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
+      }
+    },
+    {
+      "code": "IndexerDataError",
+      "name": "IndexerDataError",
+      "source": "midnight-js",
+      "category": "midnight-js-indexer-error",
+      "group": {
+        "name": "midnight-js-indexer-public-data-provider errors",
+        "description": "Errors from @midnight-ntwrk/midnight-js-indexer-public-data-provider."
+      },
+      "description": "Raised (v4.1.1+) when indexer-returned data is structurally inconsistent with the provider's expectations. Carries a discriminated `context` (kind: 'unknown-status' | 'missing-contract-action' | 'missing-identifier'); construct via static factories unknownStatus/missingContractAction/missingIdentifier.",
+      "fixes": [
+        "Branch on `error.context.kind`; usually an indexer/SDK schema mismatch or unindexed data — verify indexer compatibility and that the contract/transaction is fully indexed"
+      ],
+      "aliases": [],
+      "severity": "error",
+      "see_also": [
+        "IndexerError"
+      ],
+      "verified_against": {
+        "source_repo": "midnightntwrk/midnight-js",
+        "ref": "main",
+        "anchor": "packages/indexer-public-data-provider/src/errors.ts",
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
+      }
+    },
+    {
+      "code": "IndexerSubscriptionDataError",
+      "name": "IndexerSubscriptionDataError",
+      "source": "midnight-js",
+      "category": "midnight-js-indexer-error",
+      "group": {
+        "name": "midnight-js-indexer-public-data-provider errors",
+        "description": "Errors from @midnight-ntwrk/midnight-js-indexer-public-data-provider."
+      },
+      "description": "Raised (v4.1.1+) when an indexer subscription payload is missing a top-level field the provider relies on. Carries `missingField` ('blocks' | 'contractActions'). Message: \"Expected '${missingField}' in indexer subscription data, got null/undefined\".",
+      "fixes": [
+        "Usually an indexer/SDK schema mismatch; verify indexer compatibility"
+      ],
+      "aliases": [],
+      "severity": "error",
+      "see_also": [
+        "IndexerError"
+      ],
+      "verified_against": {
+        "source_repo": "midnightntwrk/midnight-js",
+        "ref": "main",
+        "anchor": "packages/indexer-public-data-provider/src/errors.ts",
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
+      }
+    },
+    {
+      "code": "IndexerProviderConfigError",
+      "name": "IndexerProviderConfigError",
+      "source": "midnight-js",
+      "category": "midnight-js-indexer-error",
+      "group": {
+        "name": "midnight-js-indexer-public-data-provider errors",
+        "description": "Errors from @midnight-ntwrk/midnight-js-indexer-public-data-provider."
+      },
+      "description": "Raised (v4.1.1+) when the consumer passes a configuration the provider does not support (e.g. an unservable observable mode). Signals API misuse, not a server-side issue.",
+      "fixes": [
+        "Review the provider configuration / observable mode against the supported options"
+      ],
+      "aliases": [],
+      "severity": "error",
+      "see_also": [
+        "IndexerError"
+      ],
+      "verified_against": {
+        "source_repo": "midnightntwrk/midnight-js",
+        "ref": "main",
+        "anchor": "packages/indexer-public-data-provider/src/errors.ts",
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {

--- a/plugins/midnight-status-codes/skills/status-codes-lookup/scripts/codes.json
+++ b/plugins/midnight-status-codes/skills/status-codes-lookup/scripts/codes.json
@@ -3399,10 +3399,10 @@
       "verified_against": {
         "source_repo": "midnight-ntwrk/artifacts",
         "ref": "private",
-        "anchor": "compact-js@2.5.0 (verified via npm pack)",
+        "anchor": "compact-js@2.5.1 (verified via npm pack)",
         "anchor_modified": "2026-04-23",
-        "verified_at": "2026-05-04",
-        "package_version": "2.5.0"
+        "verified_at": "2026-06-02",
+        "package_version": "2.5.1"
       }
     },
     {
@@ -3421,10 +3421,10 @@
       "verified_against": {
         "source_repo": "midnight-ntwrk/artifacts",
         "ref": "private",
-        "anchor": "compact-js@2.5.0 (verified via npm pack)",
+        "anchor": "compact-js@2.5.1 (verified via npm pack)",
         "anchor_modified": "2026-04-23",
-        "verified_at": "2026-05-04",
-        "package_version": "2.5.0"
+        "verified_at": "2026-06-02",
+        "package_version": "2.5.1"
       }
     },
     {
@@ -3443,10 +3443,10 @@
       "verified_against": {
         "source_repo": "midnight-ntwrk/artifacts",
         "ref": "private",
-        "anchor": "compact-js@2.5.0 (verified via npm pack)",
+        "anchor": "compact-js@2.5.1 (verified via npm pack)",
         "anchor_modified": "2026-04-23",
-        "verified_at": "2026-05-04",
-        "package_version": "2.5.0"
+        "verified_at": "2026-06-02",
+        "package_version": "2.5.1"
       }
     },
     {
@@ -3468,10 +3468,10 @@
       "verified_against": {
         "source_repo": "midnight-ntwrk/artifacts",
         "ref": "private",
-        "anchor": "compact-js@2.5.0 (verified via npm pack)",
+        "anchor": "compact-js@2.5.1 (verified via npm pack)",
         "anchor_modified": "2026-04-23",
-        "verified_at": "2026-05-04",
-        "package_version": "2.5.0"
+        "verified_at": "2026-06-02",
+        "package_version": "2.5.1"
       }
     },
     {
@@ -3557,8 +3557,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -3579,8 +3579,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -3601,8 +3601,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -3623,8 +3623,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -3645,8 +3645,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -3667,8 +3667,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -3689,8 +3689,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -3710,8 +3710,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -3731,8 +3731,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -3753,8 +3753,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -3775,8 +3775,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -3796,8 +3796,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -8527,8 +8527,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -8554,8 +8554,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -8581,8 +8581,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -8606,8 +8606,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -8633,8 +8633,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -8660,8 +8660,8 @@
         "ref": "main",
         "anchor": "packages/contracts/src/errors.ts",
         "anchor_modified": "2026-04-13",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -9554,9 +9554,10 @@
       "verified_against": {
         "source_repo": "midnight-ntwrk/artifacts",
         "ref": "private",
-        "anchor": "compact-js-command@2.5.0 (verified via npm pack)",
+        "anchor": "compact-js-command@2.5.1 (verified via npm pack)",
         "anchor_modified": "2026-04-23",
-        "verified_at": "2026-05-04"
+        "verified_at": "2026-06-02",
+        "package_version": "2.5.1"
       }
     },
     {
@@ -9580,9 +9581,10 @@
       "verified_against": {
         "source_repo": "midnight-ntwrk/artifacts",
         "ref": "private",
-        "anchor": "compact-js-command@2.5.0 (verified via npm pack)",
+        "anchor": "compact-js-command@2.5.1 (verified via npm pack)",
         "anchor_modified": "2026-04-23",
-        "verified_at": "2026-05-04"
+        "verified_at": "2026-06-02",
+        "package_version": "2.5.1"
       }
     },
     {
@@ -9941,11 +9943,11 @@
       "class": "Error",
       "verified_against": {
         "source_repo": "midnightntwrk/midnight-js",
-        "ref": "midnight-js-utils-4.0.4",
+        "ref": "midnight-js-utils-4.1.1",
         "anchor": "packages/utils/src/assertion-utils.ts",
         "anchor_modified": "2026-05-01",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -9969,11 +9971,11 @@
       "class": "Error",
       "verified_against": {
         "source_repo": "midnightntwrk/midnight-js",
-        "ref": "midnight-js-utils-4.0.4",
+        "ref": "midnight-js-utils-4.1.1",
         "anchor": "packages/utils/src/assertion-utils.ts",
         "anchor_modified": "2026-05-01",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -9997,11 +9999,11 @@
       "class": "TypeError",
       "verified_against": {
         "source_repo": "midnightntwrk/midnight-js",
-        "ref": "midnight-js-utils-4.0.4",
+        "ref": "midnight-js-utils-4.1.1",
         "anchor": "packages/utils/src/hex-utils.ts",
         "anchor_modified": "2026-05-01",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -10025,11 +10027,11 @@
       "class": "Error",
       "verified_against": {
         "source_repo": "midnightntwrk/midnight-js",
-        "ref": "midnight-js-utils-4.0.4",
+        "ref": "midnight-js-utils-4.1.1",
         "anchor": "packages/utils/src/hex-utils.ts",
         "anchor_modified": "2026-05-01",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -10054,11 +10056,11 @@
       "class": "TypeError",
       "verified_against": {
         "source_repo": "midnightntwrk/midnight-js",
-        "ref": "midnight-js-utils-4.0.4",
+        "ref": "midnight-js-utils-4.1.1",
         "anchor": "packages/utils/src/hex-utils.ts",
         "anchor_modified": "2026-05-01",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -10083,11 +10085,11 @@
       "class": "TypeError",
       "verified_against": {
         "source_repo": "midnightntwrk/midnight-js",
-        "ref": "midnight-js-utils-4.0.4",
+        "ref": "midnight-js-utils-4.1.1",
         "anchor": "packages/utils/src/hex-utils.ts",
         "anchor_modified": "2026-05-01",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -10111,11 +10113,11 @@
       "class": "TypeError",
       "verified_against": {
         "source_repo": "midnightntwrk/midnight-js",
-        "ref": "midnight-js-utils-4.0.4",
+        "ref": "midnight-js-utils-4.1.1",
         "anchor": "packages/utils/src/hex-utils.ts",
         "anchor_modified": "2026-05-01",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -10139,11 +10141,11 @@
       "class": "TypeError",
       "verified_against": {
         "source_repo": "midnightntwrk/midnight-js",
-        "ref": "midnight-js-utils-4.0.4",
+        "ref": "midnight-js-utils-4.1.1",
         "anchor": "packages/utils/src/hex-utils.ts",
         "anchor_modified": "2026-05-01",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {
@@ -10169,11 +10171,11 @@
       "class": "TypeError",
       "verified_against": {
         "source_repo": "midnightntwrk/midnight-js",
-        "ref": "midnight-js-utils-4.0.4",
+        "ref": "midnight-js-utils-4.1.1",
         "anchor": "packages/utils/src/type-utils.ts",
         "anchor_modified": "2026-05-01",
-        "verified_at": "2026-05-04",
-        "package_version": "4.0.4"
+        "verified_at": "2026-06-02",
+        "package_version": "4.1.1"
       }
     },
     {

--- a/plugins/midnight-status-codes/skills/status-codes/SKILL.md
+++ b/plugins/midnight-status-codes/skills/status-codes/SKILL.md
@@ -37,7 +37,7 @@ These are `LedgerApiError` codes that surface via Substrate's `InvalidTransactio
 
 Read `references/sdk-errors.md`
 
-**Recognise by:** Error class names like `TxFailedError`, `DeployTxFailedError`, `CallTxFailedError`, `ContractTypeError`, `InvalidProtocolSchemeError`, `PrivateStateImportError`, `IndexerFormattedError`. These are standard JavaScript `Error` subclasses thrown by the midnight-js SDK packages.
+**Recognise by:** Error class names like `TxFailedError`, `DeployTxFailedError`, `CallTxFailedError`, `ContractTypeError`, `InvalidProtocolSchemeError`, `PrivateStateImportError`, `IndexerFormattedError`, `IndexerError`, `IndexerQueryError`, `IndexerDataError`, `IndexerSubscriptionDataError`, `IndexerProviderConfigError`. These are standard JavaScript `Error` subclasses thrown by the midnight-js SDK packages.
 
 ### 3. Effect tagged error with `_tag` like `Wallet.*`
 

--- a/plugins/midnight-status-codes/skills/status-codes/SKILL.md
+++ b/plugins/midnight-status-codes/skills/status-codes/SKILL.md
@@ -67,7 +67,7 @@ Read `references/runtime-errors.md`
 
 Read `references/zk-errors.md`
 
-**Recognise by:** Error messages containing "Synthesis error", "constraint system", "NotEnoughRowsAvailable", "wrong arity", PLONK-related terms, or proof verification failures.
+**Recognise by:** Error messages containing "Synthesis error", "constraint system", "NotEnoughRowsAvailable", "The SRS ... does not match for the given circuit", "invalid witness", PLONK-related terms, or proof verification failures.
 
 ### 8. Transaction validation or malformed transaction error (Rust-level)
 

--- a/plugins/midnight-status-codes/skills/status-codes/references/node-errors.md
+++ b/plugins/midnight-status-codes/skills/status-codes/references/node-errors.md
@@ -313,7 +313,7 @@ The runtime now uses the `#[frame_support::runtime]` macro (replacing `construct
 | 44 | pallet_federated_authority | Governance authority |
 | 45 | pallet_federated_authority_observation | Authority observation |
 | 50 | pallet_system_parameters | System parameters |
-| 51 | pallet_throttle | Transaction throttling — no error variants; failures surface as `InvalidTransaction::ExhaustsResources` from the `CheckThrottle` signed extension |
+| 51 | pallet_throttle | Transaction throttling — no error variants; failures surface as `InvalidTransaction::ExhaustsResources` from the `CheckThrottle` transaction extension |
 
 > Indices 8 (`pallet_session_validator_management`) and 32 (`pallet_partner_chains_bridge`) are upstream `input-output-hk/partner-chains` pallets vendored into the Midnight runtime; their error variants are documented below alongside the Midnight-authored pallets.
 >

--- a/plugins/midnight-status-codes/skills/status-codes/references/sdk-errors.md
+++ b/plugins/midnight-status-codes/skills/status-codes/references/sdk-errors.md
@@ -57,7 +57,7 @@ Fields:
 | `"Error executing circuit '${id}'"` | Circuit execution threw or returned an error | Inspect `cause` for the underlying error; check circuit inputs |
 | `String(err)` (stringified inner error) | Lazy `getContract()` instantiation failed; the message is just the inner error stringified | Inspect `cause` for the underlying error |
 
-> The previous reference listed three additional messages — `"Unexpected error converting runtime contract state"`, `"Failed to apply maintenance operation"`, `"Invalid number of arguments"` — that are **not present in `compact-js@2.5.0`**. They may have been retired or never existed in this exact form. Removed pending source confirmation.
+> The previous reference listed three additional messages — `"Unexpected error converting runtime contract state"`, `"Failed to apply maintenance operation"`, `"Invalid number of arguments"` — that are **not present in `compact-js@2.5.1`**. They may have been retired or never existed in this exact form. Removed pending source confirmation.
 
 ---
 

--- a/plugins/midnight-status-codes/skills/status-codes/references/sdk-errors.md
+++ b/plugins/midnight-status-codes/skills/status-codes/references/sdk-errors.md
@@ -1,6 +1,6 @@
 # Midnight SDK Error Reference
 
-> **Last verified:** 2026-05-04 — class-based family against `midnightntwrk/midnight-js@main` (`@midnight-ntwrk/midnight-js` and friends, all v4.0.4); Effect-based family against published npm tarballs of `@midnight-ntwrk/compact-js@2.5.0`, `@midnight-ntwrk/compact-js-command@2.5.0`, `@midnight-ntwrk/platform-js@2.2.4`, `@midnight-ntwrk/compact-runtime@0.16.0` (sourced from private repo `midnight-ntwrk/artifacts`).
+> **Last verified:** 2026-06-02 — class-based family against `midnightntwrk/midnight-js@main` (`@midnight-ntwrk/midnight-js` and friends, all v4.1.1); Effect-based family against published npm tarballs of `@midnight-ntwrk/compact-js@2.5.1`, `@midnight-ntwrk/compact-js-command@2.5.1`, `@midnight-ntwrk/platform-js@2.2.4`, `@midnight-ntwrk/compact-runtime@0.16.0`.
 
 ## Overview
 
@@ -328,7 +328,7 @@ Fix: Ensure the key exists and the wallet is in a state that permits key export.
 
 ## midnight-js-utils Inline Throws
 
-Package: `@midnight-ntwrk/midnight-js-utils` (v4.0.4)
+Package: `@midnight-ntwrk/midnight-js-utils` (v4.1.1)
 
 These utility helpers raise plain `Error` and `TypeError` instances inline — no `_tag`, no class hierarchy beyond the JS built-ins. Catch with `try/catch` and match by message substring.
 
@@ -352,16 +352,94 @@ Source paths are relative to `packages/utils/src/` in `midnightntwrk/midnight-js
 
 Package: `@midnight-ntwrk/midnight-js-indexer-public-data-provider`
 
-### IndexerFormattedError
+As of v4.1.1 all errors raised by this provider derive from a single abstract base class, so consumers can catch any of them with one `instanceof IndexerError` check.
+
+### IndexerError (abstract base)
 
 Extends: `Error`
 
-Wraps one or more GraphQL errors returned by the indexer.
+Abstract base class for all errors raised by the indexer public data provider. Never thrown directly — catch it to handle any indexer error in one branch, or narrow to a specific subclass below.
+
+```ts
+import { IndexerError } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
+try { /* ... */ } catch (e) { if (e instanceof IndexerError) { /* any indexer error */ } }
+```
+
+---
+
+### IndexerFormattedError
+
+Extends: `IndexerError`
+
+Raised when a GraphQL response includes one or more `GraphQLFormattedError` entries. Aggregates all server-side errors into a single numbered message.
 
 Fields:
-- `cause: readonly GraphQLFormattedError[]`
+- `errors: readonly GraphQLFormattedError[]`
 
-Fix: Inspect each entry in `cause` for the specific GraphQL error messages. Common causes: invalid queries, indexer not synced, requested data not yet indexed. Check indexer logs if the error persists.
+> **BREAKING (v4.1.1):** the GraphQL error array moved off the ES2022 `Error.cause` slot to a dedicated field named **`errors`**. Code that previously read `error.cause` must now read **`error.errors`**. (`Error.cause` was contractually a single underlying error, not a peer collection; reusing it confused Node's `util.inspect` causal chain, Sentry, and other structured loggers.)
+
+Message format: `` `Indexer GraphQL error(s):\n\t${errors.map((e, idx) => `${idx + 1}. ${e.message}`).join('\n\t')}` ``
+
+Fix: Inspect each entry in `errors` for the specific GraphQL error messages. Common causes: invalid queries, indexer not synced, requested data not yet indexed. Check indexer logs if the error persists.
+
+---
+
+### IndexerQueryError
+
+Extends: `IndexerError`
+
+Raised when an Apollo query or fetch fails at the **transport layer** (network failure, malformed response, Apollo client error) — distinct from `IndexerFormattedError`, which is for well-formed responses that carry `GraphQLFormattedError` entries. Preserves the original Apollo error via the standard `Error.cause` so consumers can inspect network details and the original stack.
+
+Fix: Check network connectivity to the indexer endpoint and the indexer URL configuration; inspect `cause` for the underlying Apollo/transport error.
+
+---
+
+### IndexerDataError
+
+Extends: `IndexerError`
+
+Raised when indexer-returned data is structurally inconsistent with the provider's expectations: unknown enum values, broken referential integrity, or missing relations the schema implies should be present.
+
+Fields:
+- `context: IndexerDataErrorContext` — a discriminated union (tag on `kind`):
+
+| `kind` | Extra fields | Message | Static factory |
+|---|---|---|---|
+| `'unknown-status'` | `value: string` | `` `Unexpected transaction status value: ${value}` `` | `IndexerDataError.unknownStatus(value)` |
+| `'missing-contract-action'` | `contractAddress: string` | `` `Deploy transaction does not contain a contract action for address ${contractAddress}` `` | `IndexerDataError.missingContractAction(contractAddress)` |
+| `'missing-identifier'` | `contractAddress: string`, `actionIndex: number`, `identifiersLength: number` | `` `Transaction missing identifier for contract action at address ${contractAddress} (actionIndex=${actionIndex}, identifiers.length=${identifiersLength})` `` | `IndexerDataError.missingIdentifier(contractAddress, actionIndex, identifiersLength)` |
+
+Construct only via the static factory methods so the message and `context` stay in sync. Branch on `error.context.kind` to handle each failure mode without parsing the message.
+
+Fix: Indicates an indexer/SDK schema mismatch or unindexed data — verify the indexer version is compatible and the contract/transaction has been fully indexed.
+
+---
+
+### IndexerSubscriptionDataError
+
+Extends: `IndexerError`
+
+Raised when an indexer subscription payload is missing a top-level field the provider relies on (server returned `null`/`undefined`).
+
+Fields:
+- `missingField: IndexerSubscriptionField` — `'blocks' | 'contractActions'`
+
+Message: `` `Expected '${missingField}' in indexer subscription data, got null/undefined` ``
+
+Fix: Usually an indexer/SDK schema mismatch; verify indexer compatibility.
+
+---
+
+### IndexerProviderConfigError
+
+Extends: `IndexerError`
+
+Raised when the consumer passes a configuration the provider does not support (e.g. an observable mode that cannot be served by the indexer's query surface). Signals API misuse, not a server-side issue.
+
+Fields:
+- inherited `message: string` only
+
+Fix: Review the provider configuration / observable mode against the supported options.
 
 ---
 

--- a/plugins/midnight-status-codes/skills/status-codes/references/zk-errors.md
+++ b/plugins/midnight-status-codes/skills/status-codes/references/zk-errors.md
@@ -1,8 +1,10 @@
 # ZK Errors Reference
 
-> **Last verified:** 2026-05-04 against `midnightntwrk/midnight-zk@midnight-proofs-v0.7.0` (the latest published proofs tag). At this tag the directory layout is `aggregator/`, `circuits/`, `curves/`, `proofs/`, `zk_stdlib/`, `zkir/` — **ZKIR is present**. The `next` branch removes ZKIR and adds `IvcError::InvalidWitness`; consumers tracking that branch should apply those changes themselves.
+> **Last verified:** 2026-06-02 against `midnightntwrk/midnight-zk@main`. The current directory layout is `aggregation/`, `circuits/`, `curves/`, `proofs/`, `zk_stdlib/` — **the `zkir/` Rust crate has been removed from `main`** (and the old `next` branch no longer exists). The "ZKIR Errors" Rust-crate section that previously appeared here has been dropped accordingly.
+>
+> **Note:** the removed `zkir/` *Rust crate* is unrelated to the `@midnight-ntwrk/zkir-v2` *npm package* (the WASM PLONK checker used by midnight-verify and the Compact toolchain), which is unaffected and still published (2.1.0). It is also unrelated to the Compact compiler's internal `zkir` pass (see compiler-errors.md).
 
-Errors from the zero-knowledge proof system used by Midnight (midnight-zk repo). Covers PLONK proving/verification, ZKIR circuit compilation, IVC aggregation, and dev/test tools. These errors surface during proof generation, proof verification, circuit compilation, or development testing.
+Errors from the zero-knowledge proof system used by Midnight (midnight-zk repo). Covers PLONK proving/verification, IVC aggregation, and dev/test tools. These errors surface during proof generation, proof verification, or development testing.
 
 ## PLONK Errors
 
@@ -23,7 +25,7 @@ Primary proof system errors:
 | `NotEnoughColumnsForConstants` | "Too few fixed columns are enabled for global constants usage" | Enable more fixed columns in circuit config |
 | `ColumnNotInPermutation(Column)` | "Column {column:?} must be included in the permutation. Help: try applying \`meta.enable_equalty\` on the column" *(note upstream typo: source says `enable_equalty`, missing an `i`; the actual API method is `enable_equality()`)* | Add `meta.enable_equality()` on the column |
 | `TableError(TableError)` | Delegates to TableError | See Table Errors below |
-| `SrsError(usize, usize)` | "The SRS does not match for the given circuit" | SRS size doesn't match circuit; regenerate keys with correct SRS |
+| `SrsError(usize, usize)` | "The SRS (with size {srs_k}) does not match for the given circuit (of size {circuit_k})" | SRS size doesn't match circuit; regenerate keys with correct SRS |
 | `CompletenessFailure` | "Completeness failure due to bad luck in random sampling. This error is expected to be almost impossible to trigger." | Extremely rare; retry the proof generation |
 
 ## Table Errors
@@ -32,7 +34,7 @@ Source: `proofs/src/plonk/error.rs`
 
 | Variant | Message | Fixes |
 |---------|---------|-------|
-| `ColumnNotAssigned(TableColumn)` | "{col} not fully assigned. Assign a value at offset 0." | Assign values to all table column rows |
+| `ColumnNotAssigned(TableColumn)` | "{col:?} not fully assigned. Help: assign a value at offset 0." *(`{col:?}` is the column's Debug repr, e.g. `TableColumn { inner: Column { index: 0, column_type: Fixed } }`)* | Assign values to all table column rows |
 | `UnevenColumnLengths` | "{col} has length {n} while {table} has length {m}" | All columns in a lookup table must have equal length |
 | `UsedColumn(TableColumn)` | "{col} has already been used" | Don't reuse table columns |
 | `OverwriteDefault(TableColumn, String, String)` | "Attempted to overwrite default value" | Don't assign different values to the same default cell |
@@ -47,39 +49,6 @@ Source: `proofs/src/poly/mod.rs`
 | `SamplingError` | Need to re-sample evaluation point | Retry with different randomness |
 | `DuplicatedQuery` | Duplicate query to same (commitment, opening) pair | Multiopen argument only supports single query per pair |
 
-## ZKIR Errors
-
-Source: `zkir/src/error.rs` (present on `main` and at the `midnight-proofs-v0.7.0` tag; **removed on `next`**).
-
-> **Note:** the ZKIR enum implements only `fmt::Debug`, **not `fmt::Display`**. The strings below are Debug-formatter outputs, not user-facing Display strings. When ZKIR errors flow through `From<Error> for plonk::Error`, they become `plonk::Error::Synthesis(format!("{error:?}"))`.
-
-| Variant | Debug format | Fixes |
-|---------|--------------|-------|
-| `InvalidArity(Operation)` | "wrong arity: '{op:?}'" | Operation received wrong number of inputs/outputs |
-| `ParsingError(IrType, String)` | "'{s:?}' cannot be parsed as a {t:?}" | Value doesn't match expected type (Bool, Native, JubjubScalar) |
-| `NotFound(Name)` | "'{s}' not found" | Variable or witness not in memory; check circuit definitions |
-| `DuplicatedName(Name)` | "'{s}' already exists" | Variable name collision; rename to avoid shadowing |
-| `ExpectingType(IrType, IrType)` | "type {e:?} was expected instead of {t:?}" | Type mismatch in circuit IR |
-| `Unsupported(Operation, Vec<IrType>)` | "{op:?} is not supported on {t:?}" | Operation not supported for these types |
-| `Other(String)` | "{s}" | Catch-all; check message for specifics |
-
-Verified `Other` messages constructed at `midnight-proofs-v0.7.0` (full enumeration of `Error::Other(...)` constructor sites in the `zkir` crate):
-
-| Message (verbatim format-string) | Source file |
-|----------------------------------|-------------|
-| `"cannot convert {:?} to {:?}"` (e.g. `cannot convert Bool to "Native"`, `cannot convert BigUint(7) to "Native"`, `cannot convert Native to "Bytes"`) — emitted by the `TryFrom<IrValue>` macro for every typed extractor | `zkir/src/types.rs` |
-| `"invalid length"` (off-circuit and in-circuit inner-product when `v.len() != w.len()` or empty) | `zkir/src/instructions/operations/inner_product.rs` |
-| `"underflow subtracting {b} from {a}"` (BigUint subtraction when `a < b`) | `zkir/src/instructions/operations/sub.rs` |
-| `"cannot convert {x} to Bytes({n})"` and `"cannot convert {big} to Bytes({n})"` | `zkir/src/instructions/operations/into_bytes.rs` |
-| `"cannot convert {bytes:?} to JubjubPoint"` and `"expecting Bytes(n), got {:?}"` (from-bytes-incircuit) | `zkir/src/instructions/operations/from_bytes.rs` |
-| `"assertion violated: {:?} == {:?}"` (off-circuit `AssertEqual` failure) | `zkir/src/parser/offcircuit.rs` |
-| `"assertion violated: {:?} != {:?}"` (off-circuit `AssertNotEqual` failure) | `zkir/src/parser/offcircuit.rs` |
-| `"expecting Bytes(n), got {:?}"` (off-circuit `FromBytes` input not Bytes) | `zkir/src/parser/offcircuit.rs` |
-| `"invalid format: {value}"` (constant parsing in `parse_constant`) | `zkir/src/utils/constants.rs` |
-| `"{e}"` (serde_json error during `ZkirRelation::read`) | `zkir/src/zkir.rs` |
-
-Plus the implicit `From<plonk::Error> for Error` conversion in `zkir/src/error.rs` wraps any PLONK error as `Error::Other(format!("{error:?}"))` — so any PLONK failure surfaced through ZKIR will appear here with the Debug-format of the underlying `plonk::Error`.
-
 ## IVC Errors
 
 Source: `aggregation/src/ivc/error.rs`
@@ -88,6 +57,7 @@ Source: `aggregation/src/ivc/error.rs`
 |---------|---------|-------|
 | `ProofGeneration(plonk::Error)` | "proof generation failed: {e}" | Wraps PLONK error; see PLONK errors above |
 | `InvalidInstance` | "invalid instance" | IVC instance is malformed |
+| `InvalidWitness(String)` | "invalid witness: {msg}" | The witness supplied to the IVC step is invalid; check the message for specifics |
 | `VkMismatch` | "verifying-key mismatch" | VK in instance doesn't match verifier's key; ensure consistent keys |
 | `InvalidProof` | "invalid proof" | Accumulator pairing check failed; proof is invalid |
 | `TranscriptNotEmpty` | "proof transcript not empty" | Trailing data in proof; may indicate corruption |
@@ -122,8 +92,6 @@ Dev/testing infrastructure for debugging circuit issues. All types implement Dis
 ## Error Conversion Chains
 
 ```
-zkir::Error  ──From──►  plonk::Error::Synthesis(format!("{error:?}"))
-plonk::Error ──From──►  zkir::Error::Other(format!("{error:?}"))
 io::Error    ──From──►  plonk::Error::Transcript(error)
 plonk::Error ──From──►  IvcError::ProofGeneration(e)
 ```


### PR DESCRIPTION
## What changed
- **zk-errors.md** (vs `midnightntwrk/midnight-zk` `main`): the Rust `zkir/` crate was removed upstream -> dropped the dead "ZKIR Errors"/"Other messages" sections and added a note distinguishing it from the *unaffected* published `@midnight-ntwrk/zkir-v2` (2.1.0); fixed repo layout `aggregator/` -> `aggregation/`; removed stale "track the next branch" guidance (branch 404s); added `IvcError::InvalidWitness(String)`; corrected `SrsError` and `TableError::ColumnNotAssigned` Display strings.
- **sdk-errors.md + codes.json**: added the `midnight-js` 4.1.1 `IndexerError` hierarchy and the **breaking** `IndexerFormattedError.cause` -> `.errors` rename; 6 new indexer error codes (validated via `check-schema.sh` + `lookup.sh`).

Node numeric error codes (212-250) were already accurate -- unchanged.

**Source:** midnightntwrk/midnight-zk (`main`), midnightntwrk/midnight-js `v4.1.1`.
**Verification:** facts confirmed against the published `@midnight-ntwrk/midnight-js-indexer-public-data-provider@4.1.1` tarball `.d.ts` and the zk clone; final audit verdict: clean.
**Note:** Left unmerged for review.

🤖 Part of the 2026-06-02 Midnight Expert upstream revalidation sweep.

Generated with [Claude Code](https://claude.com/claude-code)