### PR TITLE
docs(midnight-dapp-dev): midnight-js 4.1.1 provider APIs (async StorageEncryption, deploy args, accountId, new providers)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-expert",
   "metadata": {
-    "version": "0.34.0",
+    "version": "0.35.0",
     "description": "AI agent plugins for the Midnight data-protection blockchain. Covers Compact smart contract development, privacy-preserving patterns, DApp frontend design, and Midnight toolchain management."
   },
   "owner": {

--- a/plugins/midnight-dapp-dev/.claude-plugin/plugin.json
+++ b/plugins/midnight-dapp-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-dapp-dev",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Scaffold and build Midnight DApp frontends \u2014 Vite + React 19 + shadcn + Tailwind v4 templates, wallet integration, provider architecture, and a development agent for ongoing UI work.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-dapp-dev/README.md
+++ b/plugins/midnight-dapp-dev/README.md
@@ -38,13 +38,13 @@ Scaffolds a Vite + React 19 + shadcn + Tailwind v4 UI package and a TypeScript A
 
 ### midnight-dapp-dev:midnight-sdk
 
-Comprehensive reference for the Midnight.js SDK: all 10 packages, the MidnightProviders architecture, the full transaction lifecycle, advanced contract operations, observable patterns, and testkit-js.
+Comprehensive reference for the Midnight.js SDK (v4.1.1): the core packages, the MidnightProviders architecture, the full transaction lifecycle, advanced contract operations, observable patterns, and testkit-js.
 
 #### References
 
 | Name | Description | When it is used |
 |------|-------------|-----------------|
-| [`package-reference.md`](skills/midnight-sdk/references/package-reference.md) | Detailed exports, constructor signatures, and configuration for all 10 Midnight.js SDK packages | When looking up specific SDK package APIs or constructor options |
+| [`package-reference.md`](skills/midnight-sdk/references/package-reference.md) | Detailed exports, constructor signatures, and configuration for the Midnight.js SDK packages | When looking up specific SDK package APIs or constructor options |
 | [`transaction-lifecycle.md`](skills/midnight-sdk/references/transaction-lifecycle.md) | Complete reference for the five-stage transaction pipeline: build, prove, balance, submit, finalize | When implementing or debugging the contract interaction flow |
 
 ## Agents

--- a/plugins/midnight-dapp-dev/skills/core/references/provider-patterns.md
+++ b/plugins/midnight-dapp-dev/skills/core/references/provider-patterns.md
@@ -89,6 +89,9 @@ Midnight SDK's transaction pipeline.
 returned by the Lace wallet extension.
 
 ```typescript
+import { toHex, fromHex } from "@midnight-ntwrk/midnight-js-utils";
+import { Transaction } from "@midnight-ntwrk/ledger-v8";
+
 // getShieldedAddresses() resolves once; cache the keys before building the provider.
 const { shieldedCoinPublicKey, shieldedEncryptionPublicKey } =
   await connectedApi.getShieldedAddresses();
@@ -97,18 +100,34 @@ const walletProvider: WalletProvider = {
   // getCoinPublicKey / getEncryptionPublicKey are synchronous.
   getCoinPublicKey: () => shieldedCoinPublicKey,
   getEncryptionPublicKey: () => shieldedEncryptionPublicKey,
-  // WalletProvider.balanceTx is (tx, ttl?) => Promise<FinalizedTransaction>.
+  // WalletProvider.balanceTx is (tx: UnboundTransaction, ttl?: Date) =>
+  // Promise<FinalizedTransaction>. The DApp Connector speaks serialized hex
+  // strings, so serialize the unbound tx to hex, hand it to Lace, then
+  // deserialize the returned hex back into a FinalizedTransaction.
+  // options is `{ payFees?: boolean }`; an empty `{}` uses the defaults.
   balanceTx: async (tx, _ttl) => {
-    const result = await connectedApi.balanceUnsealedTransaction(serialize(tx), {});
-    return result.tx;
+    const { tx: balancedHex } = await connectedApi.balanceUnsealedTransaction(
+      toHex(tx.serialize()),
+      {},
+    );
+    // A finalized tx is Transaction<SignatureEnabled, Proof, Binding>; pass the
+    // three instance markers for those type parameters.
+    return Transaction.deserialize(
+      "signature",
+      "proof",
+      "binding",
+      fromHex(balancedHex),
+    );
   },
 };
 ```
 
 The `balanceTx` method is critical: it takes a proven (unbound) transaction,
-sends it to Lace, which adds the necessary coin inputs to cover fees and signs
-the transaction. The `serialize` call converts the SDK's internal transaction
-representation to the format Lace expects.
+sends it to Lace, which adds the necessary coin inputs to cover fees and binds
+(finalizes) the transaction. Because the DApp Connector exchanges transactions
+as serialized hex strings, `balanceTx` must `toHex(tx.serialize())` on the way
+in and `Transaction.deserialize(...)` the returned hex string back into a
+`FinalizedTransaction` on the way out — it must not return the raw string.
 
 ### 5. midnightProvider
 
@@ -121,14 +140,23 @@ network.
 `submitTransaction` method.
 
 ```typescript
+import { toHex } from "@midnight-ntwrk/midnight-js-utils";
+
 const midnightProvider: MidnightProvider = {
-  submitTx: (tx) => connectedApi.submitTransaction(serialize(tx)),
+  // submitTransaction takes a serialized hex string and returns void, so
+  // recover the tx id from the transaction's own identifiers().
+  submitTx: async (tx) => {
+    await connectedApi.submitTransaction(toHex(tx.serialize()));
+    return tx.identifiers()[0];
+  },
 };
 ```
 
 After the proof server generates the ZK proof and Lace balances the
 transaction, `submitTx` broadcasts it to the Substrate node via Lace. The
-wallet handles the actual network communication.
+wallet handles the actual network communication. `submitTransaction` returns
+`void`, so the `TransactionId` is read from `tx.identifiers()[0]` rather than
+from the call's result.
 
 ### 6. privateStateProvider
 
@@ -142,14 +170,33 @@ persist private state across sessions — when the user refreshes the page,
 private state is reconstructed from the contract's public ledger where
 possible.
 
+`PrivateStateProvider<PSI, PS>` is a ~13-method interface (`setContractAddress`,
+`set`, `get`, `remove`, `clear`, `setSigningKey`, `getSigningKey`,
+`removeSigningKey`, `clearSigningKeys`, `exportPrivateStates`,
+`importPrivateStates`, `exportSigningKeys`, `importSigningKeys`). A minimal
+in-memory implementation backs the private-state and signing-key stores with
+`Map`s; the export/import methods can reject for an ephemeral store:
+
 ```typescript
-const privateStateProvider: PrivateStateProvider = {
-  get: async (contractAddress: ContractAddress) =>
-    privateStates.get(contractAddress) ?? null,
-  set: async (contractAddress: ContractAddress, state: PrivateState) => {
-    privateStates.set(contractAddress, state);
-  },
-};
+function inMemoryPrivateStateProvider<PSI extends string, PS>(): PrivateStateProvider<PSI, PS> {
+  const states = new Map<PSI, PS>();
+  const signingKeys = new Map<ContractAddress, SigningKey>();
+  return {
+    setContractAddress: () => {},
+    set: async (id, state) => { states.set(id, state); },
+    get: async (id) => states.get(id) ?? null,
+    remove: async (id) => { states.delete(id); },
+    clear: async () => { states.clear(); },
+    setSigningKey: async (address, key) => { signingKeys.set(address, key); },
+    getSigningKey: async (address) => signingKeys.get(address) ?? null,
+    removeSigningKey: async (address) => { signingKeys.delete(address); },
+    clearSigningKeys: async () => { signingKeys.clear(); },
+    exportPrivateStates: async () => { throw new Error("not supported in-memory"); },
+    importPrivateStates: async () => { throw new Error("not supported in-memory"); },
+    exportSigningKeys: async () => { throw new Error("not supported in-memory"); },
+    importSigningKeys: async () => { throw new Error("not supported in-memory"); },
+  };
+}
 ```
 
 ## DApp Connector API Types
@@ -179,19 +226,19 @@ DApps or a contract address for existing deployments.
 
 The full API surface available after the user approves the connection.
 
-| Method                          | Return Type                      | Description                                          |
-| ------------------------------- | -------------------------------- | ---------------------------------------------------- |
-| `getConfiguration()`           | `Promise<Configuration>`        | Returns all network endpoints                        |
-| `getShieldedAddresses()`       | `Promise<string[]>`             | Shielded (private) addresses for the connected wallet |
-| `getUnshieldedAddress()`       | `Promise<string>`               | Unshielded (public) address                          |
-| `getDustAddress()`             | `Promise<string>`               | Address for dust collection                          |
-| `getShieldedBalances()`        | `Promise<Balance[]>`            | Shielded token balances                              |
-| `getUnshieldedBalances()`      | `Promise<Balance[]>`            | Unshielded token balances                            |
-| `getDustBalance()`             | `Promise<Balance>`              | Dust balance                                         |
-| `balanceUnsealedTransaction()` | `Promise<BalancedTransaction>`  | Adds coin inputs and signs                           |
-| `submitTransaction()`          | `Promise<TransactionId>`        | Broadcasts to the network                            |
-| `signData()`                   | `Promise<SignedData>`           | Signs arbitrary data                                 |
-| `getProvingProvider()`         | `Promise<ProvingProvider>`      | Returns the wallet's proving provider (if available) |
+| Method                          | Return Type                                                                          | Description                                          |
+| ------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------- |
+| `getConfiguration()`           | `Promise<Configuration>`                                                             | Returns all network endpoints                        |
+| `getShieldedAddresses()`       | `Promise<{ shieldedAddress; shieldedCoinPublicKey; shieldedEncryptionPublicKey }>`  | Shielded address plus the coin/encryption public keys (all Bech32m) |
+| `getUnshieldedAddress()`       | `Promise<{ unshieldedAddress }>`                                                    | Unshielded (public) address (Bech32m)                |
+| `getDustAddress()`             | `Promise<{ dustAddress }>`                                                           | Dust address (Bech32m)                               |
+| `getShieldedBalances()`        | `Promise<Record<string, bigint>>`                                                   | Shielded token balances by token type                |
+| `getUnshieldedBalances()`      | `Promise<Record<string, bigint>>`                                                   | Unshielded token balances by token type              |
+| `getDustBalance()`             | `Promise<{ balance; cap }>`                                                          | Dust balance and max cap                             |
+| `balanceUnsealedTransaction()` | `Promise<{ tx: string }>`                                                            | Adds coin inputs and binds; takes/returns serialized hex |
+| `submitTransaction()`          | `Promise<void>`                                                                      | Broadcasts to the network (no return value)          |
+| `signData()`                   | `Promise<Signature>`                                                                | Signs arbitrary data                                 |
+| `getProvingProvider()`         | `Promise<ProvingProvider>`                                                           | Returns the wallet's proving provider (if available) |
 
 ### Configuration
 
@@ -213,12 +260,23 @@ Errors from the DApp Connector API are plain objects, not class instances.
 This is a critical distinction for error handling.
 
 ```typescript
+type ErrorCode =
+  | "PermissionRejected"
+  | "Disconnected"
+  | "InternalError"
+  | "InvalidRequest"
+  | "Rejected";
+
 interface APIError {
   type: "DAppConnectorAPIError";
   code: ErrorCode;
   reason: string;
 }
 ```
+
+`ErrorCode` is a union of string literals (exposed via the `ErrorCodes`
+constant object), not a TypeScript `enum`. Compare against the string values
+directly.
 
 **Never use `instanceof` to check for API errors.** The error objects are
 serialized across the extension boundary and lose their prototype chain. Always
@@ -236,10 +294,10 @@ try {
   ) {
     const apiError = error as APIError;
     switch (apiError.code) {
-      case ErrorCode.UserRejected:
+      case "PermissionRejected":
         // User declined the connection in Lace
         break;
-      case ErrorCode.InternalError:
+      case "InternalError":
         // Something went wrong inside Lace
         break;
     }
@@ -247,15 +305,15 @@ try {
 }
 ```
 
-### ErrorCode Enum
+### ErrorCode Values
 
-| Code              | Meaning                                          |
-| ----------------- | ------------------------------------------------ |
-| `UserRejected`    | User declined the action in the Lace popup       |
-| `InternalError`   | Internal wallet error                            |
-| `InvalidRequest`  | Malformed request to the wallet                  |
-| `Unauthorized`    | DApp not authorized or connection expired        |
-| `NetworkError`    | Network connectivity issue                       |
+| Code                 | Meaning                                          |
+| -------------------- | ------------------------------------------------ |
+| `PermissionRejected` | Permission to perform the action was rejected    |
+| `Rejected`           | The user rejected the request                    |
+| `InternalError`      | Internal wallet error                            |
+| `InvalidRequest`     | Malformed request to the wallet (e.g. a malformed transaction) |
+| `Disconnected`       | The connection to the wallet was lost            |
 
 ## Wallet-Driven Configuration
 
@@ -302,10 +360,12 @@ The recommended pattern is a single factory function that takes a
 `ConnectedAPI` and returns all 6 providers ready for use:
 
 ```typescript
-import { type ConnectedAPI, type Configuration } from '@midnight-ntwrk/dapp-connector-api';
+import { type ConnectedAPI } from '@midnight-ntwrk/dapp-connector-api';
 import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
 import { FetchZkConfigProvider } from '@midnight-ntwrk/midnight-js-fetch-zk-config-provider';
 import { httpClientProofProvider } from '@midnight-ntwrk/midnight-js-http-client-proof-provider';
+import { toHex, fromHex } from '@midnight-ntwrk/midnight-js-utils';
+import { Transaction } from '@midnight-ntwrk/ledger-v8';
 import type {
   MidnightProviders,
   WalletProvider,
@@ -314,24 +374,30 @@ import type {
 } from '@midnight-ntwrk/midnight-js-types';
 import { setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
 
-export async function createProviders<PS, C>(
+// MidnightProviders<PCK, PSI, PS>: provable circuit ids first, private-state id
+// second, private-state type third. PCK must extend AnyProvableCircuitId (a
+// string) and PSI must extend PrivateStateId (a string).
+export async function createProviders<
+  PCK extends string,
+  PSI extends string,
+  PS,
+>(
   connectedApi: ConnectedAPI,
-): Promise<MidnightProviders<PS, C>> {
+  privateStateProvider: PrivateStateProvider<PSI, PS>,
+): Promise<MidnightProviders<PCK, PSI, PS>> {
   const config = await connectedApi.getConfiguration();
   setNetworkId(config.networkId);
 
   const proofServerUri = deriveProofServerUri(config.substrateNodeUri);
-
-  const privateStates = new Map<string, PS>();
 
   const publicDataProvider = indexerPublicDataProvider(
     config.indexerUri,
     config.indexerWsUri,
   );
 
-  const zkConfigProvider = new FetchZkConfigProvider<C>(
+  const zkConfigProvider = new FetchZkConfigProvider<PCK>(
     window.location.origin,
-    fetch,
+    fetch.bind(window),
   );
 
   const proofProvider = httpClientProofProvider(proofServerUri, zkConfigProvider);
@@ -342,25 +408,26 @@ export async function createProviders<PS, C>(
   const walletProvider: WalletProvider = {
     getCoinPublicKey: () => shieldedCoinPublicKey,
     getEncryptionPublicKey: () => shieldedEncryptionPublicKey,
-    // WalletProvider.balanceTx is (tx, ttl?) => Promise<FinalizedTransaction>.
+    // Serialize the unbound tx to hex for the connector, then deserialize the
+    // returned hex string back into a FinalizedTransaction.
     balanceTx: async (tx, _ttl) => {
-      const result = await connectedApi.balanceUnsealedTransaction(serialize(tx), {});
-      return result.tx;
+      const { tx: balancedHex } = await connectedApi.balanceUnsealedTransaction(
+        toHex(tx.serialize()),
+        {},
+      );
+      return Transaction.deserialize(
+        'signature',
+        'proof',
+        'binding',
+        fromHex(balancedHex),
+      );
     },
   };
 
   const midnightProvider: MidnightProvider = {
     submitTx: async (tx) => {
-      await connectedApi.submitTransaction(serialize(tx));
+      await connectedApi.submitTransaction(toHex(tx.serialize()));
       return tx.identifiers()[0];
-    },
-  };
-
-  const privateStateProvider: PrivateStateProvider<PS> = {
-    get: async (contractAddress) =>
-      privateStates.get(contractAddress) ?? null,
-    set: async (contractAddress, state) => {
-      privateStates.set(contractAddress, state);
     },
   };
 
@@ -375,6 +442,11 @@ export async function createProviders<PS, C>(
 }
 ```
 
+The `privateStateProvider` is passed in rather than built inline, because the
+full `PrivateStateProvider<PSI, PS>` interface has ~13 methods (see the
+in-memory implementation above). Keying it by the private-state ID (`PSI`)
+rather than by contract address matches the `MidnightProviders` generics.
+
 This factory is called once after wallet connection succeeds and stored in a
 React Context so all components can access the providers.
 
@@ -388,20 +460,26 @@ transaction to Lace, which:
 
 1. Selects appropriate coin inputs from the user's wallet
 2. Constructs change outputs if necessary
-3. Signs the transaction with the user's private key
-4. Returns the balanced, signed transaction
+3. Binds (finalizes) the transaction
+4. Returns the balanced, bound transaction
 
-The `serialize` function converts the SDK's internal representation to the
-wire format expected by Lace. Import it from the appropriate SDK package for
-your contract.
+The DApp Connector exchanges transactions as serialized hex strings.
+`balanceTx` therefore hex-encodes the unbound transaction with
+`toHex(tx.serialize())` before calling `balanceUnsealedTransaction`, and
+deserializes the returned `{ tx }` string with
+`Transaction.deserialize('signature', 'proof', 'binding', fromHex(tx))` to
+produce the `FinalizedTransaction` it must return. `serialize`/`deserialize`
+come from `@midnight-ntwrk/ledger-v8`; `toHex`/`fromHex` from
+`@midnight-ntwrk/midnight-js-utils`.
 
 ## MidnightProvider and submitTx
 
 The `midnightProvider.submitTx` method wraps Lace's `submitTransaction`. After
-balancing and signing, the transaction is ready for broadcast. `submitTx` sends
-it to Lace, which forwards it to the Substrate node. The method returns a
-`TransactionId` that can be used to track confirmation via the indexer's
-WebSocket subscription.
+balancing and binding, the transaction is ready for broadcast. `submitTx`
+serializes it (`toHex(tx.serialize())`) and sends it to Lace, which forwards it
+to the Substrate node. Lace's `submitTransaction` resolves to `void`, so
+`submitTx` reads the `TransactionId` from `tx.identifiers()[0]` and returns
+that for tracking confirmation via the indexer's WebSocket subscription.
 
 ## Browser vs Node.js Differences
 

--- a/plugins/midnight-dapp-dev/skills/core/references/provider-patterns.md
+++ b/plugins/midnight-dapp-dev/skills/core/references/provider-patterns.md
@@ -37,7 +37,7 @@ This is the primary mechanism for keeping the UI in sync with on-chain state.
 **Purpose:** Loads the zero-knowledge circuit configuration (`.zkir` files)
 needed to construct and verify proofs.
 
-**Interface:** `ZkConfigProvider` from `@midnight-ntwrk/midnight-js-types`.
+**Interface:** `ZKConfigProvider` from `@midnight-ntwrk/midnight-js-types`.
 
 **Browser implementation:** Created via `FetchZkConfigProvider` from
 `@midnight-ntwrk/midnight-js-fetch-zk-config-provider`. In the browser,
@@ -89,17 +89,25 @@ Midnight SDK's transaction pipeline.
 returned by the Lace wallet extension.
 
 ```typescript
+// getShieldedAddresses() resolves once; cache the keys before building the provider.
+const { shieldedCoinPublicKey, shieldedEncryptionPublicKey } =
+  await connectedApi.getShieldedAddresses();
+
 const walletProvider: WalletProvider = {
-  getCoinPublicKey: () => connectedApi.getShieldedAddresses().then((addrs) => addrs[0]),
-  getEncryptionPublicKey: () => connectedApi.getShieldedAddresses().then((addrs) => addrs[0]),
-  balanceTx: (tx, newCoins) =>
-    connectedApi.balanceUnsealedTransaction(serialize(tx), newCoins),
+  // getCoinPublicKey / getEncryptionPublicKey are synchronous.
+  getCoinPublicKey: () => shieldedCoinPublicKey,
+  getEncryptionPublicKey: () => shieldedEncryptionPublicKey,
+  // WalletProvider.balanceTx is (tx, ttl?) => Promise<FinalizedTransaction>.
+  balanceTx: async (tx, _ttl) => {
+    const result = await connectedApi.balanceUnsealedTransaction(serialize(tx), {});
+    return result.tx;
+  },
 };
 ```
 
-The `balanceTx` method is critical: it takes an unbalanced transaction, sends
-it to Lace, which adds the necessary coin inputs to cover fees and signs the
-transaction. The `serialize` call converts the SDK's internal transaction
+The `balanceTx` method is critical: it takes a proven (unbound) transaction,
+sends it to Lace, which adds the necessary coin inputs to cover fees and signs
+the transaction. The `serialize` call converts the SDK's internal transaction
 representation to the format Lace expects.
 
 ### 5. midnightProvider
@@ -328,17 +336,24 @@ export async function createProviders<PS, C>(
 
   const proofProvider = httpClientProofProvider(proofServerUri, zkConfigProvider);
 
+  const { shieldedCoinPublicKey, shieldedEncryptionPublicKey } =
+    await connectedApi.getShieldedAddresses();
+
   const walletProvider: WalletProvider = {
-    getCoinPublicKey: () =>
-      connectedApi.getShieldedAddresses().then((addrs) => addrs[0]),
-    getEncryptionPublicKey: () =>
-      connectedApi.getShieldedAddresses().then((addrs) => addrs[0]),
-    balanceTx: (tx, newCoins) =>
-      connectedApi.balanceUnsealedTransaction(serialize(tx), newCoins),
+    getCoinPublicKey: () => shieldedCoinPublicKey,
+    getEncryptionPublicKey: () => shieldedEncryptionPublicKey,
+    // WalletProvider.balanceTx is (tx, ttl?) => Promise<FinalizedTransaction>.
+    balanceTx: async (tx, _ttl) => {
+      const result = await connectedApi.balanceUnsealedTransaction(serialize(tx), {});
+      return result.tx;
+    },
   };
 
   const midnightProvider: MidnightProvider = {
-    submitTx: (tx) => connectedApi.submitTransaction(serialize(tx)),
+    submitTx: async (tx) => {
+      await connectedApi.submitTransaction(serialize(tx));
+      return tx.identifiers()[0];
+    },
   };
 
   const privateStateProvider: PrivateStateProvider<PS> = {

--- a/plugins/midnight-dapp-dev/skills/core/references/state-management.md
+++ b/plugins/midnight-dapp-dev/skills/core/references/state-management.md
@@ -27,7 +27,7 @@ export function createStateObservable<L, P>(
   parseLedger: (state: ContractState) => L,
 ): Observable<DAppState<L, P>> {
   const ledger$ = publicDataProvider
-    .contractStateObservable(contractAddress)
+    .contractStateObservable(contractAddress, { type: "latest" })
     .pipe(
       map((state) => parseLedger(state)),
       retry({ delay: 500 }),
@@ -148,7 +148,7 @@ observable after a 500ms delay when an error occurs:
 
 ```typescript
 const ledger$ = publicDataProvider
-  .contractStateObservable(contractAddress)
+  .contractStateObservable(contractAddress, { type: "latest" })
   .pipe(
     map((state) => parseLedger(state)),
     retry({ delay: 500 }),
@@ -220,8 +220,17 @@ restarts.
 ```typescript
 import { levelPrivateStateProvider } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
 
-const privateStateProvider = levelPrivateStateProvider({ dataDir: './state' });
+const privateStateProvider = levelPrivateStateProvider({
+  privateStateStoreName: 'private-states',
+  signingKeyStoreName: 'signing-keys',
+  accountId: walletAddress, // required: scopes LevelDB storage per account
+  privateStoragePasswordProvider: () => process.env.PRIVATE_STATE_PASSWORD!,
+});
 ```
+
+The LevelDB-backed encryption is async under the hood (Web Crypto + PBKDF2 as of
+midnight-js 4.1.0); the password from `privateStoragePasswordProvider` is subject to a
+strict policy.
 
 Choose in-memory for browser DApps. Choose LevelDB for long-running processes
 or integration tests where state must persist across runs.
@@ -307,7 +316,7 @@ indexer:
 
 ```typescript
 const shared$ = publicDataProvider
-  .contractStateObservable(contractAddress)
+  .contractStateObservable(contractAddress, { type: "latest" })
   .pipe(shareReplay(1));
 ```
 

--- a/plugins/midnight-dapp-dev/skills/core/references/state-management.md
+++ b/plugins/midnight-dapp-dev/skills/core/references/state-management.md
@@ -230,7 +230,10 @@ const privateStateProvider = levelPrivateStateProvider({
 
 The LevelDB-backed encryption is async under the hood (Web Crypto + PBKDF2 as of
 midnight-js 4.1.0); the password from `privateStoragePasswordProvider` is subject to a
-strict policy.
+strict policy: it must be at least 16 characters and contain at least 3 of the 4
+character classes (lowercase, uppercase, digits, symbols), or the SDK throws a
+`PasswordValidationError`. A short value like a bare `process.env.PRIVATE_STATE_PASSWORD`
+will fail at runtime unless it satisfies this policy.
 
 Choose in-memory for browser DApps. Choose LevelDB for long-running processes
 or integration tests where state must persist across runs.

--- a/plugins/midnight-dapp-dev/skills/core/references/testing-patterns.md
+++ b/plugins/midnight-dapp-dev/skills/core/references/testing-patterns.md
@@ -99,7 +99,11 @@ export function createMockConnectedApi(
 ): ConnectedAPI {
   return {
     getConfiguration: vi.fn().mockResolvedValue(mockConfiguration),
-    getShieldedAddresses: vi.fn().mockResolvedValue(['mock-shielded-address']),
+    getShieldedAddresses: vi.fn().mockResolvedValue({
+      shieldedAddress: 'mock-shielded-address',
+      shieldedCoinPublicKey: 'mock-shielded-coin-public-key',
+      shieldedEncryptionPublicKey: 'mock-shielded-encryption-public-key',
+    }),
     getUnshieldedAddress: vi.fn().mockResolvedValue('mock-unshielded-address'),
     getDustAddress: vi.fn().mockResolvedValue('mock-dust-address'),
     getShieldedBalances: vi.fn().mockResolvedValue([]),
@@ -223,7 +227,7 @@ describe('wallet connection states', () => {
     const mockApi = createMockInitialApi();
     mockApi.connect = vi.fn().mockRejectedValue({
       type: 'DAppConnectorAPIError',
-      code: 'UserRejected',
+      code: 'PermissionRejected',
       reason: 'User declined connection',
     });
     (window as any).midnight = { mnLace: mockApi };
@@ -315,11 +319,20 @@ function createMockMidnightProvider(): MidnightProvider {
   return { submitTx: vi.fn().mockResolvedValue('mock-tx-id') };
 }
 
-function createMockPrivateStateProvider(): PrivateStateProvider {
+function createMockPrivateStateProvider(): PrivateStateProvider<string, unknown> {
+  // Partial mock: the real PrivateStateProvider interface requires ~13 members
+  // (setContractAddress, set, get, remove, clear, setSigningKey, getSigningKey,
+  // removeSigningKey, clearSigningKeys, exportPrivateStates, importPrivateStates,
+  // exportSigningKeys, importSigningKeys). We stub only the commonly-called ones and
+  // cast via `as unknown` so TypeScript does not flag the missing members. Add more
+  // stubs here if a test exercises them.
   return {
     get: vi.fn().mockResolvedValue(null),
     set: vi.fn().mockResolvedValue(undefined),
-  };
+    remove: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn().mockResolvedValue(undefined),
+    setContractAddress: vi.fn().mockResolvedValue(undefined),
+  } as unknown as PrivateStateProvider<string, unknown>;
 }
 
 function renderWithProviders(ui: React.ReactElement) {

--- a/plugins/midnight-dapp-dev/skills/core/references/testing-patterns.md
+++ b/plugins/midnight-dapp-dev/skills/core/references/testing-patterns.md
@@ -284,15 +284,23 @@ an object matching the corresponding provider interface from `@midnight-ntwrk/mi
 
 ```typescript
 function createMockPublicDataProvider(): PublicDataProvider {
-  return { contractStateObservable: vi.fn().mockReturnValue(new BehaviorSubject(null)) };
+  // contractStateObservable(address, config) — config is required at runtime.
+  return { contractStateObservable: vi.fn().mockReturnValue(new BehaviorSubject(null)) } as unknown as PublicDataProvider;
 }
 
-function createMockZkConfigProvider(): ZkConfigProvider {
-  return { getZkConfig: vi.fn().mockResolvedValue({ circuit: new Uint8Array() }) };
+function createMockZkConfigProvider(): ZKConfigProvider<string> {
+  // ZKConfigProvider exposes getZKIR / getProverKey / getVerifierKey / get(circuitId).
+  return {
+    get: vi.fn().mockResolvedValue({ circuit: new Uint8Array() }),
+    getZKIR: vi.fn().mockResolvedValue(new Uint8Array()),
+    getProverKey: vi.fn().mockResolvedValue(new Uint8Array()),
+    getVerifierKey: vi.fn().mockResolvedValue(new Uint8Array()),
+  } as unknown as ZKConfigProvider<string>;
 }
 
 function createMockProofProvider(): ProofProvider {
-  return { prove: vi.fn().mockResolvedValue(new Uint8Array()) };
+  // ProofProvider.proveTx(unprovenTx, config?) => Promise<UnboundTransaction>.
+  return { proveTx: vi.fn().mockResolvedValue(new Uint8Array()) } as unknown as ProofProvider;
 }
 
 function createMockWalletProvider(): WalletProvider {

--- a/plugins/midnight-dapp-dev/skills/core/templates/api/package.json
+++ b/plugins/midnight-dapp-dev/skills/core/templates/api/package.json
@@ -16,6 +16,9 @@
     "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^4.1.1",
     "@midnight-ntwrk/midnight-js-fetch-zk-config-provider": "^4.1.1",
     "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^4.1.1",
+    "@midnight-ntwrk/midnight-js-utils": "^4.1.1",
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
+    "@midnight-ntwrk/compact-runtime": "^0.16.0",
     "@midnight-ntwrk/dapp-connector-api": "^4.0.1",
     "rxjs": "^7.8.1"
   },

--- a/plugins/midnight-dapp-dev/skills/core/templates/api/package.json
+++ b/plugins/midnight-dapp-dev/skills/core/templates/api/package.json
@@ -10,13 +10,13 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@midnight-ntwrk/midnight-js-contracts": "^3.0.0",
-    "@midnight-ntwrk/midnight-js-types": "^3.0.0",
-    "@midnight-ntwrk/midnight-js-network-id": "^3.0.0",
-    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^3.0.0",
-    "@midnight-ntwrk/midnight-js-fetch-zk-config-provider": "^3.0.0",
-    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^3.0.0",
-    "@midnight-ntwrk/dapp-connector-api": "^4.0.0",
+    "@midnight-ntwrk/midnight-js-contracts": "^4.1.1",
+    "@midnight-ntwrk/midnight-js-types": "^4.1.1",
+    "@midnight-ntwrk/midnight-js-network-id": "^4.1.1",
+    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^4.1.1",
+    "@midnight-ntwrk/midnight-js-fetch-zk-config-provider": "^4.1.1",
+    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^4.1.1",
+    "@midnight-ntwrk/dapp-connector-api": "^4.0.1",
     "rxjs": "^7.8.1"
   },
   "peerDependencies": {

--- a/plugins/midnight-dapp-dev/skills/core/templates/api/src/index.ts
+++ b/plugins/midnight-dapp-dev/skills/core/templates/api/src/index.ts
@@ -2,12 +2,18 @@ import { setNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
 import { indexerPublicDataProvider } from "@midnight-ntwrk/midnight-js-indexer-public-data-provider";
 import { FetchZkConfigProvider } from "@midnight-ntwrk/midnight-js-fetch-zk-config-provider";
 import { httpClientProofProvider } from "@midnight-ntwrk/midnight-js-http-client-proof-provider";
+import { toHex, fromHex } from "@midnight-ntwrk/midnight-js-utils";
+import {
+  Transaction,
+  type FinalizedTransaction,
+} from "@midnight-ntwrk/ledger-v8";
+import type { ChargedState } from "@midnight-ntwrk/compact-runtime";
 import type { ConnectedAPI } from "@midnight-ntwrk/dapp-connector-api";
 import type {
   WalletProvider,
   MidnightProvider,
 } from "@midnight-ntwrk/midnight-js-types";
-import { combineLatest, map, retry, type Observable } from "rxjs";
+import { combineLatest, map, retry, Observable } from "rxjs";
 import { inMemoryPrivateStateProvider } from "./private-state.js";
 import type {
   AppProviders,
@@ -72,18 +78,34 @@ export async function createProviders(
   const walletProvider: WalletProvider = {
     getCoinPublicKey: () => shieldedCoinPublicKey,
     getEncryptionPublicKey: () => shieldedEncryptionPublicKey,
-    // WalletProvider.balanceTx is (tx, ttl?) => Promise<FinalizedTransaction>.
-    // The Lace DApp Connector handles fee/coin selection internally; pass an
-    // (empty) options object so the extension can append its {sender} arg.
+    // WalletProvider.balanceTx is (tx: UnboundTransaction, ttl?: Date) =>
+    // Promise<FinalizedTransaction>. The DApp Connector speaks serialized hex
+    // strings, so we hex-encode the unbound tx, hand it to Lace (which selects
+    // fee inputs/change and binds it), then deserialize the returned hex string
+    // back into a FinalizedTransaction. The options object is `{ payFees?:
+    // boolean }`; an empty `{}` uses the defaults (payFees: true). There is no
+    // `sender`, `newCoins`, or `ttl` argument on this method.
     balanceTx: async (tx, _ttl) => {
-      const result = await api.balanceUnsealedTransaction(tx, {});
-      return result.tx;
+      const { tx: balancedHex } = await api.balanceUnsealedTransaction(
+        toHex(tx.serialize()),
+        {},
+      );
+      // A balanced/finalized tx is Transaction<SignatureEnabled, Proof, Binding>.
+      // deserialize takes the three instance markers for those type params.
+      return Transaction.deserialize(
+        "signature",
+        "proof",
+        "binding",
+        fromHex(balancedHex),
+      ) satisfies FinalizedTransaction;
     },
   };
 
   const midnightProvider: MidnightProvider = {
     submitTx: async (tx) => {
-      await api.submitTransaction(tx);
+      // submitTransaction takes a serialized hex string and returns void; the
+      // tx id is recovered from the transaction's own identifiers().
+      await api.submitTransaction(toHex(tx.serialize()));
       return tx.identifiers()[0];
     },
   };
@@ -136,7 +158,9 @@ export function createStateObservable(
   publicDataProvider: AppProviders["publicDataProvider"],
   privateStateProvider: AppProviders["privateStateProvider"],
   contractAddress: string,
-  parseLedger: (data: Uint8Array) => ContractState,
+  // `state.data` is now a ChargedState (not a Uint8Array). Your compiled
+  // contract's generated `YourContract.ledger(state.data)` accepts this value.
+  parseLedger: (data: ChargedState) => ContractState,
 ): Observable<DerivedState> {
   const public$ = publicDataProvider
     .contractStateObservable(contractAddress, { type: "latest" })

--- a/plugins/midnight-dapp-dev/skills/core/templates/api/src/index.ts
+++ b/plugins/midnight-dapp-dev/skills/core/templates/api/src/index.ts
@@ -72,11 +72,11 @@ export async function createProviders(
   const walletProvider: WalletProvider = {
     getCoinPublicKey: () => shieldedCoinPublicKey,
     getEncryptionPublicKey: () => shieldedEncryptionPublicKey,
-    balanceTx: async (tx, newCoins, ttl) => {
-      const result = await api.balanceUnsealedTransaction(tx, {
-        newCoins,
-        ttl,
-      });
+    // WalletProvider.balanceTx is (tx, ttl?) => Promise<FinalizedTransaction>.
+    // The Lace DApp Connector handles fee/coin selection internally; pass an
+    // (empty) options object so the extension can append its {sender} arg.
+    balanceTx: async (tx, _ttl) => {
+      const result = await api.balanceUnsealedTransaction(tx, {});
       return result.tx;
     },
   };
@@ -84,7 +84,7 @@ export async function createProviders(
   const midnightProvider: MidnightProvider = {
     submitTx: async (tx) => {
       await api.submitTransaction(tx);
-      return tx.txId;
+      return tx.identifiers()[0];
     },
   };
 

--- a/plugins/midnight-dapp-dev/skills/core/templates/api/src/private-state.ts
+++ b/plugins/midnight-dapp-dev/skills/core/templates/api/src/private-state.ts
@@ -1,18 +1,74 @@
 import type { PrivateStateProvider } from "@midnight-ntwrk/midnight-js-types";
+import type { ContractAddress, SigningKey } from "@midnight-ntwrk/compact-runtime";
 
+/**
+ * Session-scoped, in-memory implementation of the full PrivateStateProvider
+ * interface. Browser DApps cannot use LevelDB, so private state and signing
+ * keys live in plain Maps for the lifetime of the page.
+ *
+ * This implements the complete 13-method PrivateStateProvider<PSI, PS>
+ * contract. The export/import methods are not meaningful for an ephemeral
+ * in-memory store, so they reject — swap in an encrypting persistent provider
+ * (e.g. IndexedDB) if you need cross-session private state or real exports.
+ */
 export function inMemoryPrivateStateProvider<
   PSI extends string,
   PS,
 >(): PrivateStateProvider<PSI, PS> {
-  const store = new Map<string, PS>();
+  const states = new Map<PSI, PS>();
+  const signingKeys = new Map<ContractAddress, SigningKey>();
 
   return {
-    get: async (id: PSI) => store.get(id) ?? null,
+    // Contract-address scoping is a no-op for this flat in-memory store; the
+    // private state IDs are already unique within a single browser session.
+    setContractAddress: (_address: ContractAddress) => {},
+
     set: async (id: PSI, state: PS) => {
-      store.set(id, state);
+      states.set(id, state);
     },
+    get: async (id: PSI) => states.get(id) ?? null,
     remove: async (id: PSI) => {
-      store.delete(id);
+      states.delete(id);
+    },
+    clear: async () => {
+      states.clear();
+    },
+
+    setSigningKey: async (address: ContractAddress, signingKey: SigningKey) => {
+      signingKeys.set(address, signingKey);
+    },
+    getSigningKey: async (address: ContractAddress) =>
+      signingKeys.get(address) ?? null,
+    removeSigningKey: async (address: ContractAddress) => {
+      signingKeys.delete(address);
+    },
+    clearSigningKeys: async () => {
+      signingKeys.clear();
+    },
+
+    exportPrivateStates: async () => {
+      throw new Error(
+        "inMemoryPrivateStateProvider does not support exportPrivateStates; " +
+          "use a persistent encrypting provider for exports.",
+      );
+    },
+    importPrivateStates: async () => {
+      throw new Error(
+        "inMemoryPrivateStateProvider does not support importPrivateStates; " +
+          "use a persistent encrypting provider for imports.",
+      );
+    },
+    exportSigningKeys: async () => {
+      throw new Error(
+        "inMemoryPrivateStateProvider does not support exportSigningKeys; " +
+          "use a persistent encrypting provider for exports.",
+      );
+    },
+    importSigningKeys: async () => {
+      throw new Error(
+        "inMemoryPrivateStateProvider does not support importSigningKeys; " +
+          "use a persistent encrypting provider for imports.",
+      );
     },
   };
 }

--- a/plugins/midnight-dapp-dev/skills/core/templates/ui/package.json
+++ b/plugins/midnight-dapp-dev/skills/core/templates/ui/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "{{API_PACKAGE_NAME}}": "workspace:*",
-    "@midnight-ntwrk/dapp-connector-api": "^4.0.0",
-    "@midnight-ntwrk/midnight-js-types": "^3.0.0",
+    "@midnight-ntwrk/dapp-connector-api": "^4.0.1",
+    "@midnight-ntwrk/midnight-js-types": "^4.1.1",
     "@radix-ui/react-slot": "^1.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/plugins/midnight-dapp-dev/skills/dapp-connector/SKILL.md
+++ b/plugins/midnight-dapp-dev/skills/dapp-connector/SKILL.md
@@ -356,6 +356,8 @@ In the browser, the DApp Connector replaces the Node.js WalletFacade. The `Conne
 ```typescript
 import type { WalletProvider, MidnightProvider } from "@midnight-ntwrk/midnight-js-types";
 import type { ConnectedAPI } from "@midnight-ntwrk/dapp-connector-api";
+import { toHex, fromHex } from "@midnight-ntwrk/midnight-js-utils";
+import { Transaction } from "@midnight-ntwrk/ledger-v8";
 
 async function createWalletProvider(api: ConnectedAPI): Promise<WalletProvider> {
   const { shieldedCoinPublicKey, shieldedEncryptionPublicKey } =
@@ -364,12 +366,21 @@ async function createWalletProvider(api: ConnectedAPI): Promise<WalletProvider> 
   return {
     getCoinPublicKey: () => shieldedCoinPublicKey,
     getEncryptionPublicKey: () => shieldedEncryptionPublicKey,
-    // WalletProvider.balanceTx is (tx, ttl?) => Promise<FinalizedTransaction>.
-    // The DApp Connector selects fee inputs internally; pass an options object so
-    // the extension can append its {sender} argument in the correct position.
+    // WalletProvider.balanceTx is (tx: UnboundTransaction, ttl?: Date) =>
+    // Promise<FinalizedTransaction>. balanceUnsealedTransaction takes/returns
+    // serialized hex strings, so serialize in and deserialize out.
+    // options is `{ payFees?: boolean }`; an empty `{}` uses the defaults.
     balanceTx: async (tx, _ttl) => {
-      const result = await api.balanceUnsealedTransaction(tx, {});
-      return result.tx;
+      const { tx: balancedHex } = await api.balanceUnsealedTransaction(
+        toHex(tx.serialize()),
+        {},
+      );
+      return Transaction.deserialize(
+        "signature",
+        "proof",
+        "binding",
+        fromHex(balancedHex),
+      );
     },
   };
 }
@@ -377,7 +388,9 @@ async function createWalletProvider(api: ConnectedAPI): Promise<WalletProvider> 
 function createMidnightProvider(api: ConnectedAPI): MidnightProvider {
   return {
     submitTx: async (tx) => {
-      await api.submitTransaction(tx);
+      // submitTransaction takes a serialized hex string and returns void;
+      // recover the tx id from the transaction's identifiers().
+      await api.submitTransaction(toHex(tx.serialize()));
       return tx.identifiers()[0];
     },
   };

--- a/plugins/midnight-dapp-dev/skills/dapp-connector/SKILL.md
+++ b/plugins/midnight-dapp-dev/skills/dapp-connector/SKILL.md
@@ -364,8 +364,11 @@ async function createWalletProvider(api: ConnectedAPI): Promise<WalletProvider> 
   return {
     getCoinPublicKey: () => shieldedCoinPublicKey,
     getEncryptionPublicKey: () => shieldedEncryptionPublicKey,
-    balanceTx: async (tx, newCoins, ttl) => {
-      const result = await api.balanceUnsealedTransaction(tx, { newCoins, ttl });
+    // WalletProvider.balanceTx is (tx, ttl?) => Promise<FinalizedTransaction>.
+    // The DApp Connector selects fee inputs internally; pass an options object so
+    // the extension can append its {sender} argument in the correct position.
+    balanceTx: async (tx, _ttl) => {
+      const result = await api.balanceUnsealedTransaction(tx, {});
       return result.tx;
     },
   };
@@ -375,7 +378,7 @@ function createMidnightProvider(api: ConnectedAPI): MidnightProvider {
   return {
     submitTx: async (tx) => {
       await api.submitTransaction(tx);
-      return tx.txId;
+      return tx.identifiers()[0];
     },
   };
 }

--- a/plugins/midnight-dapp-dev/skills/dapp-connector/references/browser-providers.md
+++ b/plugins/midnight-dapp-dev/skills/dapp-connector/references/browser-providers.md
@@ -22,6 +22,8 @@ import { setNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
 import { indexerPublicDataProvider } from "@midnight-ntwrk/midnight-js-indexer-public-data-provider";
 import { FetchZkConfigProvider } from "@midnight-ntwrk/midnight-js-fetch-zk-config-provider";
 import { httpClientProofProvider } from "@midnight-ntwrk/midnight-js-http-client-proof-provider";
+import { toHex, fromHex } from "@midnight-ntwrk/midnight-js-utils";
+import { Transaction } from "@midnight-ntwrk/ledger-v8";
 import type {
   MidnightProviders,
   WalletProvider,
@@ -30,10 +32,10 @@ import type {
 } from "@midnight-ntwrk/midnight-js-types";
 import type { ConnectedAPI } from "@midnight-ntwrk/dapp-connector-api";
 
-export async function createBrowserProviders<ICK extends string, PSI extends string, PS>(
+export async function createBrowserProviders<PCK extends string, PSI extends string, PS>(
   api: ConnectedAPI,
   privateStateProvider: PrivateStateProvider<PSI, PS>,
-): Promise<MidnightProviders<ICK, PSI, PS>> {
+): Promise<MidnightProviders<PCK, PSI, PS>> {
   // 1. Read configuration from wallet (respects user's network choice)
   const config = await api.getConfiguration();
   setNetworkId(config.networkId);
@@ -45,7 +47,7 @@ export async function createBrowserProviders<ICK extends string, PSI extends str
   );
 
   // 3. Build ZK config provider for browser (fetches via HTTP)
-  const zkConfigProvider = new FetchZkConfigProvider<ICK>(
+  const zkConfigProvider = new FetchZkConfigProvider<PCK>(
     window.location.origin,
     fetch.bind(window),
   );
@@ -63,20 +65,34 @@ export async function createBrowserProviders<ICK extends string, PSI extends str
   const walletProvider: WalletProvider = {
     getCoinPublicKey: () => shieldedCoinPublicKey,
     getEncryptionPublicKey: () => shieldedEncryptionPublicKey,
-    // WalletProvider.balanceTx is (tx, ttl?) => Promise<FinalizedTransaction>.
-    // The DApp Connector handles fee/coin selection; pass an options object so
-    // the extension can append its {sender} argument in the right position.
+    // WalletProvider.balanceTx is (tx: UnboundTransaction, ttl?: Date) =>
+    // Promise<FinalizedTransaction>. The DApp Connector speaks serialized hex
+    // strings, so serialize the unbound tx to hex, let Lace select fee inputs
+    // and bind it, then deserialize the returned hex back into a
+    // FinalizedTransaction. options is `{ payFees?: boolean }`; `{}` uses
+    // defaults (payFees: true).
     balanceTx: async (tx, _ttl) => {
-      const result = await api.balanceUnsealedTransaction(tx, {});
-      return result.tx;
+      const { tx: balancedHex } = await api.balanceUnsealedTransaction(
+        toHex(tx.serialize()),
+        {},
+      );
+      // A finalized tx is Transaction<SignatureEnabled, Proof, Binding>; pass
+      // the three instance markers for those type parameters.
+      return Transaction.deserialize(
+        "signature",
+        "proof",
+        "binding",
+        fromHex(balancedHex),
+      );
     },
   };
 
   // 6. Build midnight provider from DApp Connector
   const midnightProvider: MidnightProvider = {
     submitTx: async (tx) => {
-      await api.submitTransaction(tx);
-      // submitTransaction returns void; recover the tx id from the transaction's identifiers()
+      // submitTransaction takes a serialized hex string and returns void;
+      // recover the tx id from the transaction's identifiers().
+      await api.submitTransaction(toHex(tx.serialize()));
       return tx.identifiers()[0];
     },
   };
@@ -122,20 +138,33 @@ The `FetchZkConfigProvider` constructs URLs relative to the base URL to load the
 
 Browser DApps cannot use LevelDB. Use an in-memory provider for session-scoped private state:
 
+`PrivateStateProvider<PSI, PS>` is a ~13-method interface, so a compiling
+in-memory implementation must provide all of them. Private state and signing
+keys are kept in `Map`s; the export/import methods reject because an ephemeral
+store has nothing meaningful to export:
+
 ```typescript
 import type { PrivateStateProvider } from "@midnight-ntwrk/midnight-js-types";
+import type { ContractAddress, SigningKey } from "@midnight-ntwrk/compact-runtime";
 
 function inMemoryPrivateStateProvider<PSI extends string, PS>(): PrivateStateProvider<PSI, PS> {
-  const store = new Map<string, PS>();
+  const states = new Map<PSI, PS>();
+  const signingKeys = new Map<ContractAddress, SigningKey>();
 
   return {
-    get: async (id: PSI) => store.get(id) ?? null,
-    set: async (id: PSI, state: PS) => {
-      store.set(id, state);
-    },
-    remove: async (id: PSI) => {
-      store.delete(id);
-    },
+    setContractAddress: () => {},
+    set: async (id, state) => { states.set(id, state); },
+    get: async (id) => states.get(id) ?? null,
+    remove: async (id) => { states.delete(id); },
+    clear: async () => { states.clear(); },
+    setSigningKey: async (address, key) => { signingKeys.set(address, key); },
+    getSigningKey: async (address) => signingKeys.get(address) ?? null,
+    removeSigningKey: async (address) => { signingKeys.delete(address); },
+    clearSigningKeys: async () => { signingKeys.clear(); },
+    exportPrivateStates: async () => { throw new Error("not supported in-memory"); },
+    importPrivateStates: async () => { throw new Error("not supported in-memory"); },
+    exportSigningKeys: async () => { throw new Error("not supported in-memory"); },
+    importSigningKeys: async () => { throw new Error("not supported in-memory"); },
   };
 }
 ```
@@ -166,6 +195,11 @@ async function indexedDBPrivateStateProvider<PSI extends string, PS>(
     remove: async (id: PSI) => {
       await db.delete("privateState", id);
     },
+    // The private-state methods are shown for brevity. A complete
+    // PrivateStateProvider<PSI, PS> must also implement setContractAddress,
+    // clear, the four signing-key methods (setSigningKey, getSigningKey,
+    // removeSigningKey, clearSigningKeys), and the export/import methods —
+    // back them with an additional IndexedDB object store.
   };
 }
 ```

--- a/plugins/midnight-dapp-dev/skills/dapp-connector/references/browser-providers.md
+++ b/plugins/midnight-dapp-dev/skills/dapp-connector/references/browser-providers.md
@@ -63,8 +63,11 @@ export async function createBrowserProviders<ICK extends string, PSI extends str
   const walletProvider: WalletProvider = {
     getCoinPublicKey: () => shieldedCoinPublicKey,
     getEncryptionPublicKey: () => shieldedEncryptionPublicKey,
-    balanceTx: async (tx, newCoins, ttl) => {
-      const result = await api.balanceUnsealedTransaction(tx, { newCoins, ttl });
+    // WalletProvider.balanceTx is (tx, ttl?) => Promise<FinalizedTransaction>.
+    // The DApp Connector handles fee/coin selection; pass an options object so
+    // the extension can append its {sender} argument in the right position.
+    balanceTx: async (tx, _ttl) => {
+      const result = await api.balanceUnsealedTransaction(tx, {});
       return result.tx;
     },
   };
@@ -73,8 +76,8 @@ export async function createBrowserProviders<ICK extends string, PSI extends str
   const midnightProvider: MidnightProvider = {
     submitTx: async (tx) => {
       await api.submitTransaction(tx);
-      // submitTransaction returns void; the txId is already known from the balanced tx
-      return tx.txId;
+      // submitTransaction returns void; recover the tx id from the transaction's identifiers()
+      return tx.identifiers()[0];
     },
   };
 
@@ -169,19 +172,31 @@ async function indexedDBPrivateStateProvider<PSI extends string, PS>(
 
 ## Wallet-Delegated Proving
 
-Instead of running a local proof server, the wallet can generate proofs:
+Instead of running a local proof server, the wallet can generate proofs. The dedicated `@midnight-ntwrk/midnight-js-dapp-connector-proof-provider` package wraps this into a ready-to-use `ProofProvider`:
+
+```typescript
+import { dappConnectorProofProvider } from "@midnight-ntwrk/midnight-js-dapp-connector-proof-provider";
+
+// `api` exposes getProvingProvider; costModel comes from the protocol/ledger types.
+const proofProvider = await dappConnectorProofProvider(
+  api,
+  zkConfigProvider,
+  costModel,
+);
+// Use this proofProvider in place of httpClientProofProvider when assembling
+// MidnightProviders — proving is delegated to the Lace wallet, with no separate
+// proof server connection from the browser.
+```
+
+Under the hood this calls the DApp Connector's `getProvingProvider(keyMaterialProvider)` to obtain the wallet's proving provider once, then reuses it for every `proveTx`. If you need lower-level access, you can still call `api.getProvingProvider(...)` directly:
 
 ```typescript
 const provingProvider = await api.getProvingProvider({
-  getKeyMaterial: async (circuitId: string) => {
-    // Return the ZK key material for the given circuit
-    const response = await fetch(`/managed/mycontract/keys/${circuitId}.bzkir`);
-    return new Uint8Array(await response.arrayBuffer());
-  },
+  getZKIR: async (loc) => new Uint8Array(await (await fetch(loc)).arrayBuffer()),
+  getProverKey: async (loc) => new Uint8Array(await (await fetch(loc)).arrayBuffer()),
+  getVerifierKey: async (loc) => new Uint8Array(await (await fetch(loc)).arrayBuffer()),
 });
 ```
-
-This delegates proof generation to the Lace wallet extension, removing the need for a separate proof server connection from the browser. The wallet manages proving internally.
 
 ## Full Integration Example
 

--- a/plugins/midnight-dapp-dev/skills/midnight-sdk/SKILL.md
+++ b/plugins/midnight-dapp-dev/skills/midnight-sdk/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   deploying or finding contracts with deployContract or findDeployedContract,
   calling circuits with callTx or submitCallTx, the transaction lifecycle,
   SDK provider types (WalletProvider, MidnightProvider, PublicDataProvider,
-  ProofProvider, ZkConfigProvider, PrivateStateProvider), testkit-js testing,
+  ProofProvider, ZKConfigProvider, PrivateStateProvider), testkit-js testing,
   observable state subscriptions, contract maintenance and verifier keys,
   or connecting to the indexer or proof server.
 version: 0.1.0
@@ -14,7 +14,7 @@ version: 0.1.0
 
 # Midnight SDK Reference
 
-Comprehensive reference for the Midnight.js SDK: all 10 packages, the MidnightProviders architecture, the full transaction lifecycle, advanced contract operations, observable patterns, and testkit-js. For the deployment workflow, see `references/transaction-lifecycle.md`. For TypeScript witness implementation, see `compact-core:compact-witness-ts`. For browser wallet integration via the DApp Connector, see `midnight-dapp-dev:dapp-connector`.
+Comprehensive reference for the Midnight.js SDK (v4.1.1 — all `@midnight-ntwrk/midnight-js-*` packages move in lockstep): the core packages, the MidnightProviders architecture, the full transaction lifecycle, advanced contract operations, observable patterns, and testkit-js. For the deployment workflow, see `references/transaction-lifecycle.md`. For TypeScript witness implementation, see `compact-core:compact-witness-ts`. For browser wallet integration via the DApp Connector, see `midnight-dapp-dev:dapp-connector`.
 
 For the underlying Wallet SDK packages (WalletFacade, HD derivation, three-wallet architecture), see `midnight-wallet:wallet-sdk`.
 
@@ -23,32 +23,38 @@ For the underlying Wallet SDK packages (WalletFacade, HD derivation, three-walle
 | Package | Purpose | Key Exports |
 |---------|---------|-------------|
 | `@midnight-ntwrk/midnight-js-contracts` | Contract deployment and interaction | `deployContract`, `findDeployedContract`, `submitCallTx`, `callTx`, `submitCallTxAsync`, `submitTxAsync`, `createUnprovenCallTx`, `getStates`, `getPublicStates`, `getUnshieldedBalances`, `verifyContractState`, `submitInsertVerifierKeyTx`, `submitRemoveVerifierKeyTx`, `submitReplaceAuthorityTx`, `replaceAuthority` |
-| `@midnight-ntwrk/midnight-js-types` | Core type definitions | `MidnightProviders`, `WalletProvider`, `MidnightProvider`, `PublicDataProvider`, `PrivateStateProvider`, `ProofProvider`, `ZkConfigProvider` |
+| `@midnight-ntwrk/midnight-js-types` | Core type definitions | `MidnightProviders`, `WalletProvider`, `MidnightProvider`, `PublicDataProvider`, `PrivateStateProvider`, `ProofProvider`, `ZKConfigProvider` |
 | `@midnight-ntwrk/midnight-js-network-id` | Network configuration | `setNetworkId` |
 | `@midnight-ntwrk/midnight-js-indexer-public-data-provider` | Indexer connection | `indexerPublicDataProvider()` |
 | `@midnight-ntwrk/midnight-js-http-client-proof-provider` | Proof server communication | `httpClientProofProvider()` |
 | `@midnight-ntwrk/midnight-js-level-private-state-provider` | LevelDB private state (Node.js) | `levelPrivateStateProvider()` |
 | `@midnight-ntwrk/midnight-js-node-zk-config-provider` | Node.js ZK asset loading | `NodeZkConfigProvider` |
 | `@midnight-ntwrk/midnight-js-fetch-zk-config-provider` | Browser ZK asset loading | `FetchZkConfigProvider` |
-| `@midnight-ntwrk/midnight-js-logger-provider` | Optional structured logging | `loggerProvider()` |
+| `@midnight-ntwrk/midnight-js-logger-provider` | Optional structured logging (pino wrapper) | `LoggerProvider` (class; `new LoggerProvider(pinoLogger)`) |
+| `@midnight-ntwrk/midnight-js-dapp-connector-proof-provider` | Browser wallet-delegated proving | `dappConnectorProofProvider(api, zkConfigProvider, costModel)` |
 | `@midnight-ntwrk/midnight-js-utils` | Utility functions | `toHex` (as of the current release, `toHex` is the primary utility export) |
 
 All packages are published on the **public npm registry** under the `@midnight-ntwrk` scope. Do not configure custom registries or `.npmrc` overrides.
 
 ## MidnightProviders Deep Dive
 
-`MidnightProviders<ICK, PSI, PS>` bundles the six providers required for contract deployment and interaction:
+`MidnightProviders<PCK, PSI, PS>` bundles the six required providers (plus an optional logger) for contract deployment and interaction:
 
 ```typescript
 import type { MidnightProviders } from "@midnight-ntwrk/midnight-js-types";
 
-interface MidnightProviders<ICK extends string, PSI extends string, PS> {
-  walletProvider: WalletProvider;
-  midnightProvider: MidnightProvider;
-  publicDataProvider: PublicDataProvider;
-  privateStateProvider: PrivateStateProvider<PSI, PS>;
-  zkConfigProvider: ZkConfigProvider<ICK>;
-  proofProvider: ProofProvider<ICK>;
+interface MidnightProviders<
+  PCK extends AnyProvableCircuitId = AnyProvableCircuitId,
+  PSI extends PrivateStateId = PrivateStateId,
+  PS = any,
+> {
+  readonly privateStateProvider: PrivateStateProvider<PSI, PS>;
+  readonly publicDataProvider: PublicDataProvider;
+  readonly zkConfigProvider: ZKConfigProvider<PCK>;
+  readonly proofProvider: ProofProvider;
+  readonly walletProvider: WalletProvider;
+  readonly midnightProvider: MidnightProvider;
+  readonly loggerProvider?: LoggerProvider;
 }
 ```
 
@@ -56,8 +62,8 @@ interface MidnightProviders<ICK extends string, PSI extends string, PS> {
 
 | Parameter | Meaning | Example |
 |-----------|---------|---------|
-| `ICK` | Impure circuit keys -- union of circuit names that have witnesses | `"transfer" \| "mint"` |
-| `PSI` | Private state identifier -- the key used in the private state store | `typeof "myContractState"` |
+| `PCK` | Provable circuit keys -- union of circuit names that have witnesses (`AnyProvableCircuitId`) | `"transfer" \| "mint"` |
+| `PSI` | Private state identifier (`PrivateStateId`, a `string`) -- the key used in the private state store | `"myContractState"` |
 | `PS` | Private state type -- the shape of off-chain state | `{ secretKey: Uint8Array }` |
 
 ### Provider Details
@@ -69,19 +75,20 @@ Handles transaction balancing (adding fee inputs/outputs) and provides signing k
 ```typescript
 interface WalletProvider {
   /** Get the shielded coin public key for receiving funds */
-  getCoinPublicKey(): string;
+  getCoinPublicKey(): CoinPublicKey;
 
   /** Get the encryption public key for encrypted outputs */
-  getEncryptionPublicKey(): string;
+  getEncryptionPublicKey(): EncPublicKey;
 
-  /** Balance an unproven transaction by adding fee inputs/outputs */
+  /** Balance an unbound (proven) transaction by adding fee inputs/outputs */
   balanceTx(
-    tx: UnprovenTransaction,
-    newCoins?: ShieldedCoinInfo[],
+    tx: UnboundTransaction,
     ttl?: Date,
-  ): Promise<BalancedProvingRecipe>;
+  ): Promise<FinalizedTransaction>;
 }
 ```
+
+`getCoinPublicKey()` / `getEncryptionPublicKey()` are synchronous and return the `CoinPublicKey` / `EncPublicKey` types (string aliases) from the ledger.
 
 - **Node.js**: Built from `WalletFacade` (see the Deployment section below)
 - **Browser**: Built from `ConnectedAPI.balanceUnsealedTransaction` (see `midnight-dapp-dev:dapp-connector`)
@@ -106,14 +113,27 @@ Connects to the indexer for on-chain state queries and subscriptions:
 
 ```typescript
 interface PublicDataProvider {
-  queryContractState(address: ContractAddress): Promise<ContractState | null>;
-  watchForDeployTxData(address: ContractAddress): Observable<DeployTxData>;
+  queryContractState(
+    address: ContractAddress,
+    config?: BlockHeightConfig | BlockHashConfig,
+  ): Promise<ContractState | null>;
+  // Resolves once when the deploy tx appears on-chain (NOT an observable):
+  watchForDeployTxData(address: ContractAddress): Promise<FinalizedTxData>;
+  watchForTxData(txId: TransactionId): Promise<FinalizedTxData>;
   contractStateObservable(
     address: ContractAddress,
-    options?: { type: "latest" },
+    config: ContractStateObservableConfig,
   ): Observable<ContractState>;
+  // ...also queryZSwapAndContractState, queryDeployContractState,
+  // queryUnshieldedBalances, watchForContractState, unshieldedBalancesObservable
 }
 ```
+
+`ContractStateObservableConfig` is required and selects where the stream starts:
+`{ type: "latest" }`, `{ type: "all" }`, `{ type: "txId"; txId }`,
+`{ type: "blockHeight"; blockHeight }`, or `{ type: "blockHash"; blockHash }`
+(the last three take an optional `inclusive` flag, default `true`). As of v4.1.1 the
+`blockHeight` / `blockHash` configurations correctly emit the state at that block.
 
 Created identically in both Node.js and browser via `indexerPublicDataProvider(httpUrl, wsUrl)`.
 
@@ -132,13 +152,17 @@ interface PrivateStateProvider<PSI extends string, PS> {
 - **Node.js**: `levelPrivateStateProvider()` using LevelDB
 - **Browser**: In-memory `Map` or IndexedDB (see `midnight-dapp-dev:dapp-connector`)
 
-#### ZkConfigProvider
+#### ZKConfigProvider
 
 Loads ZK circuit configurations from compiled assets:
 
 ```typescript
-interface ZkConfigProvider<ICK extends string> {
-  getZkConfig(circuitId: ICK): Promise<ZkConfig>;
+abstract class ZKConfigProvider<K extends string> {
+  abstract getZKIR(circuitId: K): Promise<ZKIR>;
+  abstract getProverKey(circuitId: K): Promise<ProverKey>;
+  abstract getVerifierKey(circuitId: K): Promise<VerifierKey>;
+  getVerifierKeys(circuitIds: K[]): Promise<[K, VerifierKey][]>;
+  get(circuitId: K): Promise<ZKConfig<K>>;  // bundles ZKIR + prover + verifier keys
 }
 ```
 
@@ -150,12 +174,15 @@ interface ZkConfigProvider<ICK extends string> {
 Communicates with the proof server to generate ZK proofs:
 
 ```typescript
-interface ProofProvider<ICK extends string> {
-  prove(circuitId: ICK, inputs: ProveInputs): Promise<Proof>;
+interface ProofProvider {
+  proveTx(
+    unprovenTx: UnprovenTransaction,
+    proveTxConfig?: ProveTxConfig,
+  ): Promise<UnboundTransaction>;
 }
 ```
 
-Created via `httpClientProofProvider(proofServerUrl, zkConfigProvider)` in both environments.
+Created via `httpClientProofProvider(proofServerUrl, zkConfigProvider)` in both environments. For browser DApps, `dappConnectorProofProvider(api, zkConfigProvider, costModel)` from `@midnight-ntwrk/midnight-js-dapp-connector-proof-provider` returns a `ProofProvider` that delegates proving to the connected Lace wallet.
 
 ## Transaction Lifecycle
 
@@ -489,5 +516,5 @@ Both types provide the on-chain confirmation data needed to verify that the oper
 
 | Topic | Reference File |
 |-------|---------------|
-| Detailed exports, constructor signatures, and configuration for all 10 SDK packages | `references/package-reference.md` |
+| Detailed exports, constructor signatures, and configuration for the SDK packages | `references/package-reference.md` |
 | Complete transaction lifecycle with low-level API, proving flow, balancing internals, and finalization | `references/transaction-lifecycle.md` |

--- a/plugins/midnight-dapp-dev/skills/midnight-sdk/SKILL.md
+++ b/plugins/midnight-dapp-dev/skills/midnight-sdk/SKILL.md
@@ -208,7 +208,7 @@ const txData = await deployed.callTx.myCircuit(arg1, arg2);
 // txData contains:
 txData.public.txId;         // TransactionId
 txData.public.txHash;       // string
-txData.public.blockHeight;  // bigint
+txData.public.blockHeight;  // number
 ```
 
 ### Low-Level API
@@ -478,7 +478,7 @@ interface FinalizedDeployTxData<C> {
     contractAddress: ContractAddress;
     txId: TransactionId;
     txHash: string;
-    blockHeight: bigint;
+    blockHeight: number;
   };
   private: {
     signingKey: Uint8Array;
@@ -494,7 +494,7 @@ interface FinalizedCallTxData<C, ICK> {
   public: {
     txId: TransactionId;
     txHash: string;
-    blockHeight: bigint;
+    blockHeight: number;
   };
 }
 ```

--- a/plugins/midnight-dapp-dev/skills/midnight-sdk/references/package-reference.md
+++ b/plugins/midnight-dapp-dev/skills/midnight-sdk/references/package-reference.md
@@ -1,6 +1,6 @@
 # SDK Package Reference
 
-Detailed exports, constructor signatures, and configuration for all 10 Midnight.js SDK packages. For high-level usage patterns, see the main `midnight-sdk` skill. For the transaction lifecycle, see `references/transaction-lifecycle.md`.
+Detailed exports, constructor signatures, and configuration for the Midnight.js SDK packages (v4.1.1; all `@midnight-ntwrk/midnight-js-*` packages move in lockstep). For high-level usage patterns, see the main `midnight-sdk` skill. For the transaction lifecycle, see `references/transaction-lifecycle.md`.
 
 ## @midnight-ntwrk/midnight-js-contracts
 
@@ -16,18 +16,22 @@ import {
 
 // Deploy a new contract
 const deployed: DeployedContract<C> = await deployContract(
-  providers: MidnightProviders<ICK, PSI, PS>,
+  providers: MidnightProviders<PCK, PSI, PS>,
   options: {
     compiledContract: CompiledContract;
     privateStateId: PSI;
     initialPrivateState: PS;
-    args?: unknown[];  // Constructor arguments
+    // `args` is REQUIRED when the contract's constructor takes parameters
+    // (its type is `Contract.InitializeParameters<C>`); for a no-argument
+    // constructor the `args` field is omitted from the options type entirely.
+    args: ConstructorArgs;
+    signingKey?: SigningKey;  // optional; a fresh CMA signing key is sampled if omitted
   },
 );
 
 // Find an existing contract by address
 const found: FoundContract<C> = await findDeployedContract(
-  providers: MidnightProviders<ICK, PSI, PS>,
+  providers: MidnightProviders<PCK, PSI, PS>,
   options: {
     contractAddress: ContractAddress;
     compiledContract: CompiledContract;
@@ -193,13 +197,10 @@ Core type definitions used across all SDK packages.
 
 ```typescript
 interface WalletProvider {
-  getCoinPublicKey(): string;
-  getEncryptionPublicKey(): string;
-  balanceTx(
-    tx: UnprovenTransaction,
-    newCoins?: ShieldedCoinInfo[],
-    ttl?: Date,
-  ): Promise<BalancedProvingRecipe>;
+  getCoinPublicKey(): CoinPublicKey;
+  getEncryptionPublicKey(): EncPublicKey;
+  // Balances a proven (unbound) transaction; returns a finalized transaction.
+  balanceTx(tx: UnboundTransaction, ttl?: Date): Promise<FinalizedTransaction>;
 }
 
 interface MidnightProvider {
@@ -207,12 +208,23 @@ interface MidnightProvider {
 }
 
 interface PublicDataProvider {
-  queryContractState(address: ContractAddress): Promise<ContractState | null>;
-  watchForDeployTxData(address: ContractAddress): Observable<DeployTxData>;
+  queryContractState(
+    address: ContractAddress,
+    config?: BlockHeightConfig | BlockHashConfig,
+  ): Promise<ContractState | null>;
+  // Resolves once when the deployment tx appears on-chain (a Promise, not an Observable):
+  watchForDeployTxData(address: ContractAddress): Promise<FinalizedTxData>;
+  watchForTxData(txId: TransactionId): Promise<FinalizedTxData>;
   contractStateObservable(
     address: ContractAddress,
-    options?: { type: "latest" },
+    config: ContractStateObservableConfig,
   ): Observable<ContractState>;
+  unshieldedBalancesObservable(
+    address: ContractAddress,
+    config: ContractStateObservableConfig,
+  ): Observable<UnshieldedBalances>;
+  // ...also queryZSwapAndContractState, queryDeployContractState,
+  // queryUnshieldedBalances, watchForContractState, watchForUnshieldedBalances
 }
 
 interface PrivateStateProvider<PSI extends string, PS> {
@@ -221,25 +233,42 @@ interface PrivateStateProvider<PSI extends string, PS> {
   remove(id: PSI): Promise<void>;
 }
 
-interface ZkConfigProvider<ICK extends string> {
-  getZkConfig(circuitId: ICK): Promise<ZkConfig>;
+// Abstract class, not a plain interface.
+abstract class ZKConfigProvider<K extends string> {
+  abstract getZKIR(circuitId: K): Promise<ZKIR>;
+  abstract getProverKey(circuitId: K): Promise<ProverKey>;
+  abstract getVerifierKey(circuitId: K): Promise<VerifierKey>;
+  get(circuitId: K): Promise<ZKConfig<K>>;
 }
 
-interface ProofProvider<ICK extends string> {
-  prove(circuitId: ICK, inputs: ProveInputs): Promise<Proof>;
+interface ProofProvider {
+  proveTx(
+    unprovenTx: UnprovenTransaction,
+    proveTxConfig?: ProveTxConfig,
+  ): Promise<UnboundTransaction>;
 }
 ```
+
+`ContractStateObservableConfig` is required:
+`{ type: "latest" }`, `{ type: "all" }`, `{ type: "txId"; txId }`,
+`{ type: "blockHeight"; blockHeight }`, or `{ type: "blockHash"; blockHash }`.
+As of v4.1.1 the `blockHeight` / `blockHash` configurations emit the state at that block.
 
 ### MidnightProviders Bundle
 
 ```typescript
-interface MidnightProviders<ICK extends string, PSI extends string, PS> {
-  walletProvider: WalletProvider;
-  midnightProvider: MidnightProvider;
-  publicDataProvider: PublicDataProvider;
-  privateStateProvider: PrivateStateProvider<PSI, PS>;
-  zkConfigProvider: ZkConfigProvider<ICK>;
-  proofProvider: ProofProvider<ICK>;
+interface MidnightProviders<
+  PCK extends AnyProvableCircuitId = AnyProvableCircuitId,
+  PSI extends PrivateStateId = PrivateStateId,
+  PS = any,
+> {
+  readonly privateStateProvider: PrivateStateProvider<PSI, PS>;
+  readonly publicDataProvider: PublicDataProvider;
+  readonly zkConfigProvider: ZKConfigProvider<PCK>;
+  readonly proofProvider: ProofProvider;
+  readonly walletProvider: WalletProvider;
+  readonly midnightProvider: MidnightProvider;
+  readonly loggerProvider?: LoggerProvider;  // optional pino-backed logger
 }
 ```
 
@@ -281,10 +310,10 @@ import { httpClientProofProvider } from "@midnight-ntwrk/midnight-js-http-client
  * @param zkConfigProvider - ZK config provider for circuit configurations
  * @returns ProofProvider instance
  */
-httpClientProofProvider<ICK extends string>(
+httpClientProofProvider<K extends string>(
   proofServerUrl: string,
-  zkConfigProvider: ZkConfigProvider<ICK>,
-): ProofProvider<ICK>;
+  zkConfigProvider: ZKConfigProvider<K>,
+): ProofProvider;
 ```
 
 ## @midnight-ntwrk/midnight-js-level-private-state-provider
@@ -292,20 +321,45 @@ httpClientProofProvider<ICK extends string>(
 Node.js only. Uses LevelDB for persistent off-chain state storage.
 
 ```typescript
-import { levelPrivateStateProvider } from "@midnight-ntwrk/midnight-js-level-private-state-provider";
+import {
+  levelPrivateStateProvider,
+  StorageEncryption,
+} from "@midnight-ntwrk/midnight-js-level-private-state-provider";
 
 /**
  * Create a PrivateStateProvider backed by LevelDB.
- * @param options.privateStateStoreName - LevelDB database name for state
- * @param options.signingKeyStoreName - LevelDB database name for signing keys
- * @param options.privateStoragePasswordProvider - Function returning the encryption password
- * @returns PrivateStateProvider instance
+ * @param config.privateStateStoreName - LevelDB store name for private state
+ * @param config.signingKeyStoreName - LevelDB store name for signing keys
+ * @param config.privateStoragePasswordProvider - Returns the encryption password
+ *        (may be sync or async; passwords are subject to a strict policy)
+ * @param config.accountId - required: scopes storage per account (hashed SHA-256);
+ *        any unique id such as the wallet address
+ * @param config.cryptoBackend - Optional: "webcrypto" | "noble" (e.g. React Native)
+ * @param config.levelFactory - Optional: custom LevelDB factory (e.g. browser/RN)
  */
-levelPrivateStateProvider<PSI extends string, PS>(options: {
+levelPrivateStateProvider<PSI extends string, PS = any>(config: {
   privateStateStoreName: string;
   signingKeyStoreName: string;
-  privateStoragePasswordProvider: () => string;
+  privateStoragePasswordProvider: () => string | Promise<string>;
+  accountId: string; // required: scopes storage per account (hashed SHA-256); any unique id such as the wallet address
+  cryptoBackend?: "webcrypto" | "noble";
+  levelFactory?: (dbName: string) => DatabaseLevel;
 }): PrivateStateProvider<PSI, PS>;
+```
+
+As of v4.1.0 the storage encryption migrated to Web Crypto + PBKDF2 and
+`StorageEncryption` is now **async**. There is no public `new StorageEncryption(pwd)`
+constructor — construct via `await StorageEncryption.create(password, options?)`, and
+`encrypt` / `decrypt` / `decryptWithPassword` / `verifyPassword` are all async. The salt
+is supplied through the options object (`{ existingSalt }`), not a positional argument:
+
+```typescript
+const encryption = await StorageEncryption.create(password, {
+  existingSalt,            // optional Buffer | Uint8Array
+  cryptoBackend: "webcrypto",
+});
+const ciphertext = await encryption.encrypt(plaintext);
+const recovered = await encryption.decrypt(ciphertext);
 ```
 
 ## @midnight-ntwrk/midnight-js-node-zk-config-provider
@@ -316,10 +370,10 @@ Node.js only. Loads ZK circuit configurations from the local filesystem.
 import { NodeZkConfigProvider } from "@midnight-ntwrk/midnight-js-node-zk-config-provider";
 
 /**
- * Create a ZkConfigProvider that reads from the filesystem.
+ * Create a ZKConfigProvider that reads from the filesystem.
  * @param basePath - Path to the managed/<contract> directory
  */
-new NodeZkConfigProvider<ICK extends string>(basePath: string): ZkConfigProvider<ICK>;
+new NodeZkConfigProvider<K extends string>(basePath: string): ZKConfigProvider<K>;
 ```
 
 ## @midnight-ntwrk/midnight-js-fetch-zk-config-provider
@@ -330,28 +384,52 @@ Browser only. Loads ZK circuit configurations via HTTP fetch.
 import { FetchZkConfigProvider } from "@midnight-ntwrk/midnight-js-fetch-zk-config-provider";
 
 /**
- * Create a ZkConfigProvider that fetches via HTTP.
+ * Create a ZKConfigProvider that fetches via HTTP.
  * @param baseUrl - Base URL for ZK asset files (e.g., window.location.origin)
  * @param fetchFn - Fetch function (use fetch.bind(window) in browser)
  */
-new FetchZkConfigProvider<ICK extends string>(
+new FetchZkConfigProvider<K extends string>(
   baseUrl: string,
   fetchFn: typeof fetch,
-): ZkConfigProvider<ICK>;
+): ZKConfigProvider<K>;
 ```
 
 ## @midnight-ntwrk/midnight-js-logger-provider
 
-Optional structured logging for SDK operations.
+Optional structured logging for SDK operations. Exports a `LoggerProvider` class (wrapping a `pino` logger) — there is no `loggerProvider()` factory. Pass an instance as the optional `loggerProvider` member of `MidnightProviders`.
 
 ```typescript
-import { loggerProvider } from "@midnight-ntwrk/midnight-js-logger-provider";
+import { LoggerProvider } from "@midnight-ntwrk/midnight-js-logger-provider";
+import pino from "pino";
 
 /**
- * Create a logger provider for SDK diagnostic output.
- * Attach to providers for operation tracing.
+ * Wrap a pino logger for SDK diagnostic output.
+ * The constructor requires a pino-compatible Logger instance.
  */
-const logger = loggerProvider();
+const loggerProvider = new LoggerProvider(pino());
+// loggerProvider exposes info/error/warn/debug/trace/fatal and isLevelEnabled(level)
+```
+
+## @midnight-ntwrk/midnight-js-dapp-connector-proof-provider
+
+Browser wallet-delegated proving. Builds a `ProofProvider` whose
+`proveTx` delegates ZK proof generation to the connected Lace wallet via the DApp
+Connector, removing the need for a separately reachable proof server in the browser.
+
+```typescript
+import { dappConnectorProofProvider } from "@midnight-ntwrk/midnight-js-dapp-connector-proof-provider";
+
+/**
+ * @param api - DApp Connector wallet API exposing `getProvingProvider`
+ * @param zkConfigProvider - Supplies ZK artifacts / key material
+ * @param costModel - Cost model applied during transaction proving
+ * @returns Promise<ProofProvider>
+ */
+const proofProvider = await dappConnectorProofProvider(
+  api,
+  zkConfigProvider,
+  costModel,
+);
 ```
 
 ## @midnight-ntwrk/midnight-js-utils

--- a/plugins/midnight-dapp-dev/skills/midnight-sdk/references/package-reference.md
+++ b/plugins/midnight-dapp-dev/skills/midnight-sdk/references/package-reference.md
@@ -24,7 +24,7 @@ const deployed: DeployedContract<C> = await deployContract(
     // `args` is REQUIRED when the contract's constructor takes parameters
     // (its type is `Contract.InitializeParameters<C>`); for a no-argument
     // constructor the `args` field is omitted from the options type entirely.
-    args: ConstructorArgs;
+    args: Contract.InitializeParameters<C>;
     signingKey?: SigningKey;  // optional; a fresh CMA signing key is sampled if omitted
   },
 );
@@ -171,7 +171,7 @@ interface FinalizedDeployTxData<C> {
     contractAddress: ContractAddress;
     txId: TransactionId;
     txHash: string;
-    blockHeight: bigint;
+    blockHeight: number;
   };
   private: {
     signingKey: Uint8Array;
@@ -184,7 +184,7 @@ interface FinalizedCallTxData<C, ICK> {
   public: {
     txId: TransactionId;
     txHash: string;
-    blockHeight: bigint;
+    blockHeight: number;
   };
 }
 ```
@@ -308,11 +308,13 @@ import { httpClientProofProvider } from "@midnight-ntwrk/midnight-js-http-client
  * Create a ProofProvider that communicates with a proof server via HTTP.
  * @param proofServerUrl - Proof server base URL (e.g., "http://localhost:6300")
  * @param zkConfigProvider - ZK config provider for circuit configurations
+ * @param config - Optional proving provider configuration (ProvingProviderConfig)
  * @returns ProofProvider instance
  */
 httpClientProofProvider<K extends string>(
   proofServerUrl: string,
   zkConfigProvider: ZKConfigProvider<K>,
+  config?: ProvingProviderConfig,
 ): ProofProvider;
 ```
 

--- a/plugins/midnight-dapp-dev/skills/midnight-sdk/references/transaction-lifecycle.md
+++ b/plugins/midnight-dapp-dev/skills/midnight-sdk/references/transaction-lifecycle.md
@@ -162,7 +162,10 @@ const deployed = await deployContract(providers, {
   compiledContract,
   privateStateId: "myState",
   initialPrivateState: { secretKey },
-  args: [constructorArg1],  // Optional constructor arguments
+  // `args` holds the contract constructor's parameters. It is REQUIRED when the
+  // Compact constructor takes parameters (pass them in declared order), and
+  // omitted entirely when the constructor takes no arguments.
+  args: [constructorArg1],
 });
 
 // deployed.deployTxData contains:

--- a/plugins/midnight-dapp-dev/skills/midnight-sdk/references/transaction-lifecycle.md
+++ b/plugins/midnight-dapp-dev/skills/midnight-sdk/references/transaction-lifecycle.md
@@ -11,7 +11,7 @@ Every contract interaction follows a five-stage pipeline:
    |                |                 |                 |                 |
    v                v                 v                 v                 v
    createUnproven   proofProvider     walletProvider    midnightProvider  publicDataProvider
-   CallTx()         .prove()          .balanceTx()      .submitTx()       (indexer confirms)
+   CallTx()         .proveTx()        .balanceTx()      .submitTx()       (indexer confirms)
    |                |                 |                 |                 |
    v                v                 v                 v                 v
    UnprovenTx  ->  ProvenTx     ->  BalancedTx   ->  TransactionId ->  FinalizedTxData
@@ -46,7 +46,7 @@ The proof server generates a zero-knowledge proof that the circuit was executed 
 
 ```typescript
 // Happens automatically in callTx, or manually:
-const proof = await providers.proofProvider.prove(circuitId, proveInputs);
+const unbound = await providers.proofProvider.proveTx(unprovenTx);
 ```
 
 During this stage:
@@ -63,10 +63,9 @@ The wallet adds fee inputs and change outputs to make the transaction valid:
 
 ```typescript
 // Happens automatically in callTx, or manually:
-const balanced = await providers.walletProvider.balanceTx(
-  unprovenTx,
-  newCoins,  // Optional: newly created shielded coins
-  ttl,       // Optional: transaction time-to-live
+const finalized = await providers.walletProvider.balanceTx(
+  unboundTx,  // the proven (unbound) transaction from proveTx
+  ttl,        // Optional: transaction time-to-live (Date)
 );
 ```
 


### PR DESCRIPTION
## What changed
Revalidated against **midnight-js 4.1.1** (was 3.0.0/4.0.x) and dapp-connector-api 4.0.1:
- provider interfaces updated (`MidnightProviders`, `WalletProvider.balanceTx(tx,ttl?)` returning `FinalizedTransaction`, `ZKConfigProvider` casing, `PublicDataProvider` config-required observables);
- **`StorageEncryption` is now async** (`new StorageEncryption()` -> `await StorageEncryption.create()`);
- `levelPrivateStateProvider` now **requires `accountId`** (plus optional `cryptoBackend`/`levelFactory`);
- `deployContract` args is conditionally required (plus optional `signingKey`); `getShieldedAddresses()` returns an object; new providers `dapp-connector-proof-provider` (first published 4.0.3) and `logger-provider`;
- corrected `submitTx` to return `tx.identifiers()[0]` (the non-existent `tx.txId` was removed) and the `CoinPublicKey`/`EncPublicKey` "branded" wording to "string aliases".

**Source:** midnightntwrk/midnight-js `v4.1.1`, example-bboard/starter-template consumer code.
**Verification:** every API claim checked against the published 4.1.1 `.d.ts`; reviewer found and fixed a runtime-breaking missing `accountId`; final audit fixed two version-introduction errors. Consumer import paths left as direct imports (the `midnight-js-protocol` ACL is monorepo-internal).
**Known follow-up (pre-existing, out of scope):** the browser `balanceTx`/`submitTx` template snippets omit `serialize(tx)` (canonical examples use `toHex(tx.serialize())` plus `Transaction.deserialize(..., fromHex(received.tx))`); the verified pattern lives in `provider-patterns.md`. Recommend a dedicated template fix.
**Note:** Left unmerged for review.

🤖 Part of the 2026-06-02 Midnight Expert upstream revalidation sweep.

Generated with [Claude Code](https://claude.com/claude-code)