### PR TITLE
docs(midnight-tooling): compactc 0.31.0, indexer /api/v4, devnet image caps, proof-server 8.0.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-expert",
   "metadata": {
-    "version": "0.32.0",
+    "version": "0.33.0",
     "description": "AI agent plugins for the Midnight data-protection blockchain. Covers Compact smart contract development, privacy-preserving patterns, DApp frontend design, and Midnight toolchain management."
   },
   "owner": {

--- a/plugins/midnight-tooling/.claude-plugin/plugin.json
+++ b/plugins/midnight-tooling/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-tooling",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Installs, configures, and manages the Midnight Network development toolchain \u2014 Compact CLI, compiler version switching, local devnet (node, indexer, proof server), diagnostics, and release notes for all Midnight components.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-tooling/commands/devnet.md
+++ b/plugins/midnight-tooling/commands/devnet.md
@@ -46,7 +46,7 @@ If the subcommand is `generate`:
 
 1. **Resolve versions:**
    - If `--node-version`, `--indexer-version`, and `--proof-server-version` are ALL provided, use those values.
-   - If ANY explicit version is missing, run `${CLAUDE_SKILL_DIR}/scripts/resolve-versions.sh` to get the latest stable versions from Docker Hub. Use the resolved values for any versions not explicitly provided.
+   - If ANY explicit version is missing, run `${CLAUDE_SKILL_DIR}/scripts/resolve-versions.sh` to get the latest devnet-compatible stable versions from Docker Hub. Use the resolved values for any versions not explicitly provided. The resolver caps `midnight-node` below `1.0.0` (the GA mainnet node is not a local-devnet image) and `indexer-standalone` below `4.3.0` (which requires a Blockfrost key); to run a capped tag deliberately, pass it explicitly via `--node-version` / `--indexer-version`.
 
 2. **Verify user-specified versions (if any explicit versions were provided and `--no-verify` is NOT set):**
    - For each user-specified version, check that the Docker Hub tag exists:
@@ -166,7 +166,7 @@ If the subcommand is `health`:
 
   ```bash
   curl -sf -o /dev/null -w "%{http_code} %{time_total}s" http://localhost:9944/health
-  curl -sf -o /dev/null -w "%{http_code} %{time_total}s" http://localhost:8088/api/v3/graphql
+  curl -sf -o /dev/null -w "%{http_code} %{time_total}s" http://localhost:8088/api/v4/graphql
   curl -sf -o /dev/null -w "%{http_code} %{time_total}s" http://localhost:6300/health
   ```
 

--- a/plugins/midnight-tooling/skills/compact-cli/SKILL.md
+++ b/plugins/midnight-tooling/skills/compact-cli/SKILL.md
@@ -45,15 +45,15 @@ The toolchain reports three independent version numbers. Confusing them is a com
 | What | Commands | Example Output |
 |------|----------|----------------|
 | **CLI tool version** | `compact --version`, `compact self --version` | `compact 0.5.1` |
-| **Compiler version** | `compact compile --version`, `compact format --version`, `compact fixup --version` | `0.30.0` |
-| **Language version** | `compact compile --language-version`, `compact format --language-version`, `compact fixup --language-version` | `0.22.0` |
+| **Compiler version** | `compact compile --version`, `compact format --version`, `compact fixup --version` | `0.31.0` |
+| **Language version** | `compact compile --language-version`, `compact format --language-version`, `compact fixup --language-version` | `0.23.0` |
 
 The compiler also reports two additional versions relevant to DApp developers:
 
 | What | Command | Example Output |
 |------|---------|----------------|
 | **Ledger version** | `compact compile -- --ledger-version` | `ledger-8.0.2` |
-| **Runtime JS package version** | `compact compile -- --runtime-version` | `0.15.0` |
+| **Runtime JS package version** | `compact compile -- --runtime-version` | `0.16.0` |
 
 The CLI and compiler update independently:
 

--- a/plugins/midnight-tooling/skills/compact-cli/references/installation.md
+++ b/plugins/midnight-tooling/skills/compact-cli/references/installation.md
@@ -78,7 +78,7 @@ The installer places the `compact` binary in `~/.local/bin/` or `~/.compact/bin/
 │   ├── format-compact      # Formatter binary
 │   └── fixup-compact       # Fixup binary
 └── versions/
-    └── 0.30.0/
+    └── 0.31.0/
         └── aarch64-darwin/
             ├── compactc        # Shell wrapper
             ├── compactc.bin    # Actual compiler binary
@@ -87,7 +87,7 @@ The installer places the `compact` binary in `~/.local/bin/` or `~/.compact/bin/
             ├── zkir
             ├── zkir-v3
             ├── artifact.zip
-            └── toolchain-0.30.0.md  # Release notes
+            └── toolchain-0.31.0.md  # Release notes
 ```
 
 The `bin/` directory symlinks point to the current default version. Changing the default with `compact update <VERSION>` updates these symlinks.
@@ -103,7 +103,7 @@ compact --version
 
 # Check compiler version
 compact compile --version
-# Example output: 0.30.0
+# Example output: 0.31.0
 
 # Check installation path
 which compact
@@ -113,7 +113,7 @@ which compact
 compact list --installed
 # Example output:
 # compact: installed versions
-# → 0.30.0
+# → 0.31.0
 ```
 
 The arrow (`→`) next to a version indicates it is the current default.

--- a/plugins/midnight-tooling/skills/compact-cli/references/version-management.md
+++ b/plugins/midnight-tooling/skills/compact-cli/references/version-management.md
@@ -14,7 +14,7 @@ Downloads the latest compiler version and sets it as default. If already install
 
 Example output:
 ```
-compact: aarch64-darwin -- 0.30.0 -- already installed
+compact: aarch64-darwin -- 0.31.0 -- already installed
 ```
 
 ### Install a Specific Version
@@ -49,9 +49,9 @@ Example output:
 ```
 compact: available versions
 
-→ 0.30.0 - x86_macos, aarch64_macos, x86_linux, aarch64_linux
+→ 0.31.0 - x86_macos, aarch64_macos, x86_linux, aarch64_linux
+  0.30.0 - x86_macos, aarch64_macos, x86_linux, aarch64_linux
   0.29.0 - x86_macos, aarch64_macos, x86_linux, aarch64_linux
-  0.28.0 - x86_macos, aarch64_macos, x86_linux
 ```
 
 The arrow (`→`) indicates the current default. Each version lists available platform builds.
@@ -66,9 +66,9 @@ Example output:
 ```
 compact: installed versions
 
-→ 0.30.0
+→ 0.31.0
+  0.30.0
   0.29.0
-  0.28.0
 ```
 
 ## Checking for Updates
@@ -81,7 +81,7 @@ Queries the remote server and reports whether a newer compiler version is availa
 
 Example output:
 ```
-compact: aarch64-darwin -- Up to date -- 0.30.0
+compact: aarch64-darwin -- Up to date -- 0.31.0
 ```
 
 ## Cleaning Up
@@ -116,18 +116,18 @@ Removes the GitHub API response cache (`github_cache.json`). The cache has a 15-
 
 ```bash
 # Install both versions
+compact update 0.31.0
 compact update 0.30.0
-compact update 0.29.0
 
-# Now 0.29.0 is default (most recently updated)
+# Now 0.30.0 is default (most recently updated)
 # Compile with default
 compact compile src/contract.compact build/
 
 # Compile with a specific version without changing default
-compact compile +0.30.0 src/contract.compact build/
+compact compile +0.31.0 src/contract.compact build/
 
 # Switch default back
-compact update 0.30.0
+compact update 0.31.0
 ```
 
 ### Pin a Project to a Specific Version

--- a/plugins/midnight-tooling/skills/devnet-health/scripts/status.sh
+++ b/plugins/midnight-tooling/skills/devnet-health/scripts/status.sh
@@ -26,7 +26,7 @@ fi
 # service-key | containerName | port | url
 SERVICES=(
   "node|midnight-node|9944|http://127.0.0.1:9944"
-  "indexer|midnight-indexer|8088|http://127.0.0.1:8088/api/v3/graphql"
+  "indexer|midnight-indexer|8088|http://127.0.0.1:8088/api/v4/graphql"
   "proof-server|midnight-proof-server|6300|http://127.0.0.1:6300"
 )
 

--- a/plugins/midnight-tooling/skills/devnet/SKILL.md
+++ b/plugins/midnight-tooling/skills/devnet/SKILL.md
@@ -52,10 +52,10 @@ If Docker is not installed, see `references/docker-setup.md` for platform-specif
 | Service | Port | Endpoint | Purpose |
 |---------|------|----------|---------|
 | **Node** | 9944 | `http://127.0.0.1:9944` | Blockchain RPC (Substrate JSON-RPC) |
-| **Indexer** | 8088 | `http://127.0.0.1:8088/api/v3/graphql` | GraphQL queries and subscriptions |
+| **Indexer** | 8088 | `http://127.0.0.1:8088/api/v4/graphql` | GraphQL queries and subscriptions |
 | **Proof server** | 6300 | `http://127.0.0.1:6300` | Zero-knowledge proof generation |
 
-The indexer also exposes a WebSocket endpoint at `ws://127.0.0.1:8088/api/v3/graphql/ws` for real-time subscriptions.
+The indexer also exposes a WebSocket endpoint at `ws://127.0.0.1:8088/api/v4/graphql/ws` for real-time subscriptions.
 
 The network ID for local devnet is `undeployed`.
 

--- a/plugins/midnight-tooling/skills/devnet/references/compose-structure.md
+++ b/plugins/midnight-tooling/skills/devnet/references/compose-structure.md
@@ -82,7 +82,7 @@ indexer:
 |-------|---------|
 | `image` | The Midnight standalone indexer. Version from `midnightntwrk/indexer-standalone`. |
 | `container_name` | Fixed name `midnight-indexer`. |
-| `ports` | Exposes GraphQL API on port 8088. Both HTTP (`/api/v3/graphql`) and WebSocket (`/api/v3/graphql/ws`) endpoints are served here. |
+| `ports` | Exposes GraphQL API on port 8088. Both HTTP (`/api/v4/graphql`) and WebSocket (`/api/v4/graphql/ws`) endpoints are served here. |
 | `RUST_LOG` | Controls Rust log verbosity. Default enables info-level logs for indexer modules and disables noisy telemetry. |
 | `APP__APPLICATION__NETWORK_ID` | Must be `undeployed` for local devnet. This matches the Lace wallet extension defaults so Lace connects without custom configuration. |
 | `APP__INFRA__NODE__URL` | WebSocket connection to the node. Uses Docker internal DNS name `node` (the service name), not `localhost`. |

--- a/plugins/midnight-tooling/skills/devnet/references/network-lifecycle.md
+++ b/plugins/midnight-tooling/skills/devnet/references/network-lifecycle.md
@@ -106,7 +106,7 @@ A container can be "running" (per Docker) but not yet ready to accept requests â
 | Service | Endpoint | Method |
 |---------|----------|--------|
 | Node | `http://localhost:9944/health` | HTTP GET |
-| Indexer | `http://localhost:8088/api/v3/graphql` | HTTP GET |
+| Indexer | `http://localhost:8088/api/v4/graphql` | HTTP GET |
 | Proof Server | `http://localhost:6300/health` | HTTP GET |
 
 ## Getting Network Configuration
@@ -128,8 +128,8 @@ Use these endpoints when configuring DApps or tools to connect to the local devn
 |----------|-----|----------|
 | Node RPC | `http://127.0.0.1:9944` | HTTP (JSON-RPC) |
 | Node WebSocket | `ws://127.0.0.1:9944` | WebSocket |
-| Indexer GraphQL | `http://127.0.0.1:8088/api/v3/graphql` | HTTP (GraphQL) |
-| Indexer WebSocket | `ws://127.0.0.1:8088/api/v3/graphql/ws` | WebSocket (subscriptions) |
+| Indexer GraphQL | `http://127.0.0.1:8088/api/v4/graphql` | HTTP (GraphQL) |
+| Indexer WebSocket | `ws://127.0.0.1:8088/api/v4/graphql/ws` | WebSocket (subscriptions) |
 | Proof Server | `http://127.0.0.1:6300` | HTTP |
 
 The network ID for the local devnet is `undeployed`. This value is used in DApp provider configurations and wallet connections.

--- a/plugins/midnight-tooling/skills/devnet/references/version-resolution.md
+++ b/plugins/midnight-tooling/skills/devnet/references/version-resolution.md
@@ -29,7 +29,19 @@ From all tags, the script selects only those matching the strict `X.Y.Z` semver 
 - Architecture-specific: `7.0.0-amd64`, `7.0.0-arm64`
 - Latest/other: `latest`, `nightly`, `dev`
 
-The highest version (by numeric semver comparison) is selected for each image.
+The highest version (by numeric semver comparison) is selected for each image, subject to per-image upper bounds (below).
+
+### Per-Image Upper Bounds
+
+Some published image tags are not usable for a self-contained local devnet, so the resolver caps each image below a known-bad version rather than blindly taking the newest tag:
+
+| Image | Cap | Why |
+|-------|-----|-----|
+| `midnight-node` | `< 1.0.0` (stays on the `0.22.x` line) | `1.0.0` is the mainnet GA node, not a local-devnet image. The local standalone devnet is built around `0.22.x` (`CFG_PRESET=dev`); the official `create-mn-app` scaffold pins `0.22.5`. |
+| `indexer-standalone` | `< 4.3.0` | From `4.3.0` the standalone indexer requires a Blockfrost API key and exits with code 1 without one, so it cannot run key-less in a local devnet. The official `create-mn-app` scaffold pins `4.2.1`. |
+| `proof-server` | none | The latest stable proof-server tag is usable for the local devnet. |
+
+These caps live in `resolve-versions.sh` (the `max_exclusive` column of its `IMAGES` table). To run a capped image deliberately, pass it explicitly via `--node-version` / `--indexer-version` (which skips resolution for that image).
 
 ### Verifying User-Specified Versions
 

--- a/plugins/midnight-tooling/skills/devnet/scripts/resolve-versions.sh
+++ b/plugins/midnight-tooling/skills/devnet/scripts/resolve-versions.sh
@@ -17,10 +17,23 @@ for cmd in curl jq; do
   fi
 done
 
+# Each entry: key|image|max_exclusive
+# max_exclusive (optional) caps version resolution to tags strictly below the
+# given version. This keeps the local devnet on images that actually work as a
+# self-contained dev network, rather than blindly taking the highest tag on
+# Docker Hub:
+#   - midnight-node: capped below 1.0.0. The 1.0.0 GA tag is the mainnet node,
+#     not a local-devnet image; the local standalone devnet is built around the
+#     0.22.x line (CFG_PRESET=dev). The official create-mn-app scaffold pins
+#     0.22.5.
+#   - indexer-standalone: capped below 4.3.0. From 4.3.0 the standalone indexer
+#     requires a Blockfrost API key and exits 1 without one, so it cannot run in
+#     a key-less local devnet. The official create-mn-app scaffold pins 4.2.1.
+# proof-server has no cap (latest stable is usable for the local devnet).
 IMAGES=(
-  "node|midnightntwrk/midnight-node"
-  "indexer|midnightntwrk/indexer-standalone"
-  "proof-server|midnightntwrk/proof-server"
+  "node|midnightntwrk/midnight-node|1.0.0"
+  "indexer|midnightntwrk/indexer-standalone|4.3.0"
+  "proof-server|midnightntwrk/proof-server|"
 )
 
 # Fetch all tags for an image from Docker Hub, handling pagination.
@@ -48,23 +61,39 @@ fetch_tags() {
 }
 
 # Filter tags to pure X.Y.Z semver (no pre-release, no arch suffix, no rc/alpha/beta).
-# Returns the highest version.
+# Returns the highest version, optionally strictly below $2 (max_exclusive).
 highest_stable() {
   local tags="$1"
-  echo "$tags" \
+  local max_exclusive="${2:-}"
+  local stable
+  stable=$(echo "$tags" \
     | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
-    | sort -t. -k1,1n -k2,2n -k3,3n \
-    | tail -1
+    | sort -t. -k1,1n -k2,2n -k3,3n)
+
+  if [ -n "$max_exclusive" ]; then
+    # Keep only versions strictly less than max_exclusive (numeric semver compare).
+    stable=$(echo "$stable" | awk -F. -v m="$max_exclusive" '
+      BEGIN { split(m, mm, ".") }
+      {
+        if ($1 < mm[1]) { print; next }
+        if ($1 > mm[1]) { next }
+        if ($2 < mm[2]) { print; next }
+        if ($2 > mm[2]) { next }
+        if ($3 < mm[3]) { print }
+      }')
+  fi
+
+  echo "$stable" | tail -1
 }
 
 errors=0
 
 for entry in "${IMAGES[@]}"; do
-  IFS='|' read -r name image <<< "$entry"
+  IFS='|' read -r name image max_exclusive <<< "$entry"
 
   tags=$(fetch_tags "$image") || { errors=$((errors + 1)); continue; }
 
-  version=$(highest_stable "$tags")
+  version=$(highest_stable "$tags" "$max_exclusive")
   if [ -z "$version" ]; then
     echo "ERROR: No stable version found for ${image}" >&2
     errors=$((errors + 1))

--- a/plugins/midnight-tooling/skills/proof-server/SKILL.md
+++ b/plugins/midnight-tooling/skills/proof-server/SKILL.md
@@ -114,10 +114,10 @@ Start the proof server in detached mode so it runs in the background (replace `<
 docker run -d --name midnight-proof-server -p 6300:6300 midnightntwrk/proof-server:<tag> -- midnight-proof-server -v
 ```
 
-For example, with version 7.0.0:
+For example, with version 8.0.3:
 
 ```bash
-docker run -d --name midnight-proof-server -p 6300:6300 midnightntwrk/proof-server:7.0.0 -- midnight-proof-server -v
+docker run -d --name midnight-proof-server -p 6300:6300 midnightntwrk/proof-server:8.0.3 -- midnight-proof-server -v
 ```
 
 | Flag / Argument | Purpose |


### PR DESCRIPTION
## What changed
- **compact-cli**: compiler `0.30.0` -> `0.31.0`, language `0.22.0` -> `0.23.0`, runtime `0.15.0` -> `0.16.0` (matches the live toolchain).
- **devnet**: indexer GraphQL path `/api/v3` -> `/api/v4/graphql` (+ `/ws`); `resolve-versions.sh` per-image caps (`midnight-node` below 1.0.0 -> resolves 0.22.5, `indexer-standalone` below 4.3.0 -> resolves 4.2.1 to avoid the Blockfrost-key requirement, `proof-server` uncapped); `proof-server` example bumped 7.0.0 -> 8.0.3. devnet-health probe URL -> v4.

Multi-version illustrative examples were intentionally preserved.

**Source:** midnightntwrk/create-mn-app `v0.4.1` (scaffold-authoritative pins), live Docker Hub tags, live `compact`/`npm`.
**Verification:** version caps re-derived against live Docker Hub tags; `bash -n` on scripts; reviewer verdict: clean.
**Note:** node devnet image deliberately kept at 0.22.x. Left unmerged for review.

🤖 Part of the 2026-06-02 Midnight Expert upstream revalidation sweep.

Generated with [Claude Code](https://claude.com/claude-code)