### PR TITLE
docs(midnight-indexer): align with indexer v4.3.2 schema (/api/v4, HexEncoded, new subscriptions/fields)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-expert",
   "metadata": {
-    "version": "0.33.0",
+    "version": "0.34.0",
     "description": "AI agent plugins for the Midnight data-protection blockchain. Covers Compact smart contract development, privacy-preserving patterns, DApp frontend design, and Midnight toolchain management."
   },
   "owner": {

--- a/plugins/midnight-indexer/.claude-plugin/plugin.json
+++ b/plugins/midnight-indexer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-indexer",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Technical reference for the Midnight indexer \u2014 architecture, GraphQL API, data model, and operational guidance for querying on-chain state",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-indexer/skills/indexer-architecture/SKILL.md
+++ b/plugins/midnight-indexer/skills/indexer-architecture/SKILL.md
@@ -8,7 +8,7 @@ version: 0.1.0
 
 The Midnight indexer is a Rust application (edition 2024) built with async-graphql, axum, and subxt. It connects to a Midnight node via WebSocket, indexes on-chain data into a database, and exposes it through a GraphQL API.
 
-**Current version:** 4.0.0 (released 2026-03-17)
+**Current version:** 4.3.2 (released 2026-05-15)
 
 ## Component Overview
 

--- a/plugins/midnight-indexer/skills/indexer-graphql-api/SKILL.md
+++ b/plugins/midnight-indexer/skills/indexer-graphql-api/SKILL.md
@@ -100,7 +100,7 @@ query {
 
 | Mutation | Parameters | Returns | Purpose |
 |---------|-----------|---------|---------|
-| `connect(viewingKey!, options?)` | Bech32m or hex-encoded viewing key; optional `ConnectOptions { startIndex }` to begin scanning from a transaction index | Session ID (`HexEncoded`) | Establish wallet session for shielded transaction scanning |
+| `connect(viewingKey!, options?)` | Bech32m-encoded viewing key (`ViewingKey` scalar); optional `ConnectOptions { startIndex }` to begin scanning from a transaction index | Session ID (`HexEncoded`) | Establish wallet session for shielded transaction scanning |
 | `disconnect(sessionId!)` | Session ID from `connect` | `Unit` (empty) | End wallet session |
 
 ### Example: Wallet Connection
@@ -131,9 +131,13 @@ The indexer provides 9 subscriptions for real-time event streaming over WebSocke
 | `unshieldedTransactions(address!, transactionId?)` | `UnshieldedAddress` (Bech32m), optional `Int` transactionId | `UnshieldedTransactionsEvent` union (UnshieldedTransaction or UnshieldedTransactionsProgress) |
 | `dustLedgerEvents(id?)` | Optional `Int` event id to resume from | DUST ledger events |
 | `zswapLedgerEvents(id?)` | Optional `Int` event id to resume from | Zswap ledger events |
-| `dustGenerations(dustAddress!, startIndex!, endIndex!)` | DUST address + inclusive index range | `DustGenerationsEvent` union (generation entries, collapsed Merkle updates, dtime updates) |
-| `dustNullifierTransactions(nullifierPrefixes!, fromBlock?, toBlock?)` | DUST nullifier prefixes + optional block range | DustNullifierTransaction (tx/block references) |
+| `dustGenerations(dustAddress!, startIndex!, endIndex!)` | DUST address (`DustAddress` scalar) + inclusive `[startIndex, endIndex]` index range | `DustGenerationsEvent` union (generation entries, collapsed Merkle updates, dtime updates) |
+| `dustNullifierTransactions(nullifierLeBytesPrefixes!, fromBlock?, toBlock?)` | DUST nullifier prefixes (`[HexEncoded!]!`) + optional block range | DustNullifierTransaction (tx/block references) |
 | `shieldedNullifierTransactions(nullifierPrefixes!, fromBlock?, toBlock?)` | Shielded (zswap) nullifier prefixes + optional block range | ShieldedNullifierTransaction (tx/block references) |
+
+> **Note:** the two nullifier subscriptions deliberately use different prefix-arg names — `dustNullifierTransactions` takes `nullifierLeBytesPrefixes`, while `shieldedNullifierTransactions` takes `nullifierPrefixes`.
+
+> **`dustGenerations` index range:** `[startIndex, endIndex]` is **inclusive** at the subscription level. Note the off-by-one against the natural source value `Block.dustGenerationEndIndex`, which is **exclusive** — to cover up to a block's end, pass `endIndex: dustGenerationEndIndex - 1`.
 
 ### Example: Subscribe to Blocks
 
@@ -224,7 +228,7 @@ All contract actions share these fields:
 | Field | Type | Description |
 |-------|------|-------------|
 | `status` | TransactionResultStatus | Overall outcome (see enum below) |
-| `segments` | [Segment!] | Per-segment success flags (present on partial success) |
+| `segments` | [Segment!] | Per-segment success flags. **Null unless `status` is `PARTIAL_SUCCESS`** — null-check before iterating |
 
 `TransactionResultStatus` enum values:
 

--- a/plugins/midnight-indexer/skills/indexer-graphql-api/SKILL.md
+++ b/plugins/midnight-indexer/skills/indexer-graphql-api/SKILL.md
@@ -62,7 +62,7 @@ query {
     timestamp
     transactions {
       hash
-      identifier
+      identifiers
     }
   }
 }
@@ -87,7 +87,7 @@ query {
       zswapState
       unshieldedBalances {
         tokenType
-        value
+        amount
       }
     }
   }
