### PR TITLE
docs(compact-core): compact-runtime 0.16.0 / compact-js 2.5.1, CompiledContract pipeline, ownPublicKey caveat

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-expert",
   "metadata": {
-    "version": "0.35.0",
+    "version": "0.36.0",
     "description": "AI agent plugins for the Midnight data-protection blockchain. Covers Compact smart contract development, privacy-preserving patterns, DApp frontend design, and Midnight toolchain management."
   },
   "owner": {

--- a/plugins/compact-core/.claude-plugin/plugin.json
+++ b/plugins/compact-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compact-core",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Core knowledge for writing Midnight Compact smart contracts \u2014 contract structure, data types, ledger declarations, circuits, witnesses, and common patterns.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/compact-core/skills/basic-start/references/step-4-counter-contract.md
+++ b/plugins/compact-core/skills/basic-start/references/step-4-counter-contract.md
@@ -84,7 +84,7 @@ Create `package.json`:
     "deploy": "node --import tsx src/deploy.ts"
   },
   "dependencies": {
-    "@midnight-ntwrk/compact-js": "2.5.1",
+    "@midnight-ntwrk/compact-js": "2.5.0",
     "@midnight-ntwrk/compact-runtime": "0.16.0",
     "@midnight-ntwrk/ledger-v8": "8.0.3",
     "@midnight-ntwrk/midnight-js-contracts": "4.0.4",

--- a/plugins/compact-core/skills/basic-start/references/step-4-counter-contract.md
+++ b/plugins/compact-core/skills/basic-start/references/step-4-counter-contract.md
@@ -84,8 +84,8 @@ Create `package.json`:
     "deploy": "node --import tsx src/deploy.ts"
   },
   "dependencies": {
-    "@midnight-ntwrk/compact-js": "2.5.0",
-    "@midnight-ntwrk/compact-runtime": "0.15.0",
+    "@midnight-ntwrk/compact-js": "2.5.1",
+    "@midnight-ntwrk/compact-runtime": "0.16.0",
     "@midnight-ntwrk/ledger-v8": "8.0.3",
     "@midnight-ntwrk/midnight-js-contracts": "4.0.4",
     "@midnight-ntwrk/midnight-js-http-client-proof-provider": "4.0.4",

--- a/plugins/compact-core/skills/compact-init-project/references/project-structure.md
+++ b/plugins/compact-core/skills/compact-init-project/references/project-structure.md
@@ -92,8 +92,8 @@ These are the versions used by `create-mn-app` v0.3.26 hello-world template (ver
 
 | Package | Version |
 |---------|---------|
-| `@midnight-ntwrk/compact-runtime` | 0.15.0 |
-| `@midnight-ntwrk/compact-js` | 2.5.0 |
+| `@midnight-ntwrk/compact-runtime` | 0.16.0 |
+| `@midnight-ntwrk/compact-js` | 2.5.1 |
 | `@midnight-ntwrk/ledger-v8` | 8.0.3 |
 | `@midnight-ntwrk/midnight-js-contracts` | 4.0.2 |
 | `@midnight-ntwrk/midnight-js-http-client-proof-provider` | 4.0.2 |

--- a/plugins/compact-core/skills/compact-init-project/references/project-structure.md
+++ b/plugins/compact-core/skills/compact-init-project/references/project-structure.md
@@ -88,39 +88,39 @@ The counter uses npm workspaces — both `contract` and `counter-cli` are worksp
 
 ## SDK Package Versions
 
-These are the versions used by `create-mn-app` v0.3.26 hello-world template (verified on 2026-03-30). Versions may have been updated since — run `npm view <package> version` to check current versions:
+These are the versions used by `create-mn-app` v0.4.1 hello-world template (verified on 2026-06-02). Versions may have been updated since — run `npm view <package> version` to check current versions:
 
 | Package | Version |
 |---------|---------|
 | `@midnight-ntwrk/compact-runtime` | 0.16.0 |
-| `@midnight-ntwrk/compact-js` | 2.5.1 |
+| `@midnight-ntwrk/compact-js` | 2.5.0 |
 | `@midnight-ntwrk/ledger-v8` | 8.0.3 |
-| `@midnight-ntwrk/midnight-js-contracts` | 4.0.2 |
-| `@midnight-ntwrk/midnight-js-http-client-proof-provider` | 4.0.2 |
-| `@midnight-ntwrk/midnight-js-indexer-public-data-provider` | 4.0.2 |
-| `@midnight-ntwrk/midnight-js-level-private-state-provider` | 4.0.2 |
-| `@midnight-ntwrk/midnight-js-node-zk-config-provider` | 4.0.2 |
-| `@midnight-ntwrk/midnight-js-network-id` | 4.0.2 |
-| `@midnight-ntwrk/midnight-js-types` | 4.0.2 |
-| `@midnight-ntwrk/midnight-js-utils` | 4.0.2 |
+| `@midnight-ntwrk/midnight-js-contracts` | 4.0.4 |
+| `@midnight-ntwrk/midnight-js-http-client-proof-provider` | 4.0.4 |
+| `@midnight-ntwrk/midnight-js-indexer-public-data-provider` | 4.0.4 |
+| `@midnight-ntwrk/midnight-js-level-private-state-provider` | 4.0.4 |
+| `@midnight-ntwrk/midnight-js-node-zk-config-provider` | 4.0.4 |
+| `@midnight-ntwrk/midnight-js-network-id` | 4.0.4 |
+| `@midnight-ntwrk/midnight-js-types` | 4.0.4 |
+| `@midnight-ntwrk/midnight-js-utils` | 4.0.4 |
 | `@midnight-ntwrk/wallet-sdk-facade` | 3.0.0 |
 | `@midnight-ntwrk/wallet-sdk-hd` | 3.0.1 |
 | `@midnight-ntwrk/wallet-sdk-shielded` | 2.1.0 |
 | `@midnight-ntwrk/wallet-sdk-unshielded-wallet` | 2.1.0 |
 | `@midnight-ntwrk/wallet-sdk-dust-wallet` | 3.0.0 |
 
-Dev dependencies: `typescript ^5.9.3`, `tsx ^4.21.0`, `@types/node ^22.0.0`
+Dev dependencies: `typescript ^6.0.3`, `tsx ^4.21.0`, `@types/node ^22.0.0`
 
 Counter template requires Compact compiler >= 0.28.0 (current: compactc-v0.30.x).
 
 ## Toolchain Versions
 
-Verified on 2026-03-30. Use `compact --version` and `npm view create-mn-app version` to check for newer releases.
+Verified on 2026-06-02. Use `compact --version` and `npm view create-mn-app version` to check for newer releases.
 
 | Component | Version | Install/Update |
 |-----------|---------|----------------|
 | Compact compiler | compactc-v0.30.x | `compact update` |
-| create-mn-app | 0.3.26 | `npx create-mn-app@latest` |
+| create-mn-app | 0.4.1 | `npx create-mn-app@latest` |
 | Proof server Docker image | midnightntwrk/proof-server:8.0.3 | Via Docker |
 | Node.js | 22+ required | https://nodejs.org/ |
 

--- a/plugins/compact-core/skills/compact-patterns/references/access-control-patterns.md
+++ b/plugins/compact-core/skills/compact-patterns/references/access-control-patterns.md
@@ -76,6 +76,7 @@ export circuit adminAction(value: Field): [] {
 | `export ledger owner: Bytes<32>` | `export sealed ledger owner: Bytes<32>` | Without `sealed`, owner can be reassigned |
 | `assert(caller == owner, "msg")` | `assert(disclose(caller == owner), "msg")` | Witness-derived comparison needs `disclose()` |
 | `public_key(sk)` | `get_public_key(sk)` using `persistentHash` | `public_key` is not a builtin |
+| `assert(ownPublicKey() == owner, "msg")` | `assert(disclose(get_public_key(local_secret_key()) == owner), "msg")` | `ownPublicKey()` is prover-supplied (the circuit-context `coinPublicKey`), not bound to the transaction signer — any caller can supply any value, so it is bypassable for authorization. Derive identity from a witness secret. Its only safe use is routing shielded tokens *to* the caller. |
 
 ---
 

--- a/plugins/compact-core/skills/compact-standard-library/references/types-and-constructors.md
+++ b/plugins/compact-core/skills/compact-standard-library/references/types-and-constructors.md
@@ -305,9 +305,11 @@ struct ZswapCoinPublicKey { bytes: Bytes<32>; }
 
 | Obtained via | Context |
 |--------------|---------|
-| `ownPublicKey()` | Returns the transaction submitter's public key |
+| `ownPublicKey()` | Returns the Zswap coin public key the prover supplies for this transaction |
 
 Used as a recipient in `sendShielded`, `sendImmediateShielded`, and `createZswapOutput`.
+
+> **Security:** `ownPublicKey()` is *prover-supplied* (passed into the circuit context as `coinPublicKey`), **not** bound to the wallet that signs the transaction. Use it only to route shielded tokens *to* the caller — never for authorization (`assert(ownPublicKey() == admin)`) or identity gating, which a caller can trivially bypass by supplying any value. Derive caller identity from a witness secret instead. See `compact-tokens/references/token-operations.md` and `compact-patterns/references/access-control-patterns.md`.
 
 ### UserAddress
 

--- a/plugins/compact-core/skills/compact-tokens/references/token-operations.md
+++ b/plugins/compact-core/skills/compact-tokens/references/token-operations.md
@@ -113,7 +113,7 @@ assert(coin.color == nativeToken(), "Not a native token");
 | `sendImmediateShielded(input, target, value)` | `input: ShieldedCoinInfo, target: Either<ZswapCoinPublicKey, ContractAddress>, value: Uint<128>` | `ShieldedSendResult` | Send value from a same-transaction coin to target; returns change |
 | `mergeCoin(a, b)` | `a: QualifiedShieldedCoinInfo, b: QualifiedShieldedCoinInfo` | `ShieldedCoinInfo` | Combine two ledger coins into one |
 | `mergeCoinImmediate(a, b)` | `a: QualifiedShieldedCoinInfo, b: ShieldedCoinInfo` | `ShieldedCoinInfo` | Combine a ledger coin with a same-transaction coin |
-| `ownPublicKey()` | -- | `ZswapCoinPublicKey` | Returns the public key of the end-user creating this transaction |
+| `ownPublicKey()` | -- | `ZswapCoinPublicKey` | Returns the Zswap coin public key the prover supplies for this transaction. Use it as a token recipient, **not** as an authorization check (see security note below) |
 | `createZswapInput(coin)` | `coin: QualifiedShieldedCoinInfo` | `[]` | Low-level: notify context to create a Zswap input |
 | `createZswapOutput(coin, recipient)` | `coin: ShieldedCoinInfo, recipient: Either<ZswapCoinPublicKey, ContractAddress>` | `[]` | Low-level: notify context to create a Zswap output |
 
@@ -137,6 +137,13 @@ if (res.change.is_some) {
 **`createZswapInput` and `createZswapOutput` are low-level:** Prefer `sendShielded`, `sendImmediateShielded`, and `receiveShielded`. The low-level functions do not handle coin splitting, change, or validation. Use them only when building custom token protocols.
 
 **`sendShielded` does not create coin ciphertexts:** Sending to a user public key other than the current user (`ownPublicKey()`) will not inform that user of the coin. The recipient must discover the coin through other means.
+
+**Security: `ownPublicKey()` is prover-supplied, not signer-bound.** `ownPublicKey()` returns a value the prover passes into the circuit context (the `coinPublicKey` argument to `createConstructorContext` / `createCircuitContext` in `@midnight-ntwrk/compact-runtime`). It is **not** cryptographically bound to the wallet that signs the transaction — any caller can supply any 32-byte value. Its only safe use is identifying the **recipient** of an outgoing shielded token transfer (routing tokens *to* the caller): if the prover lies, they only lose access to their own coins, so there is no boundary to bypass. Do **not** use it for authorization or identity gating:
+
+- `assert(ownPublicKey() == admin, "...")` is bypassable — any chain reader copies the public `admin` value and supplies it.
+- `assert(!blacklist.member(ownPublicKey()), "...")` is bypassable — a blacklisted caller supplies a different value.
+
+For caller identity and access control, derive the public key from a witness-supplied secret instead (see `compact-patterns/references/access-control-patterns.md` and `compact-privacy-disclosure/references/privacy-patterns.md`, which use `get_public_key(sk)` / domain-separated `persistentHash` over a witness secret).
 
 **Nonce management with `evolveNonce`:** Every shielded coin requires a unique nonce. Reusing a nonce compromises privacy by linking coins. Use `evolveNonce` with a counter to derive deterministic nonces from a single seed:
 

--- a/plugins/compact-core/skills/compact-witness-ts/SKILL.md
+++ b/plugins/compact-core/skills/compact-witness-ts/SKILL.md
@@ -137,9 +137,14 @@ import { Contract, pureCircuits, ledger } from "./managed/mycontract/contract/in
 // Local testing only — instantiate Contract directly with witnesses
 const contractInstance = new Contract(witnesses);
 
-// Production — use CompiledContract.make() from @midnight-ntwrk/compact-js
+// Production — use CompiledContract.make() from @midnight-ntwrk/compact-js.
+// make() takes a tag and the Contract CLASS (not an instance); attach witnesses
+// and ZK assets via .pipe(). It is synchronous — do NOT `await` it.
 import { CompiledContract } from "@midnight-ntwrk/compact-js";
-const compiledContract = await CompiledContract.make(contractInstance);
+const compiledContract = CompiledContract.make("mycontract", Contract).pipe(
+  CompiledContract.withWitnesses(witnesses),
+  CompiledContract.withCompiledFileAssets(zkConfigPath),
+);
 
 // Pure circuits — module-level export, local computation, no proof, no transaction
 const hash = pureCircuits.computeHash(inputData);

--- a/plugins/compact-core/skills/compact-witness-ts/SKILL.md
+++ b/plugins/compact-core/skills/compact-witness-ts/SKILL.md
@@ -142,6 +142,8 @@ const contractInstance = new Contract(witnesses);
 // and ZK assets via .pipe(). It is synchronous — do NOT `await` it.
 import { CompiledContract } from "@midnight-ntwrk/compact-js";
 const compiledContract = CompiledContract.make("mycontract", Contract).pipe(
+  // Attach witness implementations (or CompiledContract.withVacantWitnesses if the
+  // contract declares no witnesses — note: it is a value used bare in .pipe(...), NOT called as withVacantWitnesses())
   CompiledContract.withWitnesses(witnesses),
   CompiledContract.withCompiledFileAssets(zkConfigPath),
 );

--- a/plugins/compact-core/skills/compact-witness-ts/references/contract-runtime.md
+++ b/plugins/compact-core/skills/compact-witness-ts/references/contract-runtime.md
@@ -156,11 +156,21 @@ if (contractState != null) {
 When deploying or joining a contract, you provide a string identifier for the private state store. This lets the runtime persist and retrieve private state across sessions:
 
 ```typescript
-// Wrap the Contract instance in a CompiledContract
+// Build a CompiledContract with CompiledContract.make + .pipe (compact-js 2.5.x)
 import { CompiledContract } from "@midnight-ntwrk/compact-js";
-const compiledContract = new CompiledContract(contractInstance);
+import { MyContract } from "@midnight-ntwrk/mycontract-contract";
 
-// Deploying
+const compiledContract = CompiledContract.make('mycontract', MyContract.Contract).pipe(
+  // Attach witness implementations (or CompiledContract.withVacantWitnesses if none)
+  CompiledContract.withWitnesses(witnesses),
+  // Point at the generated ZK assets (the compiler `managed/<name>` output)
+  CompiledContract.withCompiledFileAssets(zkConfigPath),
+);
+
+// Deploying — pass `args` (the constructor's InitializeParameters) when the Compact
+// constructor takes parameters, e.g. `args: [42n]`. For a no-argument constructor
+// `args` is optional and can be omitted (the option type makes it required only when
+// the constructor has parameters).
 const deployed = await deployContract(providers, {
   compiledContract: compiledContract,
   privateStateId: 'myContractPrivateState',
@@ -175,6 +185,8 @@ const found = await findDeployedContract(providers, {
   initialPrivateState: createMyPrivateState(secretKey),
 });
 ```
+
+> `CompiledContract` is a module exposing the factory `make(tag, Contract)` plus pipeable combinators (`withWitnesses` / `withVacantWitnesses`, `withCompiledFileAssets`). It is **not** a constructable class — `new CompiledContract(...)` is not valid in compact-js 2.5.x.
 
 The `privateStateId` is a string key used by the private state provider to store and retrieve state. Use a descriptive, unique name per contract type.
 


### PR DESCRIPTION
## What changed
- version refs: `@midnight-ntwrk/compact-runtime` `0.15.0` -> `0.16.0`, `@midnight-ntwrk/compact-js` `2.5.0` -> `2.5.1`;
- `CompiledContract` usage corrected to the real compact-js 2.5.1 API: `CompiledContract.make(tag, ctor)` is a **synchronous** factory (removed `await`/`new CompiledContract(...)`) used with `withWitnesses`/`withVacantWitnesses`/`withCompiledFileAssets`; `deployContract` args documented as conditionally required;
- added an `ownPublicKey()` security caveat: it is a prover-supplied value (not bound to the tx signer), so `assert(ownPublicKey()==admin)` / blacklist-membership checks are bypassable -- derive identity from a witness secret instead.

**Source:** midnightntwrk/midnight-sdk (`compact-js` 2.5.1 `.d.ts`), midnightntwrk/example-zkloan.
**Verification:** versions via `npm view`; API shapes against the published `compact-js`/`midnight-js-contracts` `.d.ts`; the `ownPublicKey` caveat confirmed against runtime `constructor-context.d.ts`. OpenZeppelin-derived example `.compact` files left unchanged. Reviewer verdict: clean.
**Note:** Unreleased ledger cost-model/commitment/MerkleTree changes excluded. Left unmerged for review.

🤖 Part of the 2026-06-02 Midnight Expert upstream revalidation sweep.

Generated with [Claude Code](https://claude.com/claude-code)