### PR TITLE
docs(security): urgent warning banners on insecure ownPublicKey()-for-auth examples

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-expert",
   "metadata": {
-    "version": "0.42.0",
+    "version": "0.42.1",
     "description": "AI agent plugins for the Midnight data-protection blockchain. Covers Compact smart contract development, privacy-preserving patterns, DApp frontend design, and Midnight toolchain management."
   },
   "owner": {

--- a/plugins/compact-core/.claude-plugin/plugin.json
+++ b/plugins/compact-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compact-core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Core knowledge for writing Midnight Compact smart contracts \u2014 contract structure, data types, ledger declarations, circuits, witnesses, and common patterns.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/compact-core/skills/compact-tokens/examples/FungibleToken.compact
+++ b/plugins/compact-core/skills/compact-tokens/examples/FungibleToken.compact
@@ -37,6 +37,39 @@
 
 pragma language_version >= 0.22;
 
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation in the
+//  compact-examples plugin:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see that plugin's references/applications.md for rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 /**
  * @module FungibleToken
  * @description An unshielded FungibleToken library.
@@ -337,6 +370,7 @@ module FungibleToken {
  Initializable_assertInitialized();
  // ownPublicKey() returns the ZswapCoinPublicKey of the transaction signer (the caller).
  // Wrapping in left<>() creates an Either value representing a user (not a contract).
+ // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
  const owner = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
  _unsafeUncheckedTransfer(owner, to, value);
  return true;
@@ -405,6 +439,7 @@ module FungibleToken {
  Initializable_assertInitialized();
 
  // Identify the caller as the owner of the allowance being set
+ // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
  const owner = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
  _approve(owner, spender, value);
  return true;
@@ -476,6 +511,7 @@ module FungibleToken {
 
  // The caller (spender) is identified via ownPublicKey(), not passed as a parameter.
  // This prevents a malicious caller from impersonating another spender.
+ // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
  const spender = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
  // Deduct from the spender's allowance before performing the transfer
  _spendAllowance(fromAddress, spender, value);

--- a/plugins/compact-core/skills/compact-tokens/examples/MultiToken.compact
+++ b/plugins/compact-core/skills/compact-tokens/examples/MultiToken.compact
@@ -41,6 +41,39 @@
 
 pragma language_version >= 0.22;
 
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation in the
+//  compact-examples plugin:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see that plugin's references/applications.md for rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 /**
  * @module MultiToken
  * @description An unshielded MultiToken library. This library is inspired by
@@ -310,6 +343,7 @@ module MultiToken {
  // supports contract-to-contract calls, the caller could also be a ContractAddress.
  // left<L,R>() wraps the value in the Left variant of Either, identifying it as
  // a ZswapCoinPublicKey rather than a ContractAddress.
+ // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
  const caller = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
  _setApprovalForAll(caller, operator, approved);
   }
@@ -563,6 +597,7 @@ module MultiToken {
  // TODO: Contract-to-contract calls not yet supported.
  // Once available, handle ContractAddress recipients here.
  // Identify the caller as the Left variant (ZswapCoinPublicKey) of the account type.
+ // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
  const caller = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
  // Authorization check: the caller must either be the token owner (fromAddress)
  // or an operator approved via setApprovalForAll. disclose(fromAddress) is needed

--- a/plugins/compact-core/skills/compact-tokens/examples/NonFungibleToken.compact
+++ b/plugins/compact-core/skills/compact-tokens/examples/NonFungibleToken.compact
@@ -39,6 +39,39 @@
 
 pragma language_version >= 0.22;
 
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation in the
+//  compact-examples plugin:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see that plugin's references/applications.md for rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 /**
  * @module NonFungibleToken
  * @description An unshielded Non-Fungible Token library.
@@ -386,6 +419,7 @@ module NonFungibleToken {
  // The caller's identity is captured via ownPublicKey() and wrapped as the
  // Left variant of Either (ZswapCoinPublicKey). This `auth` value is passed
  // to _approve to verify the caller is the token owner or an operator.
+ // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
  const auth = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
  _approve(to, tokenId, auth);
   }
@@ -435,6 +469,7 @@ module NonFungibleToken {
  Initializable_assertInitialized();
  // Wrap the caller's public key as the owner. In Midnight, ownPublicKey()
  // identifies the transaction sender within a circuit.
+ // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
  const owner = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
  _setApprovalForAll(owner, operator, approved);
   }
@@ -559,6 +594,7 @@ module NonFungibleToken {
  assert(!Utils_isKeyOrAddressZero(to), "NonFungibleToken: Invalid Receiver");
  // Setting an "auth" arguments enables the `_isAuthorized` check which verifies that the token exists
  // (fromAddress != 0). Therefore, it is not needed to verify that the return value is not 0 here.
+ // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
  const auth = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
  // _update performs the core accounting: balance adjustment, ownership transfer,
  // and approval clearing. It returns the previous owner so we can verify the

--- a/plugins/compact-examples/.claude-plugin/plugin.json
+++ b/plugins/compact-examples/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compact-examples",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Compilable Compact smart contract examples — beginner contracts, reusable modules, token implementations, and full applications with witnesses and tests. All code at pragma language_version >= 0.22.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/compact-examples/skills/code-examples/examples/applications/kitties/Nft.compact
+++ b/plugins/compact-examples/skills/code-examples/examples/applications/kitties/Nft.compact
@@ -1,5 +1,37 @@
 pragma language_version >= 0.22;
 
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see references/applications.md for the rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 module Nft {
 
     /**
@@ -66,6 +98,7 @@ module Nft {
 
   // Approves another public key to transfer the specified token ID
   export circuit approve(to: ZswapCoinPublicKey, tokenId: Uint<64>): [] {
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const senderPublicKey = ownPublicKey();
     assert(to != default<ZswapCoinPublicKey>, "Approved address cannot be empty.");
 
@@ -88,6 +121,7 @@ module Nft {
 
   // Sets or unsets approval for an operator to manage all of the caller's tokens
   export circuit setApprovalForAll(operator: ZswapCoinPublicKey, approved: Boolean): [] {
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const senderPublicKey = ownPublicKey();
     assert(operator != default<ZswapCoinPublicKey>, "Operator cannot be empty.");
     assert(operator != senderPublicKey, "Cannot set yourself as operator.");
@@ -115,6 +149,7 @@ module Nft {
 
   // Transfers ownership of a given token ID from you to another account
   export circuit transfer(to: ZswapCoinPublicKey, tokenId: Uint<64>): [] {
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const senderPublicKey = ownPublicKey();
     assert(tokenId != default<Uint<64>>, "Token ID cannot be empty.");
 
@@ -123,6 +158,7 @@ module Nft {
 
   // Transfers ownership of a given token ID from one public key to another
   export circuit transferFrom(fromAddress: ZswapCoinPublicKey, to: ZswapCoinPublicKey, tokenId: Uint<64>): [] {
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const senderPublicKey = ownPublicKey();
     assert(tokenId != default<Uint<64>>, "Token ID cannot be empty.");
     assert(isApprovedOrOwner(disclose(senderPublicKey), disclose(tokenId)), "Not authorized to transfer.");

--- a/plugins/compact-examples/skills/code-examples/examples/applications/kitties/kitties.compact
+++ b/plugins/compact-examples/skills/code-examples/examples/applications/kitties/kitties.compact
@@ -25,6 +25,38 @@
 
 pragma language_version >= 0.22;
 
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see references/applications.md for the rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 import CompactStandardLibrary;
 import "./Nft";
 
@@ -118,6 +150,7 @@ circuit generateGender(): Gender {
 
 // Creates a new unique kitty and mints the corresponding NFT.
 export circuit createKitty(): [] {
+  // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
   const sender = ownPublicKey();
   const kittyId = (allKittiesCount.read() + 1) as Uint<64>;
   const kittyDna = generateDNA(sender, kittyId);
@@ -222,6 +255,7 @@ export circuit transferKittyFrom(fromAddress: ZswapCoinPublicKey, to: ZswapCoinP
 
 // Sets the price for a kitty and marks it as for sale if price > 0.
 export circuit setPrice(kittyId: Uint<64>, price: Uint<64>): [] {
+  // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
   const sender = ownPublicKey();
 
   // Ensure the kitty exists.
@@ -248,6 +282,7 @@ export circuit setPrice(kittyId: Uint<64>, price: Uint<64>): [] {
 
 // Allows a user to create an offer to buy a kitty that is for sale.
 export circuit createBuyOffer(kittyId: Uint<64>, bidPrice: Uint<64>): [] {
+  // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
   const buyer = ownPublicKey();
 
   // Ensure the kitty exists.
@@ -286,6 +321,7 @@ export circuit createBuyOffer(kittyId: Uint<64>, bidPrice: Uint<64>): [] {
 // Only the current owner can approve an offer.
 // Note: Currency transfer is not implemented here; only ownership is transferred.
 export circuit approveOffer(kittyId: Uint<64>, buyer: ZswapCoinPublicKey): [] {
+  // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
   assert(ownPublicKey() == ownerOf(disclose(kittyId)), "Only owner can sell.");
 
   // Retrieve the kitty's current data.
@@ -325,6 +361,7 @@ export circuit approveOffer(kittyId: Uint<64>, buyer: ZswapCoinPublicKey): [] {
 // Warning: The DNA combination uses a random seed from a witness.
 // The offspring's generation is set to max(parent generations) + 1.
 export circuit breedKitty(kittyId1: Uint<64>, kittyId2: Uint<64>): [] {
+  // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
   const sender = ownPublicKey();
 
   // Ensure both parent kitties exist.

--- a/plugins/compact-examples/skills/code-examples/examples/applications/midnight-rwa/midnight-rwa.compact
+++ b/plugins/compact-examples/skills/code-examples/examples/applications/midnight-rwa/midnight-rwa.compact
@@ -1,6 +1,38 @@
 // Copyright 2025 Brick Towers
 pragma language_version >= 0.22;
 
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see references/applications.md for the rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 import CompactStandardLibrary;
 import Crypto;
 import PassportIdentity;
@@ -131,6 +163,7 @@ export circuit provideTBTC(inputCoin: ShieldedCoinInfo): [] {
 
 export circuit buyTHF(inputCoin: ShieldedCoinInfo): [] {
   // receive tBTC and send tHF
+  // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
   isAuthorizedSend(left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()));
   const coin = disclose(inputCoin);
   assert(coin.color == tbtcCoinColor, "The coin supplied for verification is not tBTC");
@@ -185,6 +218,7 @@ export circuit onboard(quiz: QuizResult, inputCoin: ShieldedCoinInfo, identity: 
   assert(quizCommit(quiz) == quizHash, "Quiz has some incorrect answers");
   assertIdentity(identity);
   assertCoinValue(inputCoin);
+  // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
   authorizations.insert(ownPublicKey());
 }
 

--- a/plugins/compact-examples/skills/code-examples/examples/modules/access/AccessControl.compact
+++ b/plugins/compact-examples/skills/code-examples/examples/modules/access/AccessControl.compact
@@ -3,6 +3,38 @@
 
 pragma language_version >= 0.22;
 
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see references/applications.md for the rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 /**
  * @module AccessControl
  * @description An unshielded AccessControl library.
@@ -129,6 +161,7 @@ module AccessControl {
    * @return {[]} - Empty tuple.
    */
   export circuit assertOnlyRole(roleId: Bytes<32>): [] {
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     _checkRole(roleId, left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()));
   }
 
@@ -235,6 +268,7 @@ module AccessControl {
                    roleId: Bytes<32>,
                    callerConfirmation: Either<ZswapCoinPublicKey, ContractAddress>
                    ): [] {
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     assert(callerConfirmation == left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()),
            "AccessControl: bad confirmation"
            );

--- a/plugins/compact-examples/skills/code-examples/examples/modules/access/Ownable.compact
+++ b/plugins/compact-examples/skills/code-examples/examples/modules/access/Ownable.compact
@@ -3,6 +3,38 @@
 
 pragma language_version >= 0.22;
 
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see references/applications.md for the rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 /**
  * @module Ownable
  * @description An unshielded Ownable library.
@@ -161,6 +193,7 @@ module Ownable {
    */
   export circuit assertOnlyOwner(): [] {
     Initializable_assertInitialized();
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const caller = ownPublicKey();
     assert(caller == _owner.left, "Ownable: caller is not the owner");
   }

--- a/plugins/compact-examples/skills/code-examples/examples/modules/access/ZOwnablePK.compact
+++ b/plugins/compact-examples/skills/code-examples/examples/modules/access/ZOwnablePK.compact
@@ -3,6 +3,38 @@
 
 pragma language_version >= 0.22;
 
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see references/applications.md for the rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 /**
  * @module ZOwnablePK
  * @description A shielded, public key-derived Ownable module.
@@ -191,6 +223,7 @@ module ZOwnablePK {
     Initializable_assertInitialized();
 
     const nonce = wit_secretNonce();
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const callerAsEither =
             Either<ZswapCoinPublicKey, ContractAddress> { is_left: true,
                                                           left: ownPublicKey(),

--- a/plugins/compact-examples/skills/code-examples/examples/modules/token/FungibleToken.compact
+++ b/plugins/compact-examples/skills/code-examples/examples/modules/token/FungibleToken.compact
@@ -3,6 +3,38 @@
 
 pragma language_version >= 0.22;
 
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see references/applications.md for the rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 /**
  * @module FungibleToken
  * @description An unshielded FungibleToken library.
@@ -232,6 +264,7 @@ module FungibleToken {
                    value: Uint<128>
                    ): Boolean {
     Initializable_assertInitialized();
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const owner = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
     _unsafeUncheckedTransfer(owner, to, value);
     return true;
@@ -284,6 +317,7 @@ module FungibleToken {
                          ): Boolean {
     Initializable_assertInitialized();
 
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const owner = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
     _approve(owner, spender, value);
     return true;
@@ -352,6 +386,7 @@ module FungibleToken {
                    ): Boolean {
     Initializable_assertInitialized();
 
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const spender = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
     _spendAllowance(fromAddress, spender, value);
     _unsafeUncheckedTransfer(fromAddress, to, value);

--- a/plugins/compact-examples/skills/code-examples/examples/modules/token/MultiToken.compact
+++ b/plugins/compact-examples/skills/code-examples/examples/modules/token/MultiToken.compact
@@ -3,6 +3,38 @@
 
 pragma language_version >= 0.22;
 
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see references/applications.md for the rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 /**
  * @module MultiToken
  * @description An unshielded MultiToken library. This library is inspired by
@@ -184,6 +216,7 @@ module MultiToken {
     Initializable_assertInitialized();
 
     // TODO: Contract-to-contract calls not yet supported.
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const caller = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
     _setApprovalForAll(caller, operator, approved);
   }
@@ -370,6 +403,7 @@ module MultiToken {
 
     // TODO: Contract-to-contract calls not yet supported.
     // Once available, handle ContractAddress recipients here.
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const caller = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
     if (disclose(fromAddress) != caller) {
       assert(isApprovedForAll(fromAddress, caller), "MultiToken: unauthorized operator");

--- a/plugins/compact-examples/skills/code-examples/examples/modules/token/Nft.compact
+++ b/plugins/compact-examples/skills/code-examples/examples/modules/token/Nft.compact
@@ -1,3 +1,35 @@
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see references/applications.md for the rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 module Nft {
 
     /**
@@ -64,6 +96,7 @@ module Nft {
 
   // Approves another public key to transfer the specified token ID
   export circuit approve(to: ZswapCoinPublicKey, tokenId: Uint<64>): [] {
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const senderPublicKey = ownPublicKey();
     assert(to != default<ZswapCoinPublicKey>, "Approved address cannot be empty.");
 
@@ -86,6 +119,7 @@ module Nft {
 
   // Sets or unsets approval for an operator to manage all of the caller's tokens
   export circuit setApprovalForAll(operator: ZswapCoinPublicKey, approved: Boolean): [] {
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const senderPublicKey = ownPublicKey();
     assert(operator != default<ZswapCoinPublicKey>, "Operator cannot be empty.");
     assert(operator != senderPublicKey, "Cannot set yourself as operator.");
@@ -113,6 +147,7 @@ module Nft {
 
   // Transfers ownership of a given token ID from you to another account
   export circuit transfer(to: ZswapCoinPublicKey, tokenId: Uint<64>): [] {
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const senderPublicKey = ownPublicKey();
     assert(tokenId != default<Uint<64>>, "Token ID cannot be empty.");
 
@@ -121,6 +156,7 @@ module Nft {
 
   // Transfers ownership of a given token ID from one public key to another
   export circuit transferFrom(fromAddress: ZswapCoinPublicKey, to: ZswapCoinPublicKey, tokenId: Uint<64>): [] {
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const senderPublicKey = ownPublicKey();
     assert(tokenId != default<Uint<64>>, "Token ID cannot be empty.");
     assert(isApprovedOrOwner(disclose(senderPublicKey), disclose(tokenId)), "Not authorized to transfer.");

--- a/plugins/compact-examples/skills/code-examples/examples/modules/token/NftZk.compact
+++ b/plugins/compact-examples/skills/code-examples/examples/modules/token/NftZk.compact
@@ -1,3 +1,35 @@
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see references/applications.md for the rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 module NftZk {
 
   /**
@@ -85,6 +117,7 @@ module NftZk {
 
   // Approves another public key to transfer the specified token ID
   export circuit approve(to: ZswapCoinPublicKey, tokenId: Uint<64>): [] {
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const senderPublicKey = ownPublicKey();
     assert(to != default<ZswapCoinPublicKey>, "Approved account cannot be empty.");
 
@@ -119,6 +152,7 @@ module NftZk {
 
   // Sets or unsets approval for an operator to manage all of the caller's tokens
   export circuit setApprovalForAll(operator: ZswapCoinPublicKey, approved: Boolean): [] {
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const senderPublicKey = ownPublicKey();
     assert(operator != default<ZswapCoinPublicKey>, "Operator cannot be empty.");
     assert(operator != senderPublicKey, "Cannot set yourself as operator.");
@@ -152,6 +186,7 @@ module NftZk {
 
   // Transfers ownership of a given token ID from you to another account
   export circuit transfer(to: ZswapCoinPublicKey, tokenId: Uint<64>): [] {
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const senderPublicKey = ownPublicKey();
     assert(tokenId != default<Uint<64>>, "Token ID cannot be empty.");
 
@@ -163,6 +198,7 @@ module NftZk {
 
   // Transfers ownership of a given token ID from one public key to another
   export circuit transferFrom(fromHashKey: Field, to: ZswapCoinPublicKey, tokenId: Uint<64>): [] {
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const senderPublicKey = ownPublicKey();
     assert(tokenId != default<Uint<64>>, "Token ID cannot be empty.");
 

--- a/plugins/compact-examples/skills/code-examples/examples/modules/token/NonFungibleToken.compact
+++ b/plugins/compact-examples/skills/code-examples/examples/modules/token/NonFungibleToken.compact
@@ -3,6 +3,38 @@
 
 pragma language_version >= 0.22;
 
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see references/applications.md for the rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 /**
  * @module NonFungibleToken
  * @description An unshielded Non-Fungible Token library.
@@ -261,6 +293,7 @@ module NonFungibleToken {
    */
   export circuit approve(to: Either<ZswapCoinPublicKey, ContractAddress>, tokenId: Uint<128>): [] {
     Initializable_assertInitialized();
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const auth = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
     _approve(to, tokenId, auth);
   }
@@ -305,6 +338,7 @@ module NonFungibleToken {
                    approved: Boolean
                    ): [] {
     Initializable_assertInitialized();
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const owner = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
     _setApprovalForAll(owner, operator, approved);
   }
@@ -400,6 +434,7 @@ module NonFungibleToken {
     assert(!Utils_isKeyOrAddressZero(to), "NonFungibleToken: Invalid Receiver");
     // Setting an "auth" arguments enables the `_isAuthorized` check which verifies that the token exists
     // (fromAddress != 0). Therefore, it is not needed to verify that the return value is not 0 here.
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     const auth = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
     const previousOwner = _update(to, tokenId, auth);
     assert(previousOwner == fromAddress, "NonFungibleToken: Incorrect Owner");

--- a/plugins/compact-examples/skills/code-examples/examples/tokens/AccessControlledToken.compact
+++ b/plugins/compact-examples/skills/code-examples/examples/tokens/AccessControlledToken.compact
@@ -8,6 +8,38 @@
 
 pragma language_version >= 0.22.0;
 
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see references/applications.md for the rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 import CompactStandardLibrary;
 import "../modules/access/AccessControl"
   prefix AccessControl_;
@@ -28,6 +60,7 @@ constructor(
   // Grant deployer admin role — they can grant/revoke any role
   AccessControl__grantRole(
     AccessControl_DEFAULT_ADMIN_ROLE,
+    // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
     left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey())
   );
 }

--- a/plugins/compact-examples/skills/code-examples/examples/tokens/nft-zk.compact
+++ b/plugins/compact-examples/skills/code-examples/examples/tokens/nft-zk.compact
@@ -25,6 +25,38 @@
 
 pragma language_version >= 0.22.0;
 
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see references/applications.md for the rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 import CompactStandardLibrary;
 import "../modules/token/NftZk";
 
@@ -46,11 +78,13 @@ export ledger contractAdmin: ZswapCoinPublicKey;
 
 // Set the public key of the contract admin.
 constructor() {
+  // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
   contractAdmin = ownPublicKey();
 }
 
 // Example: Only Admin can mint tokens.
 export circuit mintAdmin(to: ZswapCoinPublicKey, tokenId: Uint<64>): [] {
+  // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
   const senderPublicKey = ownPublicKey();
   assert(senderPublicKey == contractAdmin, "Not authorized to mint.");
 
@@ -60,6 +94,7 @@ export circuit mintAdmin(to: ZswapCoinPublicKey, tokenId: Uint<64>): [] {
 
 // Example: Only admin can burn tokens.
 export circuit burnAdmin(tokenId: Uint<64>): [] {
+  // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
   const senderPublicKey = ownPublicKey();
   assert(senderPublicKey == contractAdmin, "Not authorized to burn.");
 

--- a/plugins/compact-examples/skills/code-examples/examples/tokens/nft.compact
+++ b/plugins/compact-examples/skills/code-examples/examples/tokens/nft.compact
@@ -25,6 +25,38 @@
 
 pragma language_version >= 0.22.0;
 
+// =============================================================================
+//  ⚠  SECURITY WARNING — INSECURE PATTERN — DO NOT COPY  ⚠
+// =============================================================================
+//  This example uses ownPublicKey() for AUTHORIZATION / IDENTITY GATING
+//  (owner/admin/role checks such as assert(ownPublicKey() == admin),
+//  contractAdmin = ownPublicKey(), or authorizations.insert(ownPublicKey())).
+//  THIS IS BYPASSABLE — DO NOT USE THIS PATTERN IN REAL CONTRACTS.
+//
+//  WHY: ownPublicKey() returns the prover-supplied Zswap coin public key (the
+//  coinPublicKey passed into the circuit context by
+//  @midnight-ntwrk/compact-runtime). It is NOT cryptographically bound to the
+//  wallet that signs the transaction. Any caller can supply ANY 32-byte value,
+//  so any authorization or identity check built on it can be trivially
+//  bypassed by reading the public target value off-chain and supplying it.
+//
+//  THE ONLY SAFE USE: routing shielded tokens *to* the caller, e.g.
+//  left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()) as a send/mint
+//  recipient — if the prover lies, they only misroute their own coins.
+//
+//  WHAT TO DO INSTEAD: derive caller identity inside the circuit from a
+//  witness-supplied secret via a domain-separated persistentHash, and pin the
+//  authority at deploy. See the secure reference implementation:
+//    examples/applications/zkloan/zkloan-credit-scorer.compact
+//    examples/applications/zkloan/witnesses.ts
+//  It derives identity with deriveAdminPublicKey(getUserSecret()) instead of
+//  ownPublicKey(); see references/applications.md for the rationale.
+//
+//  A full rework of this example to the secure pattern is tracked as a
+//  follow-up. Until then, every ownPublicKey()-based auth check below is a
+//  demonstration of what NOT to do.
+// =============================================================================
+
 import CompactStandardLibrary;
 import "../modules/token/Nft";
 
@@ -45,11 +77,13 @@ export ledger contractAdmin: ZswapCoinPublicKey;
 
 // Set the public key of the contract admin.
 constructor() {
+  // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
   contractAdmin = ownPublicKey();
 }
 
 // Example: Only Admin can mint tokens.
 export circuit mintAdmin(to: ZswapCoinPublicKey, tokenId: Uint<64>): [] {
+  // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
   const senderPublicKey = ownPublicKey();
   assert(senderPublicKey == contractAdmin, "Not authorized to mint.");
 
@@ -59,6 +93,7 @@ export circuit mintAdmin(to: ZswapCoinPublicKey, tokenId: Uint<64>): [] {
 
 // Example: Only admin can burn tokens.
 export circuit burnAdmin(tokenId: Uint<64>): [] {
+  // ⚠ INSECURE: ownPublicKey() is prover-supplied and bypassable for auth — see SECURITY WARNING banner at top of file.
   const senderPublicKey = ownPublicKey();
   assert(senderPublicKey == contractAdmin, "Not authorized to burn.");
 


### PR DESCRIPTION
## Why (urgent)

Several Compact examples in the marketplace use `ownPublicKey()` for **authorization / identity gating** (owner/admin/role checks, `contractAdmin = ownPublicKey()`, `authorizations.insert(ownPublicKey())`, allowance/operator-approval identity). That pattern is **bypassable**: `ownPublicKey()` returns the prover-supplied `coinPublicKey` from the circuit context — it is **not** cryptographically bound to the transaction signer, so any caller can supply any 32-byte value and defeat the check. This matches the repo's own canonical guidance in `compact-core .../token-operations.md` ("the only safe use is identifying the recipient of an outgoing transfer").

A full rework to witness-secret identity (the zkloan pattern) is tracked separately. This PR is the **urgent stopgap**: it adds a loud `SECURITY WARNING` banner + inline `⚠ INSECURE` markers to every affected example so nobody copies the anti-pattern in the meantime.

## What

- **Comment-only and purely additive.** 593 inserted comment/blank lines, **0 code lines changed, 0 deletions** across the 17 contract files (verified mechanically). Each file gets a banner right after its `pragma` and an inline marker above each insecure call site.
- Safe **token-routing** uses — `left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey())` as a `send`/`mint` recipient (worst case: caller misroutes their own coins) — are intentionally **left unmarked**.
- The banner links to the secure reference implementation (`examples/applications/zkloan/zkloan-credit-scorer.compact` + `witnesses.ts`, `deriveAdminPublicKey(getUserSecret())`).

### Files (17)
| Area | Files |
|---|---|
| Applications | `kitties/kitties.compact`, `kitties/Nft.compact`, `midnight-rwa/midnight-rwa.compact` |
| Access modules | `AccessControl.compact`, `Ownable.compact`, `ZOwnablePK.compact` |
| NFT contracts | `modules/token/Nft.compact`, `modules/token/NftZk.compact`, `tokens/nft.compact`, `tokens/nft-zk.compact` |
| OZ token modules (caller-identity-in-auth) | `modules/token/{FungibleToken,NonFungibleToken,MultiToken}.compact`, `compact-core/.../compact-tokens/examples/{FungibleToken,NonFungibleToken,MultiToken}.compact`, `tokens/AccessControlledToken.compact` |

## How the set was determined

Two independent `ownPublicKey()` audits (one Sonnet, one Opus) classified every call site as UNSAFE (auth/identity), SAFE (token routing), or ambiguous. They **independently agreed** that the OZ-style token modules — and the `compact-core` copies — use `ownPublicKey()` for the `owner`/`spender`/`auth`/`caller` **identity** in `approve` / `transferFrom` / `setApprovalForAll` / allowance / role-grant paths, which is bypassable authorization, not safe routing. Those were added to the banner set beyond the originally-named targets.

## Version bumps
- `compact-examples` 0.3.0 → 0.3.1
- `compact-core` 0.7.0 → 0.7.1
- marketplace 0.42.0 → 0.42.1

## Out of scope / follow-ups
- The full **witness-secret-identity rework** of these contracts (item E of the broader follow-up).
- Two **factually-wrong existing comments** in `compact-core .../FungibleToken.compact` (claims `ownPublicKey()` is "the transaction signer" / "prevents impersonation") and `NonFungibleToken.compact` ("identifies the transaction sender") were **left as-is** to keep this PR purely additive; the new `⚠ INSECURE` markers sit directly above them. Recommend correcting them during the rework.
- The intentionally-unregistered `midnight-node` / `midnight-indexer` / `proof-server` plugins are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