@@ -100,8 +100,8 @@ query {
 
 | Mutation | Parameters | Returns | Purpose |
 |---------|-----------|---------|---------|
-| `connect(viewingKey!)` | Bech32m or hex-encoded viewing key | Session ID | Establish wallet session for shielded transaction scanning |
-| `disconnect(sessionId!)` | Session ID from `connect` | Confirmation | End wallet session |
+| `connect(viewingKey!, options?)` | Bech32m or hex-encoded viewing key; optional `ConnectOptions { startIndex }` to begin scanning from a transaction index | Session ID (`HexEncoded`) | Establish wallet session for shielded transaction scanning |
+| `disconnect(sessionId!)` | Session ID from `connect` | `Unit` (empty) | End wallet session |
 
 ### Example: Wallet Connection
 
@@ -113,7 +113,7 @@ mutation {
 
 # Disconnect wallet
 mutation {
-  disconnect(sessionId: "session-uuid-here")
+  disconnect(sessionId: "session-id-hex")
 }
 ```
 
@@ -121,16 +121,19 @@ mutation {
 
 ## Subscriptions
 
-The indexer provides 6 subscriptions for real-time event streaming over WebSocket.
+The indexer provides 9 subscriptions for real-time event streaming over WebSocket.
 
 | Subscription | Parameters | Emits |
 |-------------|-----------|-------|
-| `blocks(offset?)` | Start block (hash or height) | Block objects |
-| `contractActions(address!, offset?)` | Contract address + optional start offset | ContractDeploy, ContractCall, or ContractUpdate |
-| `shieldedTransactions(sessionId!, index?)` | Session ID from `connect` mutation | RelevantTransaction + sync progress |
-| `unshieldedTransactions(address!, transactionId?)` | Bech32m address, optional resume point | UnshieldedTransaction + sync progress |
-| `dustLedgerEvents(id?)` | Optional event ID to resume from | DUST ledger events |
-| `zswapLedgerEvents(id?)` | Optional event ID to resume from | Zswap ledger events |
+| `blocks(offset?)` | Optional `BlockOffset` (hash or height) start block | Block objects |
+| `contractActions(address!, offset?)` | Contract address + optional `BlockOffset` start | ContractDeploy, ContractCall, or ContractUpdate |
+| `shieldedTransactions(sessionId!, index?)` | Session ID from `connect` mutation, optional `Int` index | `ShieldedTransactionsEvent` union (RelevantTransaction or ShieldedTransactionsProgress) |
+| `unshieldedTransactions(address!, transactionId?)` | `UnshieldedAddress` (Bech32m), optional `Int` transactionId | `UnshieldedTransactionsEvent` union (UnshieldedTransaction or UnshieldedTransactionsProgress) |
+| `dustLedgerEvents(id?)` | Optional `Int` event id to resume from | DUST ledger events |
+| `zswapLedgerEvents(id?)` | Optional `Int` event id to resume from | Zswap ledger events |
+| `dustGenerations(dustAddress!, startIndex!, endIndex!)` | DUST address + inclusive index range | `DustGenerationsEvent` union (generation entries, collapsed Merkle updates, dtime updates) |
+| `dustNullifierTransactions(nullifierPrefixes!, fromBlock?, toBlock?)` | DUST nullifier prefixes + optional block range | DustNullifierTransaction (tx/block references) |
+| `shieldedNullifierTransactions(nullifierPrefixes!, fromBlock?, toBlock?)` | Shielded (zswap) nullifier prefixes + optional block range | ShieldedNullifierTransaction (tx/block references) |
 
 ### Example: Subscribe to Blocks
 
@@ -149,16 +152,26 @@ subscription {
 
 ### Example: Subscribe to Shielded Transactions
 
+`shieldedTransactions` emits a `ShieldedTransactionsEvent` union — either a `RelevantTransaction` (a relevant transaction plus an optional collapsed Merkle tree update) or a `ShieldedTransactionsProgress` (indexing progress). Use inline fragments to handle both:
+
 ```graphql
 subscription {
-  shieldedTransactions(sessionId: "session-uuid") {
-    transaction {
-      hash
-      identifier
+  shieldedTransactions(sessionId: "session-id-hex") {
+    ... on RelevantTransaction {
+      transaction {
+        hash
+        identifiers
+      }
+      zswapCollapsedUpdate {
+        startIndex
+        endIndex
+        update
+      }
     }
-    progress {
-      current
-      total
+    ... on ShieldedTransactionsProgress {
+      highestZswapEndIndex
+      highestCheckedZswapEndIndex
+      highestRelevantZswapEndIndex
     }
   }
 }
@@ -190,11 +203,11 @@ All contract actions share these fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `address` | String | Contract address |
-| `state` | String | Contract state after action |
-| `zswapState` | String | Zswap state after action |
+| `address` | HexEncoded | Contract address |
+| `state` | HexEncoded | Contract state after action |
+| `zswapState` | HexEncoded | Zswap state after action |
 | `transaction` | Transaction | Parent transaction |
-| `unshieldedBalances` | [TokenBalance] | Unshielded token balances |
+| `unshieldedBalances` | [ContractBalance!]! | Unshielded token balances (`tokenType`, `amount`) |
 
 ### ContractAction Variants
 
@@ -206,20 +219,26 @@ All contract actions share these fields:
 
 ### TransactionResult
 
+`TransactionResult` is an object with a `status` enum and, for partial success, per-segment results.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | TransactionResultStatus | Overall outcome (see enum below) |
+| `segments` | [Segment!] | Per-segment success flags (present on partial success) |
+
+`TransactionResultStatus` enum values:
+
 | Value | Meaning |
 |-------|---------|
 | `SUCCESS` | All transaction phases completed successfully |
 | `PARTIAL_SUCCESS` | Guaranteed phase succeeded, fallible phase failed |
 | `FAILURE` | Transaction failed entirely |
 
-### TransactionFees
+### Transaction fees
 
-| Field | Description |
-|-------|-------------|
-| `paidFees` | Actual fees paid |
-| `estimatedFees` | Fees estimated before submission |
+The current fee field on a transaction is `fee: String!` (SPECK, the atomic unit of DUST). The older `fees: TransactionFees!` object (with `paidFees`/`estimatedFees`) is deprecated in favour of `fee`; within `TransactionFees`, `estimatedFees` is itself deprecated in favour of `paidFees`.
 
-> **See also:** `references/graphql-types.md` — complete type definitions including Block, Transaction, TokenBalance, RelevantTransaction, UnshieldedTransaction, and SyncProgress.
+> **See also:** `references/graphql-types.md` — complete type definitions including Block, Transaction, ContractBalance, RelevantTransaction, and UnshieldedTransaction.
 
 ## Cross-References
 

--- a/plugins/midnight-indexer/skills/indexer-graphql-api/examples/http-requests.md
+++ b/plugins/midnight-indexer/skills/indexer-graphql-api/examples/http-requests.md
@@ -8,23 +8,23 @@ Complete `curl` examples for the indexer GraphQL HTTP endpoint. All examples tar
 curl -X POST http://localhost:8088/api/v4/graphql \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "{ block { hash height timestamp transactions { hash identifier } } }"
+    "query": "{ block { hash height timestamp transactions { hash identifiers } } }"
   }'
 ```
 
-Expected response:
+Expected response (note: `timestamp` is a UNIX timestamp in seconds, and `identifiers` is an array):
 
 ```json
 {
   "data": {
     "block": {
-      "hash": "0x1a2b3c...",
+      "hash": "1a2b3c...",
       "height": 12345,
-      "timestamp": "2025-01-15T10:30:00Z",
+      "timestamp": 1736937000,
       "transactions": [
         {
-          "hash": "0xabc123...",
-          "identifier": "tx-id-1"
+          "hash": "abc123...",
+          "identifiers": ["def456..."]
         }
       ]
     }
@@ -38,7 +38,7 @@ Expected response:
 curl -X POST http://localhost:8088/api/v4/graphql \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "{ contractAction(address: \"0xYOUR_CONTRACT_ADDRESS\") { ... on ContractDeploy { address state transaction { hash } } ... on ContractCall { address entryPoint state unshieldedBalances { tokenType value } } } }"
+    "query": "{ contractAction(address: \"YOUR_CONTRACT_ADDRESS_HEX\") { ... on ContractDeploy { address state transaction { hash } } ... on ContractCall { address entryPoint state unshieldedBalances { tokenType amount } } } }"
   }'
 ```
 
@@ -59,7 +59,7 @@ Expected response:
 ```json
 {
   "data": {
-    "connect": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    "connect": "a1b2c3d4e5f6..."
   }
 }
 ```
@@ -74,6 +74,6 @@ End an active wallet session:
 curl -X POST http://localhost:8088/api/v4/graphql \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "mutation { disconnect(sessionId: \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\") }"
+    "query": "mutation { disconnect(sessionId: \"a1b2c3d4e5f6...\") }"
   }'
 ```

--- a/plugins/midnight-indexer/skills/indexer-graphql-api/examples/websocket-subscriptions.md
+++ b/plugins/midnight-indexer/skills/indexer-graphql-api/examples/websocket-subscriptions.md
@@ -32,7 +32,7 @@ const unsubscribe = client.subscribe(
         timestamp
         transactions {
           hash
-          identifier
+          identifiers
         }
       }
     }`,
@@ -85,18 +85,23 @@ async function monitorShieldedTransactions(viewingKey: string) {
     webSocketImpl: WebSocket,
   });
 
+  // shieldedTransactions emits a ShieldedTransactionsEvent union: either a
+  // RelevantTransaction or a ShieldedTransactionsProgress. The sessionId arg
+  // is the HexEncoded scalar.
   const unsubscribe = client.subscribe(
     {
-      query: `subscription($sessionId: String!) {
+      query: `subscription($sessionId: HexEncoded!) {
         shieldedTransactions(sessionId: $sessionId) {
-          transaction {
-            hash
-            identifier
-            result
+          ... on RelevantTransaction {
+            transaction {
+              hash
+              identifiers
+            }
           }
-          progress {
-            current
-            total
+          ... on ShieldedTransactionsProgress {
+            highestZswapEndIndex
+            highestCheckedZswapEndIndex
+            highestRelevantZswapEndIndex
           }
         }
       }`,
@@ -104,10 +109,14 @@ async function monitorShieldedTransactions(viewingKey: string) {
     },
     {
       next(data) {
-        const { transaction, progress } = data.data?.shieldedTransactions;
-        console.log(
-          `[${progress.current}/${progress.total}] Transaction: ${transaction.hash}`,
-        );
+        const event = data.data?.shieldedTransactions;
+        if (event?.transaction) {
+          console.log(`Relevant transaction: ${event.transaction.hash}`);
+        } else if (event) {
+          console.log(
+            `Progress: checked ${event.highestCheckedZswapEndIndex}/${event.highestZswapEndIndex}, relevant up to ${event.highestRelevantZswapEndIndex}`,
+          );
+        }
       },
       error(err) {
         console.error("Subscription error:", err);
@@ -153,14 +162,15 @@ let lastBlockHeight = 0;
 function subscribeToBlocks(client: ReturnType<typeof createClient>) {
   return client.subscribe(
     {
-      query: `subscription($offset: Int) {
+      query: `subscription($offset: BlockOffset) {
         blocks(offset: $offset) {
           hash
           height
           timestamp
         }
       }`,
-      variables: { offset: lastBlockHeight > 0 ? lastBlockHeight : null },
+      // offset is a BlockOffset (@oneOf) input — pass { height } or { hash }, or null for latest.
+      variables: { offset: lastBlockHeight > 0 ? { height: lastBlockHeight } : null },
     },
     {
       next(data) {

--- a/plugins/midnight-indexer/skills/indexer-graphql-api/references/error-handling.md
+++ b/plugins/midnight-indexer/skills/indexer-graphql-api/references/error-handling.md
@@ -4,7 +4,9 @@ Common error responses from the indexer GraphQL API and how to resolve them.
 
 ## Complexity Limit Exceeded
 
-The indexer enforces a maximum query complexity of **200**. Deeply nested or wide queries will be rejected before execution.
+The indexer enforces a maximum query complexity (configured via `max_complexity`). Deeply nested or wide queries are rejected before execution.
+
+The complexity limit is wired into the schema with async-graphql's built-in `.limit_complexity(max_complexity)` validator. The error message is the validator's fixed string `"Query is too complex."` — it does not include the configured limit or the query's actual complexity, and no `extensions.code` is attached.
 
 **Error response:**
 
@@ -12,10 +14,7 @@ The indexer enforces a maximum query complexity of **200**. Deeply nested or wid
 {
   "errors": [
     {
-      "message": "Query is too complex. Maximum complexity is 200, but the query has a complexity of 350.",
-      "extensions": {
-        "code": "QUERY_TOO_COMPLEX"
-      }
+      "message": "Query is too complex."
     }
   ]
 }
@@ -27,20 +26,35 @@ The indexer enforces a maximum query complexity of **200**. Deeply nested or wid
 - Split one large query into multiple smaller queries
 - Request only the fields you need from `Transaction` objects
 
-## Invalid Session ID
+## Session ID Errors
 
-Returned when a `sessionId` passed to `shieldedTransactions` or `disconnect` is expired, malformed, or was never created.
+Two distinct errors can be returned for the `sessionId` passed to the `shieldedTransactions` subscription or the `disconnect` mutation. The indexer does **not** attach an `extensions.code`, capitalize "Invalid", or echo the supplied id back in the message.
 
-**Error response:**
+### Malformed session ID
+
+If the supplied id cannot be decoded into a 32-byte session ID, `decode_session_id` fails and the error is wrapped with the lowercase message `"invalid session ID"`. The full message is a chain joined with `:`, where the suffix is the underlying decode failure:
 
 ```json
 {
   "errors": [
     {
-      "message": "Invalid session ID: session-id-hex",
-      "extensions": {
-        "code": "INVALID_SESSION"
-      }
+      "message": "invalid session ID:cannot hex-decode session ID:..."
+    }
+  ]
+}
+```
+
+A value that is valid hex but the wrong length yields `"invalid session ID:cannot convert into session ID:..."` instead.
+
+### Unknown or expired session ID
+
+If the id is well-formed (decodes to 32 bytes) but does not resolve to a live wallet session, the `shieldedTransactions` subscription returns the distinct message `"unknown or expired session ID"` (no source chain, no `extensions.code`):
+
+```json
+{
+  "errors": [
+    {
+      "message": "unknown or expired session ID"
     }
   ]
 }
@@ -50,6 +64,7 @@ Returned when a `sessionId` passed to `shieldedTransactions` or `disconnect` is 
 - Call the `connect` mutation with a valid viewing key to obtain a new session ID
 - Session IDs do not persist across indexer restarts; reconnect after indexer downtime
 - Ensure the session has not been explicitly disconnected via the `disconnect` mutation
+- Check the supplied value is the exact hex session ID returned by `connect` (correct length, valid hex)
 
 ## Malformed Query
 
@@ -80,7 +95,9 @@ Syntax errors in the GraphQL query are returned with position information.
 
 ## Max Depth Exceeded
 
-The indexer enforces a maximum query depth of **15** levels.
+The indexer enforces a maximum query depth (configured via `max_depth`, applied with both `.limit_depth(max_depth)` and `.limit_recursive_depth(max_depth)`).
+
+The error message is async-graphql's fixed validator string `"Query is nested too deep."` — it does not include the configured limit, and no `extensions.code` is attached.
 
 **Error response:**
 
@@ -88,10 +105,7 @@ The indexer enforces a maximum query depth of **15** levels.
 {
   "errors": [
     {
-      "message": "Query is too deep. Maximum depth is 15.",
-      "extensions": {
-        "code": "QUERY_TOO_DEEP"
-      }
+      "message": "Query is nested too deep."
     }
   ]
 }

--- a/plugins/midnight-indexer/skills/indexer-graphql-api/references/error-handling.md
+++ b/plugins/midnight-indexer/skills/indexer-graphql-api/references/error-handling.md
@@ -37,7 +37,7 @@ Returned when a `sessionId` passed to `shieldedTransactions` or `disconnect` is 
 {
   "errors": [
     {
-      "message": "Invalid session ID: session-uuid-here",
+      "message": "Invalid session ID: session-id-hex",
       "extensions": {
         "code": "INVALID_SESSION"
       }

--- a/plugins/midnight-indexer/skills/indexer-graphql-api/references/graphql-types.md
+++ b/plugins/midnight-indexer/skills/indexer-graphql-api/references/graphql-types.md
@@ -15,6 +15,12 @@ Represents a block on the Midnight blockchain.
 | `author` | HexEncoded | Hex-encoded block author (nullable) |
 | `parent` | Block | Parent block (nullable) |
 | `transactions` | [Transaction!]! | Transactions included in this block |
+| `zswapMerkleTreeRoot` | HexEncoded! | Zswap commitment Merkle tree root at this block |
+| `zswapEndIndex` | Int! | Highest zswap commitment index covered by this block |
+| `ledgerParameters` | HexEncoded! | Serialized ledger parameters in effect at this block |
+| `systemParameters` | SystemParameters! | System parameters in effect at this block |
+
+> **Note:** the schema also defines additional dust fields on `Block` — `dustCommitmentEndIndex` and `dustGenerationEndIndex` (both `Int!`, `@beta`), plus `dustCommitmentMerkleTreeRoot` and `dustGenerationMerkleTreeRoot` (nullable `HexEncoded`, latest-indexed dust state). These dust fields are part of the in-flight dust API and are omitted from the stable table above.
 
 ## Transaction (Interface)
 
@@ -30,6 +36,8 @@ Implemented by `RegularTransaction` and `SystemTransaction`. Shared fields:
 | `contractActions` | [ContractAction!]! | Contract operations performed by this transaction |
 | `unshieldedCreatedOutputs` | [UnshieldedUtxo!]! | Unshielded UTXOs created |
 | `unshieldedSpentOutputs` | [UnshieldedUtxo!]! | Unshielded UTXOs spent |
+| `zswapLedgerEvents` | [ZswapLedgerEvent!]! | Zswap ledger events from this transaction |
+| `dustLedgerEvents` | [DustLedgerEvent!]! | Dust ledger events from this transaction |
 
 `RegularTransaction` additionally exposes `transactionResult: TransactionResult!`, `identifiers: [HexEncoded!]!` (note: plural array), `zswapMerkleTreeRoot`, `zswapStartIndex`/`zswapEndIndex`, and `fee: String!` (SPECK, the atomic unit of DUST). The legacy `merkleTreeRoot`/`startIndex`/`endIndex` and `fees: TransactionFees!` fields are deprecated.
 
@@ -40,7 +48,7 @@ Object describing the outcome of applying a transaction to the ledger state.
 | Field | Type | Description |
 |-------|------|-------------|
 | `status` | TransactionResultStatus | Overall outcome (enum below) |
-| `segments` | [Segment!] | Per-segment success flags (present for partial success) |
+| `segments` | [Segment!] | Per-segment success flags. **Null unless `status` is `PARTIAL_SUCCESS`** — clients must null-check before iterating |
 
 `TransactionResultStatus` enum values:
 
@@ -69,6 +77,19 @@ Token balance held by a contract, returned in `unshieldedBalances`.
 |-------|------|-------------|
 | `tokenType` | HexEncoded | Hex-encoded token type identifier |
 | `amount` | String | Balance amount as a string (supports values up to 16 bytes) |
+
+## UnshieldedUtxo
+
+An unshielded UTXO, returned by `unshieldedCreatedOutputs`/`unshieldedSpentOutputs` (Transaction) and `createdUtxos`/`spentUtxos` (UnshieldedTransaction).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `owner` | UnshieldedAddress | Address that owns the UTXO |
+| `intentHash` | HexEncoded | Hex-encoded intent hash that produced/consumed the UTXO |
+| `value` | String | Token amount (u128) as a string, in SPECK/atomic units |
+| `tokenType` | HexEncoded | Hex-encoded token type identifier |
+
+> **Note:** the value field here is named `value` — this is correct for `UnshieldedUtxo`. The parallel balance field on `ContractBalance` is named `amount` (not `value`); the names genuinely differ between the two types, so this is not a stale field.
 
 ## RelevantTransaction
 

--- a/plugins/midnight-indexer/skills/indexer-graphql-api/references/graphql-types.md
+++ b/plugins/midnight-indexer/skills/indexer-graphql-api/references/graphql-types.md
@@ -8,26 +8,41 @@ Represents a block on the Midnight blockchain.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `hash` | String | Block hash (hex-encoded) |
+| `hash` | HexEncoded | Block hash (hex-encoded) |
 | `height` | Int | Block height (sequential index) |
-| `timestamp` | String | Block creation timestamp (ISO 8601) |
-| `transactions` | [Transaction] | Transactions included in this block |
+| `protocolVersion` | Int | Protocol version |
+| `timestamp` | Int | Block creation time as a UNIX timestamp (seconds) |
+| `author` | HexEncoded | Hex-encoded block author (nullable) |
+| `parent` | Block | Parent block (nullable) |
+| `transactions` | [Transaction!]! | Transactions included in this block |
 
-## Transaction
+## Transaction (Interface)
 
-Represents a transaction within a block.
+Implemented by `RegularTransaction` and `SystemTransaction`. Shared fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `hash` | String | Transaction hash (hex-encoded) |
-| `identifier` | String | Application-assigned transaction identifier |
-| `result` | TransactionResult | Execution outcome |
-| `fees` | TransactionFees | Fee information |
-| `contractActions` | [ContractAction] | Contract operations performed by this transaction |
+| `id` | Int | Indexer-internal transaction ID (BIGSERIAL) |
+| `hash` | HexEncoded | Transaction hash (hex-encoded) |
+| `protocolVersion` | Int | Protocol version |
+| `raw` | HexEncoded | Hex-encoded serialized transaction content |
+| `block` | Block | Parent block |
+| `contractActions` | [ContractAction!]! | Contract operations performed by this transaction |
+| `unshieldedCreatedOutputs` | [UnshieldedUtxo!]! | Unshielded UTXOs created |
+| `unshieldedSpentOutputs` | [UnshieldedUtxo!]! | Unshielded UTXOs spent |
+
+`RegularTransaction` additionally exposes `transactionResult: TransactionResult!`, `identifiers: [HexEncoded!]!` (note: plural array), `zswapMerkleTreeRoot`, `zswapStartIndex`/`zswapEndIndex`, and `fee: String!` (SPECK, the atomic unit of DUST). The legacy `merkleTreeRoot`/`startIndex`/`endIndex` and `fees: TransactionFees!` fields are deprecated.
 
 ## TransactionResult
 
-Enum indicating the outcome of a transaction.
+Object describing the outcome of applying a transaction to the ledger state.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | TransactionResultStatus | Overall outcome (enum below) |
+| `segments` | [Segment!] | Per-segment success flags (present for partial success) |
+
+`TransactionResultStatus` enum values:
 
 | Value | Meaning |
 |-------|---------|
@@ -35,53 +50,56 @@ Enum indicating the outcome of a transaction.
 | `PARTIAL_SUCCESS` | Guaranteed phase succeeded, fallible phase failed |
 | `FAILURE` | Transaction failed entirely |
 
-## TransactionFees
+`Segment` has `id: Int!` and `success: Boolean!`.
 
-Fee details for a transaction.
+## TransactionFees (deprecated)
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `paidFees` | String | Actual fees paid for this transaction |
-| `estimatedFees` | String | Fees estimated before submission |
-
-## TokenBalance
-
-Token balance associated with a contract action.
+Returned by the deprecated `fees` field. Prefer the top-level `fee: String!` field on a transaction.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `tokenType` | String | Token type identifier |
-| `value` | String | Token balance value |
+| `paidFees` | String | Actual fees paid for this transaction (SPECK) |
+| `estimatedFees` | String | Fees estimated before submission (deprecated; use `paidFees`) |
+
+## ContractBalance
+
+Token balance held by a contract, returned in `unshieldedBalances`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tokenType` | HexEncoded | Hex-encoded token type identifier |
+| `amount` | String | Balance amount as a string (supports values up to 16 bytes) |
 
 ## RelevantTransaction
 
-Returned by the `shieldedTransactions` subscription. Wraps a transaction with sync progress information.
+One variant of the `ShieldedTransactionsEvent` union returned by the `shieldedTransactions` subscription. A transaction relevant to the subscribing wallet, plus an optional collapsed Merkle tree update.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `transaction` | Transaction | The relevant transaction data |
-| `progress` | SyncProgress | Current scanning progress through the chain |
+| `transaction` | RegularTransaction | The relevant transaction data |
+| `zswapCollapsedUpdate` | MerkleTreeCollapsedUpdate | Optional collapsed zswap Merkle tree update bridging an index gap |
+
+## ShieldedTransactionsProgress
+
+The other variant of `ShieldedTransactionsEvent`. Reports the indexer's shielded indexing progress.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `highestZswapEndIndex` | Int | Highest zswap end index across all transactions (known chain state) |
+| `highestCheckedZswapEndIndex` | Int | Highest zswap end index checked for relevance for this wallet |
+| `highestRelevantZswapEndIndex` | Int | Highest zswap end index of relevant transactions for this wallet |
 
 ## UnshieldedTransaction
 
-Returned by the `unshieldedTransactions` subscription. Wraps a transaction with address context.
+One variant of the `UnshieldedTransactionsEvent` union returned by the `unshieldedTransactions` subscription.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `transaction` | Transaction | The unshielded transaction data |
-| `address` | String | The unshielded address involved |
-| `progress` | SyncProgress | Current scanning progress through the chain |
+| `createdUtxos` | [UnshieldedUtxo!]! | UTXOs created in the transaction (possibly empty) |
+| `spentUtxos` | [UnshieldedUtxo!]! | UTXOs spent in the transaction (possibly empty) |
 
-## SyncProgress
-
-Tracks how far the indexer has progressed through chain scanning, used by subscription responses to indicate completion status.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `current` | Int | Number of blocks/items processed so far |
-| `total` | Int | Total number of blocks/items to process |
-
-When `current` equals `total`, the subscription has caught up with the chain head and will emit new events in real time.
+The other variant, `UnshieldedTransactionsProgress`, has a single field `highestTransactionId: Int!`.
 
 ## ContractAction (Interface)
 
@@ -89,11 +107,11 @@ All contract action variants share these base fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `address` | String | Contract address |
-| `state` | String | Contract state after the action |
-| `zswapState` | String | Zswap state after the action |
+| `address` | HexEncoded | Contract address |
+| `state` | HexEncoded | Contract state after the action |
+| `zswapState` | HexEncoded | Zswap state after the action |
 | `transaction` | Transaction | Parent transaction |
-| `unshieldedBalances` | [TokenBalance] | Unshielded token balances after the action |
+| `unshieldedBalances` | [ContractBalance!]! | Unshielded token balances after the action |
 
 ### ContractDeploy
 

--- a/plugins/midnight-indexer/skills/indexer-graphql-api/references/pagination-and-offsets.md
+++ b/plugins/midnight-indexer/skills/indexer-graphql-api/references/pagination-and-offsets.md
@@ -4,19 +4,19 @@ The indexer GraphQL API uses offset-based addressing to specify starting points 
 
 ## BlockOffset
 
-A `BlockOffset` identifies a specific block. It accepts either form:
+A `BlockOffset` is a `@oneOf` input object: supply **exactly one** of `hash` or `height`.
 
-| Form | Type | Example |
-|------|------|---------|
-| Block hash | Hex string | `"0x1a2b3c..."` |
-| Block height | Integer | `42` |
+| Field | Type | Example |
+|-------|------|---------|
+| `hash` | HexEncoded | `{ hash: "1a2b3c..." }` |
+| `height` | Int | `{ height: 42 }` |
 
-When omitted, the query or subscription starts from the **latest** block.
+When the argument is omitted, the query or subscription starts from the **latest** block.
 
 ```graphql
 # By hash
 query {
-  block(offset: "0x1a2b3c4d5e6f...") {
+  block(offset: { hash: "1a2b3c4d5e6f..." }) {
     height
     timestamp
   }
@@ -24,7 +24,7 @@ query {
 
 # By height
 query {
-  block(offset: 42) {
+  block(offset: { height: 42 }) {
     hash
     timestamp
   }
@@ -41,33 +41,39 @@ query {
 
 ## TransactionOffset
 
-A `TransactionOffset` identifies a specific transaction. It accepts either form:
+A `TransactionOffset` is a `@oneOf` input object: supply **exactly one** of `hash` or `identifier`.
 
-| Form | Type | Example |
-|------|------|---------|
-| Transaction hash | Hex string | `"0xabc123..."` |
-| Transaction identifier | String | `"tx-identifier-string"` |
+| Field | Type | Example |
+|-------|------|---------|
+| `hash` | HexEncoded | `{ hash: "abc123..." }` |
+| `identifier` | HexEncoded | `{ identifier: "def456..." }` |
 
 This parameter is **required** for the `transactions` query.
 
 ```graphql
 # By hash
 query {
-  transactions(offset: "0xabc123...") {
+  transactions(offset: { hash: "abc123..." }) {
     hash
-    identifier
-    result
+    identifiers
+    transactionResult {
+      status
+    }
   }
 }
 
 # By identifier
 query {
-  transactions(offset: "my-tx-identifier") {
+  transactions(offset: { identifier: "def456..." }) {
     hash
-    result
+    transactionResult {
+      status
+    }
   }
 }
 ```
+
+> The `contractAction` query uses `ContractActionOffset`, a `@oneOf` input with either a `blockOffset: BlockOffset` or a `transactionOffset: TransactionOffset` (e.g. `offset: { blockOffset: { height: 10 } }`).
 
 ## Subscription Offsets for Resumption
 
@@ -75,11 +81,11 @@ Each subscription accepts an optional offset parameter to resume from a specific
 
 ### blocks
 
-Resume from a specific block height or hash:
+Resume from a specific block height or hash. `offset` is a `BlockOffset` (`@oneOf`):
 
 ```graphql
 subscription {
-  blocks(offset: 1000) {
+  blocks(offset: { height: 1000 }) {
     hash
     height
     timestamp
@@ -89,11 +95,11 @@ subscription {
 
 ### contractActions
 
-Resume from a block offset within a contract's action history:
+Resume from a block offset within a contract's action history. `offset` is a `BlockOffset` (note: the subscription uses `BlockOffset`, not `ContractActionOffset`):
 
 ```graphql
 subscription {
-  contractActions(address: "0x...", offset: 500) {
+  contractActions(address: "...", offset: { height: 500 }) {
     ... on ContractCall {
       entryPoint
       transaction { hash }
@@ -104,44 +110,61 @@ subscription {
 
 ### shieldedTransactions
 
-Resume from a transaction index within the wallet session:
+Resume from a zswap transaction `index` (`Int`) within the wallet session. The subscription emits a `ShieldedTransactionsEvent` union — use inline fragments:
 
 ```graphql
 subscription {
-  shieldedTransactions(sessionId: "session-uuid", index: 50) {
-    transaction { hash }
-    progress { current total }
+  shieldedTransactions(sessionId: "session-id-hex", index: 50) {
+    ... on RelevantTransaction {
+      transaction { hash }
+    }
+    ... on ShieldedTransactionsProgress {
+      highestZswapEndIndex
+      highestRelevantZswapEndIndex
+    }
   }
 }
 ```
 
 ### unshieldedTransactions
 
-Resume from a specific transaction ID:
+Resume from a specific transaction ID (`Int`, the indexer-internal BIGSERIAL). The subscription emits an `UnshieldedTransactionsEvent` union:
 
 ```graphql
 subscription {
-  unshieldedTransactions(address: "addr1...", transactionId: "0xtx-hash") {
-    transaction { hash }
-    progress { current total }
+  unshieldedTransactions(address: "mn_addr_test1...", transactionId: 1234) {
+    ... on UnshieldedTransaction {
+      transaction { hash }
+      createdUtxos { tokenType value }
+      spentUtxos { tokenType value }
+    }
+    ... on UnshieldedTransactionsProgress {
+      highestTransactionId
+    }
   }
 }
 ```
 
 ### dustLedgerEvents and zswapLedgerEvents
 
-Resume from a specific event ID:
+Resume from a specific event `id` (`Int`):
 
 ```graphql
 subscription {
-  dustLedgerEvents(id: "event-id-123") {
-    # event fields
+  dustLedgerEvents(id: 123) {
+    id
+    raw
+    maxId
+    protocolVersion
   }
 }
 
 subscription {
-  zswapLedgerEvents(id: "event-id-456") {
-    # event fields
+  zswapLedgerEvents(id: 456) {
+    id
+    raw
+    maxId
+    protocolVersion
   }
 }
 ```


### PR DESCRIPTION
## What changed
Aligned the indexer skill with the published **v4.3.2** GraphQL schema (was v4.0.0 / `/api/v3`):
- endpoint `/api/v3/graphql` -> `/api/v4/graphql` (+ `/ws`); `HexEncoded` scalar (no `0x` prefix on responses);
- field renames `identifier` -> `identifiers` (array), `value` -> `amount` (`ContractBalance`), `fees: TransactionFees!` -> `fee: String!` (SPECK), `TransactionResult` object+enum split, `TokenBalance` -> `ContractBalance`;
- new subscriptions (`dustGenerations`, `dustNullifierTransactions`, `shieldedNullifierTransactions`) and `@oneOf` offset inputs;
- session-id corrected to `HexEncoded` (was UUID) across examples + error-handling.

The `/api/v3` alias (nests to v4) is real and was documented, not removed.

**Source:** midnightntwrk/midnight-indexer schema at tag `v4.3.2` (latest published; rc tags excluded).
**Verification:** authoritative schema fetched at tag `v4.3.2`; stale clone schemas cross-checked and rejected; final audit verdict: clean.
**Note:** Left unmerged for review.

🤖 Part of the 2026-06-02 Midnight Expert upstream revalidation sweep.

Generated with [Claude Code](https://claude.com/claude-code)