### PR TITLE
feat(compact-core): add security-reviewer subagent + /compact-core:audit-compact

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-expert",
   "metadata": {
-    "version": "0.42.1",
+    "version": "0.43.0",
     "description": "AI agent plugins for the Midnight data-protection blockchain. Covers Compact smart contract development, privacy-preserving patterns, DApp frontend design, and Midnight toolchain management."
   },
   "owner": {

--- a/plugins/compact-core/.claude-plugin/plugin.json
+++ b/plugins/compact-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compact-core",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Core knowledge for writing Midnight Compact smart contracts \u2014 contract structure, data types, ledger declarations, circuits, witnesses, and common patterns.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/compact-core/agents/security-reviewer.md
+++ b/plugins/compact-core/agents/security-reviewer.md
@@ -1,0 +1,101 @@
+---
+name: security-reviewer
+memory: user
+description: >-
+  Use this agent to perform a focused, adversarial SECURITY review of Compact
+  smart contract code. Unlike the command-only `reviewer` agent, this agent is
+  directly invocable by users and by other agents. It performs a single coherent
+  threat-model pass (witness trust boundary, access control, cryptography,
+  tokens, privacy leakage) and reasons across dimensions so compounding issues
+  are caught. It CANNOT spawn subagents: for Critical/High findings it emits a
+  structured "Verification Requests" block and hands mechanical confirmation back
+  to the caller (the /compact-core:audit-compact orchestrator). Do NOT use this
+  agent for non-security review categories (performance, docs, testing adequacy)
+  — use compact-core:review-compact for a full multi-category review.
+
+  Example 1: User asks "audit my contract for security issues." Dispatch this
+  agent with the .compact file (and any witness .ts). It returns severity-graded
+  findings plus Verification Requests for the Critical/High ones.
+
+  Example 2: The /compact-core:audit-compact command dispatches this agent with a
+  file list and shared compilation evidence, then runs the agent's Verification
+  Requests through midnight-verify on the main thread.
+
+  Example 3: User asks "is my ownPublicKey()-based owner check safe?" Dispatch
+  this agent; it identifies the witness trust-boundary bypass and emits a PoC
+  Verification Request for the orchestrator to confirm.
+skills: compact-core:compact-security, compact-core:compact-review, compact-core:compact-structure, compact-core:compact-ledger, compact-core:compact-privacy-disclosure, compact-core:compact-tokens, compact-core:compact-standard-library, compact-core:compact-witness-ts, compact-core:compact-language-ref, devs:security-core
+tools: Read, Grep, Glob, Bash, Skill, ToolSearch, WebFetch
+model: opus
+color: red
+---
+
+You are a Midnight Compact smart-contract **security specialist**. You think like an attacker: for every circuit you ask which inputs are caller- or witness-controlled, what the code trusts about them, and whether a malicious prover could supply a different value and still pass. You have deep expertise in the Compact type system, the ZK proof pipeline, the witness trust boundary, and Midnight's privacy model.
+
+## Hard constraint: you cannot dispatch subagents
+
+You do **not** have the `Agent` or `SlashCommand` tools, and you must not attempt to run `/midnight-verify` or spawn any agent. To get Critical/High findings mechanically confirmed, you emit a `## Verification Requests` block (format below) and hand it back to the caller. The caller — the `/compact-core:audit-compact` orchestrator on the main thread — runs the verification and folds the verdicts in.
+
+## Your Assignment
+
+You will receive:
+1. A **list of files** to review (`.compact` contracts, TypeScript witnesses, test files).
+2. Optionally, **shared compilation evidence** (`COMPILE_RESULT`) pre-computed by the orchestrator. Reference it; do not re-run compilation unless it is absent.
+
+## Review Process
+
+1. **Load the threat model.** Invoke the `compact-core:compact-security` skill. Read `references/threat-catalog.md` and `references/witness-trust-boundary.md`.
+2. **Read all files** in your assignment completely.
+3. **Walk the threat catalog.** For every row, search the code. Use the Reuse Map to pull granular criteria from the `compact-core:compact-review` references (`security-review.md`, `token-security-review.md`, `privacy-review.md`). When a checklist item names a `> **Tool:**` hint (e.g. an `octocode` search), use `ToolSearch` to reach the read-only research MCP tools.
+4. **Reason across dimensions.** Note compounding issues (e.g. an auth bypass that also leaks private state via an assert message is worse than either alone).
+5. **Reference compilation evidence.** If `COMPILE_RESULT` shows errors (including sealed-field writes, type mismatches), treat them as findings or supporting evidence.
+6. **Classify every finding** by severity: Critical, High, Medium, Low, Suggestion (criteria in the skill).
+7. **Emit Verification Requests** for every Critical and High finding (format below). Do not run them.
+
+## Output Format
+
+```
+## Security Review
+
+### Critical
+- **[Issue title]** (`file:line`)
+  - **Problem:** What is wrong
+  - **Impact:** Why it matters
+  - **Fix:** Concrete fix with a code example
+
+### High
+[same format]
+
+### Medium
+[same format]
+
+### Low
+[same format]
+
+### Suggestions
+[same format]
+
+### Positive Highlights
+- [Security practices done well]
+
+## Verification Requests
+
+### VR-1  →  finding: <id> (<title>)
+- type: poc | target | source
+- claim: "<one-sentence, mechanically-testable statement>"
+- poc-sketch: |
+    <minimal contract the orchestrator can compile/run to demonstrate the issue>
+- expected: "<what a confirming result looks like>"
+- suggested command: /midnight-verify:verify "<claim>"
+```
+
+Omit any severity section that has no findings. If there are no Critical/High findings, still emit `## Verification Requests` with a single line: `(none)`.
+
+## Review Principles
+
+- **Trust-boundaries first** — witness inputs and `ownPublicKey()` before anything else.
+- **Be constructive** — every finding includes a concrete, actionable fix.
+- **Be specific** — exact `file:line`.
+- **No false positives** — only report issues you are confident about; if uncertain, raise it as a Verification Request rather than asserting it.
+- **Stay in scope** — security only. Do not report performance, documentation, or style unless it has a security consequence.
+- **Hand off verification** — never claim a Critical/High finding is "confirmed"; that is the orchestrator's job via your Verification Requests.

--- a/plugins/compact-core/commands/audit-compact.md
+++ b/plugins/compact-core/commands/audit-compact.md
@@ -1,0 +1,105 @@
+---
+name: compact-core:audit-compact
+description: Deep adversarial security audit of Compact smart contract code. Runs a single security-reviewer specialist over the threat model, then confirms Critical/High findings via midnight-verify and synthesizes a consolidated security report. Security-only; for a full 10-category review use /compact-core:review-compact.
+allowed-tools: Bash, Agent, Read, Glob, Grep, SlashCommand, TaskCreate, TaskUpdate, TaskList, AskUserQuestion, ToolSearch
+argument-hint: "[path/to/contract.compact or directory]"
+---
+
+Run a focused security audit of Compact code: one deep security-reviewer pass, then main-thread mechanical confirmation of Critical/High findings. You (the main thread) are the orchestrator — the security-reviewer agent cannot dispatch subagents, so you run all `midnight-verify` confirmations yourself.
+
+## Step 1: Identify Files
+
+If `$ARGUMENTS` provides a path, use it. Otherwise find candidates:
+
+```bash
+find . -name "*.compact" -not -path "*/node_modules/*" -not -path "*/.compact/*"
+find . -name "*.ts" -not -path "*/node_modules/*" -not -path "*/.compact/*" | grep -iE "(witness|private)" || true
+find . \( -name "*.test.ts" -o -name "*.spec.ts" \) -not -path "*/node_modules/*" | head -20
+```
+
+Present the file list and confirm with the user. Record witness `.ts` paths for the verification step.
+
+## Step 2: Compile Once (shared evidence)
+
+Compile the primary `.compact` contract:
+
+```bash
+compact compile --skip-zk <contract-file> <out-dir>
+```
+
+Capture combined stdout/stderr as `COMPILE_RESULT`. If compilation fails, keep the diagnostics as evidence — do not abort; a compile failure is itself security-relevant context for the reviewer.
+
+## Step 3: Dispatch ONE security-reviewer agent
+
+Make a single `Agent` call:
+
+```
+subagent_type: "compact-core:security-reviewer"
+description: "Security audit of <contract>"
+prompt: "Perform a security audit of the following files: [INSERT FILE LIST].
+Invoke the compact-core:compact-security skill; walk references/threat-catalog.md and
+references/witness-trust-boundary.md; pull granular criteria from the compact-review
+security/token/privacy references via the Reuse Map. Report findings in the structured
+format (Critical → Suggestion + Positive Highlights). Emit a ## Verification Requests
+block for every Critical and High finding; if none, emit (none). Do NOT run midnight-verify
+— hand the requests back to me.
+
+Shared compilation evidence (reference when evaluating items):
+- Compilation result: [INSERT COMPILE_RESULT]"
+```
+
+Wait for the agent's report.
+
+## Step 4: Parse Verification Requests
+
+From the agent's report, extract the `## Verification Requests` block. Each `VR-n` has a `type` (poc | target | source), a `claim`, and a `suggested command`. If the block is `(none)`, skip to Step 6.
+
+## Step 5: Run midnight-verify (main thread)
+
+For the **target** contract, regardless of requests, run:
+
+```
+/midnight-verify:verify <contract.compact> [<witnesses.ts>]
+```
+
+Then for each Verification Request:
+- `type: poc` or `type: source` → run `/midnight-verify:verify "<claim>"`.
+- `type: target` → run `/midnight-verify:verify <contract.compact> [<witnesses.ts>]` (reuse the target result above if identical).
+
+Record each verdict as **Confirmed**, **Refuted**, or **Inconclusive** with the evidence summary. If `midnight-verify` is unavailable (e.g. devnet down for an execution-only claim), mark the verdict basis explicitly (e.g. "source-only") and continue — never block the report.
+
+## Step 6: Synthesize the consolidated report
+
+Annotate each Critical/High finding with its verdict. **Downgrade Refuted findings but record that verification refuted them** (never silently drop). Keep Inconclusive findings with a note. Order: witness-trust/access-control and privacy first, then by severity. Produce:
+
+```
+# Compact Security Audit Report
+
+## Summary
+| Severity | Count | Confirmed | Refuted | Inconclusive |
+|----------|-------|-----------|---------|--------------|
+| Critical | N | … | … | … |
+| High | N | … | … | … |
+| Medium | N | — | — | — |
+| Low | N | — | — | — |
+| Suggestions | N | — | — | — |
+
+**Files reviewed:** […]
+
+## 1. Witness Trust Boundary & Access Control
+[findings, each Critical/High annotated: **Verification:** Confirmed | Refuted | Inconclusive — evidence]
+
+## 2. Cryptographic Correctness
+## 3. Information Leakage & Disclosure
+## 4. Token & Economic Security
+## … (only sections with findings)
+
+## Mechanical Verification
+- Target: <`/midnight-verify:verify` result>
+- VR-1 … VR-n: <verdict + evidence>
+
+## Positive Highlights
+[…]
+```
+
+Present the report to the user.

--- a/plugins/compact-core/skills/compact-review/references/security-review.md
+++ b/plugins/compact-core/skills/compact-review/references/security-review.md
@@ -87,6 +87,22 @@ Check every exported circuit for proper authorization and state guards.
   }
   ```
 
+- [ ] **`ownPublicKey()` used for authorization or identity gating.** `ownPublicKey()` returns the prover-supplied Zswap coin public key — it is NOT bound to the transaction signer, so any `assert`/state-gate built on it is bypassable. Its only safe use is routing shielded coins to the caller via `left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey())`. For authorization, derive caller identity inside the circuit from a witness-held secret via domain-separated `persistentHash`, and pin the authority at deploy. See `compact-core:compact-security` → `references/witness-trust-boundary.md`.
+
+  ```compact
+  // BAD — prover supplies any coinPublicKey; auth is bypassable
+  export circuit adminOnly(): [] {
+    assert(ownPublicKey() == admin, "Not admin");
+    // ...
+  }
+
+  // GOOD — re-derive from the caller's secret; compare to pinned authority
+  export circuit adminOnly(): [] {
+    assert(contractAdmin == deriveAdminPublicKey(getUserSecret()), "Not admin");
+    // ...
+  }
+  ```
+
 - [ ] **Missing state machine guards.** For contracts implementing a multi-phase protocol (e.g., commit-reveal, propose-vote-execute, lock-unlock), each phase transition must assert the current state before proceeding. Calling a later phase before an earlier one has completed can lead to protocol violations.
 
   ```compact
@@ -401,6 +417,7 @@ Quick reference of common security anti-patterns in Compact contracts.
 
 | Anti-Pattern | Why It's Wrong | Correct Approach |
 |---|---|---|
+| `ownPublicKey()` used for an authorization/identity check | Returns the prover-supplied coin public key, not the tx signer; a caller can supply the stored authority value and pass the gate | Derive identity from a witness secret via domain-separated `persistentHash`; pin the authority at deploy and `assert(pinned == derive(getUserSecret()))` — see `compact-core:compact-security` |
 | `export circuit` with no `assert(caller == owner)` on state change | Anyone can invoke the circuit and modify contract state, leading to unauthorized minting, draining, or resetting | Derive caller identity via `publicKey(secretKey())` and assert against stored authority before any state modification |
 | `transientHash` used for nullifier | Non-deterministic; same input produces different outputs each call; double-spend detection fails completely | `persistentHash` with domain separation and secret key inclusion; deterministic output enables reliable duplicate detection |
 | Hash/commit call without domain string | Identical inputs from different contracts or different purposes produce the same output; enables cross-protocol replay attacks | Include a unique domain prefix in every hash: `[pad(32, "appname:purpose:"), ...]` |

--- a/plugins/compact-core/skills/compact-security/SKILL.md
+++ b/plugins/compact-core/skills/compact-security/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: compact-core:compact-security
+description: This skill should be used when performing a security review or audit of Compact smart contract code, or when reasoning about Compact's security threat model. Covers the three execution contexts (public ledger, ZK circuit, local witness), the witness trust boundary and the ownPublicKey()-for-authorization anti-pattern, sealed-field misuse, disclosure placement, information leakage via assert messages, cryptographic-primitive selection (transientHash/persistentHash/transientCommit/persistentCommit), domain separation, randomness reuse, and hash-derived authentication patterns. Routes to the compact-review checklists for granular line-items and defines the Verification Requests protocol used by the security-reviewer agent.
+version: 0.1.0
+---
+
+# Compact Security Threat Model
+
+This skill provides the **threat model and adversarial methodology** for reviewing Compact smart contracts. It is the "how to think like an attacker" layer. For granular, item-by-item checklists, it routes to the existing `compact-core:compact-review` references (see the Reuse Map) — those are the single source of truth for line-items, and are not duplicated here.
+
+## Security Model
+
+Compact and the Midnight runtime give you five structural guarantees. Each is a backstop, not a substitute for review:
+
+- **Privacy by default** — witness (private) values cannot reach public ledger state unless explicitly `disclose()`d. The compiler enforces this.
+- **Compile-time validation** — type errors, illegal disclosures, and sealed-field writes are rejected at compile time.
+- **Zero-knowledge verification** — on-chain, only the proof and disclosed public inputs are checked. The verifier never sees witness values.
+- **Bounded execution** — circuits are finite; loops are fixed-iteration and fully unrolled.
+- **Immutable deployment** — deployed contract logic cannot be patched. A shipped vulnerability is permanent.
+
+The gap these do **not** cover is the subject of this skill: **what the developer trusts that they should not.**
+
+## Three Execution Contexts
+
+Every Compact value lives in one of three contexts. The reviewer's first job is to know which.
+
+| Context | Where it runs | Verified on-chain? | Visible on-chain? | Trust |
+|---------|---------------|--------------------|-------------------|-------|
+| **Public ledger** | The chain | Yes | Yes (to everyone) | Trusted, but public — never put secrets here |
+| **ZK circuit** | Prover's machine, proven | Yes (via the proof) | Only disclosed values | Trusted **if** every input is constrained inside the proof |
+| **Local witness** | Prover's machine, off-circuit | **No** | No | **Untrusted** — a witness can return anything |
+
+The boundary between *ZK circuit* and *local witness* is where most authorization bugs live.
+
+## Trust Boundaries & Adversarial Methodology
+
+Review trust-boundaries first, in this order:
+
+1. **Witness inputs are attacker-controlled.** Every `witness foo(): T` returns a value the prover chose. The circuit must constrain it (hash it, compare it against pinned state, verify a signature) before any decision depends on it. A witness value used directly in an `assert` for authorization is bypassable. See `references/witness-trust-boundary.md`.
+2. **Exported-circuit parameters are attacker-controlled.** Anyone can call any `export circuit` with any arguments. Validate every parameter.
+3. **`ownPublicKey()` is a witness, not the signer.** It returns the prover-supplied Zswap coin public key — not cryptographically bound to the transaction signer. **Never** use it for authorization/identity gating. Its only safe use is routing shielded coins to the caller. See `references/witness-trust-boundary.md`.
+4. **Disclosure is a one-way leak.** Anything `disclose()`d becomes public forever. Disclose as late and as narrowly as possible.
+5. **Assert messages are public.** A failed transaction's message is observable. Never embed private state in it.
+
+For each circuit, ask: *Which inputs are witness-supplied? What does the code trust about them? Could a malicious prover supply a different value and pass the checks?*
+
+## Reuse Map (threat → detailed checklist)
+
+Apply the threat model, then pull granular checklist items from these existing references. Read `references/threat-catalog.md` for the full index.
+
+| Threat area | Detailed checklist (single source of truth) |
+|-------------|---------------------------------------------|
+| Access control, crypto primitives, domain separation, nullifiers, Merkle paths, error leakage, input validation | `compact-core:compact-review` → `references/security-review.md` |
+| Double-spend, overflow/underflow, mint/burn/transfer authz, shielded/unshielded token ops | `compact-core:compact-review` → `references/token-security-review.md` |
+| `disclose()` placement, witness leaks, Set-vs-MerkleTree, salt reuse, conditional disclosure | `compact-core:compact-review` → `references/privacy-review.md` |
+| Witness trust boundary, `ownPublicKey()`-for-auth, secure witness-secret pattern | this skill → `references/witness-trust-boundary.md` |
+
+## Verification Requests Protocol
+
+A security review's Critical/High findings should be **mechanically confirmed**. The `security-reviewer` agent **cannot dispatch subagents**, so it does not run `midnight-verify` itself. Instead it appends a `## Verification Requests` block to its report — one entry per Critical/High finding — for the orchestrator (the `/compact-core:audit-compact` command, running on the main thread) to execute.
+
+Emit each request in this shape:
+
+```
+## Verification Requests
+
+### VR-<n>  →  finding: <finding id> (<short title>)
+- type: poc | target | source
+- claim: "<one-sentence, mechanically-testable statement>"
+- poc-sketch: |
+    <for type: poc — a minimal contract the orchestrator can compile/run to
+     demonstrate the issue: what it declares, what it asserts, what input
+     triggers the bypass, and what the secure variant does instead>
+- expected: "<what a confirming result looks like — e.g. insecure variant ACCEPTS
+              the forged input; secure variant REJECTS>"
+- suggested command: /midnight-verify:verify "<claim>"   # or: /midnight-verify:verify <file.compact> [<witnesses.ts>]
+```
+
+Rules:
+- `type: target` — confirm against the contract under review directly.
+- `type: poc` — a minimal claim/contract the orchestrator feeds to `/midnight-verify:verify "<claim>"`.
+- `type: source` — a claim best confirmed by source inspection (e.g., a stdlib signature or runtime behavior).
+- If there are **no** Critical/High findings, emit `## Verification Requests` with a single line: `(none)`.
+
+## Severity Classification
+
+| Level | Criteria |
+|-------|----------|
+| **Critical** | Will cause loss of funds, data breach, or contract exploitation |
+| **High** | Security vulnerability or privacy leak exploitable under certain conditions |
+| **Medium** | Correctness issue or significant security-relevant footgun |
+| **Low** | Minor best-practice deviation with security relevance |
+| **Suggestion** | Hardening opportunity, not a problem |

--- a/plugins/compact-core/skills/compact-security/references/threat-catalog.md
+++ b/plugins/compact-core/skills/compact-security/references/threat-catalog.md
@@ -1,0 +1,34 @@
+# Compact Security Threat Catalog
+
+The agent's working index. Walk every row. For each threat, search the code; if present, raise a finding at the indicated severity band and (for Critical/High) emit a Verification Request. The **Detailed checklist** column is the single source of truth for the item-by-item criteria — read it there; it is not duplicated here.
+
+Reference shorthand:
+- `SR` = `compact-core:compact-review` → `references/security-review.md`
+- `TR` = `compact-core:compact-review` → `references/token-security-review.md`
+- `PR` = `compact-core:compact-review` → `references/privacy-review.md`
+- `WTB` = this skill → `references/witness-trust-boundary.md`
+
+| # | Threat | Severity band | Trust boundary | Detailed checklist | PoC-confirmable? |
+|---|--------|---------------|----------------|--------------------|------------------|
+| 1 | `ownPublicKey()` used for authorization / identity gating | Critical | witness → auth | WTB; SR (Access Control) | Yes — forged `coinPublicKey` passes the gate |
+| 2 | Witness value trusted in an `assert`/state-gate without re-derivation | Critical/High | witness → auth | WTB | Yes |
+| 3 | Exported state-modifying circuit with no authorization check | Critical | caller input | SR (Access Control) | Yes |
+| 4 | Mint/burn/transfer without authority or ownership check | Critical | caller input | TR (Authorization) | Yes |
+| 5 | Authority captured from a runtime value instead of pinned at deploy | High | caller input | WTB; SR (Access Control) | Yes |
+| 6 | `transientHash` used for a nullifier (non-deterministic) | High | crypto | SR (Crypto Correctness); TR (Double-Spend) | Yes |
+| 7 | Hash/commit without domain separation | High | crypto | SR (Crypto Correctness) | Sometimes |
+| 8 | Nullifier without secret key (pre-computable) | High | crypto | SR; TR | Yes |
+| 9 | Commitment without nonce/salt (brute-forceable) | High | crypto | SR (Crypto Correctness) | Sometimes |
+| 10 | Randomness/salt reused across commitments (linkability) | High | privacy | PR; SR | Sometimes |
+| 11 | Merkle path not checked against on-chain root (`checkRoot`) | Critical | crypto | SR (Merkle Path) | Yes |
+| 12 | Double-spend: nullifier not checked before spend | Critical | token | TR (Double-Spend) | Yes |
+| 13 | Subtraction underflow / missing balance check | High | arithmetic | TR (Overflow/Underflow); SR (Error Handling) | Yes |
+| 14 | Missing `receiveShielded` in receiving contract (token loss) | Critical | token | TR (Shielded) | Yes |
+| 15 | `unshieldedBalance()` in conditional logic (construction-time lock) | Medium | token | TR (Unshielded) | Sometimes |
+| 16 | `disclose()` placed too early / too broadly | High | privacy | PR; SR | No (review judgment) |
+| 17 | Assert message leaks private state | High | privacy | SR (Error Handling) | No (review judgment) |
+| 18 | Sealed field write attempted outside constructor | Medium | compile | SR; this skill (Security Model) | Yes (compile error) |
+| 19 | Exported-circuit parameters unvalidated | High | caller input | SR (Input Validation) | Sometimes |
+| 20 | State-machine phase guard missing | High | protocol | SR (Access Control) | Yes |
+
+Severity bands are defaults — adjust to the contract's actual impact (e.g. an unauthenticated mint on a live token is Critical; on an internal test scaffold, lower).

--- a/plugins/compact-core/skills/compact-security/references/threat-catalog.md
+++ b/plugins/compact-core/skills/compact-security/references/threat-catalog.md
@@ -15,7 +15,7 @@ Reference shorthand:
 | 3 | Exported state-modifying circuit with no authorization check | Critical | caller input | SR (Access Control) | Yes |
 | 4 | Mint/burn/transfer without authority or ownership check | Critical | caller input | TR (Authorization) | Yes |
 | 5 | Authority captured from a runtime value instead of pinned at deploy | High | caller input | WTB; SR (Access Control) | Yes |
-| 6 | `transientHash` used for a nullifier (non-deterministic) | High | crypto | SR (Crypto Correctness); TR (Double-Spend) | Yes |
+| 6 | `transientHash` used for a nullifier (not reproducible across executions/upgrades) | High | crypto | SR (Crypto Correctness); TR (Double-Spend) | Yes |
 | 7 | Hash/commit without domain separation | High | crypto | SR (Crypto Correctness) | Sometimes |
 | 8 | Nullifier without secret key (pre-computable) | High | crypto | SR; TR | Yes |
 | 9 | Commitment without nonce/salt (brute-forceable) | High | crypto | SR (Crypto Correctness) | Sometimes |

--- a/plugins/compact-core/skills/compact-security/references/witness-trust-boundary.md
+++ b/plugins/compact-core/skills/compact-security/references/witness-trust-boundary.md
@@ -35,7 +35,7 @@ assert(_ownerCommitment == _computeOwnerCommitment(id, _counter),
 
 ## The secure witness-secret pattern
 
-Identity is derived **inside the circuit** from a single witness-held secret via domain-separated `persistentHash`, and the authority is **pinned at deploy**. Verbatim from the proven reference `applications/zkloan/zkloan-credit-scorer.compact` (compiles + runs on Compact `0.31.0`):
+Identity is derived **inside the circuit** from a single witness-held secret via domain-separated `persistentHash`, and the authority is **pinned at deploy**. Verbatim from the proven reference `applications/zkloan/zkloan-credit-scorer.compact` (compiles with compiler `0.31.0`; pragma `language_version >= 0.22 && <= 0.23`):
 
 ```compact
 export struct UserSecretKey { bytes: Bytes<32>; }

--- a/plugins/compact-core/skills/compact-security/references/witness-trust-boundary.md
+++ b/plugins/compact-core/skills/compact-security/references/witness-trust-boundary.md
@@ -1,0 +1,115 @@
+# The Witness Trust Boundary
+
+Witness functions run **on the prover's machine, outside the zero-knowledge circuit**, and are **not cryptographically verified**. A witness returns whatever the prover wants. Everything a contract trusts about a witness value must be *re-established inside the circuit* — by hashing it, comparing it against pinned on-chain state, or verifying a signature over it.
+
+## `ownPublicKey()` is a witness, not the caller
+
+`ownPublicKey()` returns the prover-supplied **Zswap coin public key** (`coinPublicKey`, passed into the circuit context by `@midnight-ntwrk/compact-runtime`). It is **not** bound to the wallet that signs the transaction. A caller can supply any 32-byte value. Therefore:
+
+> **Any authorization or identity check built on `ownPublicKey()` is bypassable.** An attacker reads the public target value (e.g. the stored admin/owner) off-chain and supplies it as their own `coinPublicKey`.
+
+### The ONLY safe use of `ownPublicKey()`
+
+Routing shielded tokens **to** the caller, where lying only misroutes the prover's *own* coins:
+
+```compact
+// SAFE — recipient of a mint/send; a dishonest prover only hurts themselves
+left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey())
+```
+
+### Insecure: `ownPublicKey()` for authorization (DO NOT COPY)
+
+Adapted from `modules/access/ZOwnablePK.compact` (`assertOnlyOwner`), which carries a SECURITY WARNING banner:
+
+```compact
+// ❌ INSECURE — caller identity built from ownPublicKey() and used for an owner gate.
+//    A prover can supply the owner's coinPublicKey and pass this check.
+const callerAsEither =
+  Either<ZswapCoinPublicKey, ContractAddress> { is_left: true,
+                                                left: ownPublicKey(),
+                                                right: ContractAddress { bytes: pad(32, "") } };
+const id = _computeOwnerId(callerAsEither, nonce);
+assert(_ownerCommitment == _computeOwnerCommitment(id, _counter),
+       "caller is not the owner");   // bypassable
+```
+
+## The secure witness-secret pattern
+
+Identity is derived **inside the circuit** from a single witness-held secret via domain-separated `persistentHash`, and the authority is **pinned at deploy**. Verbatim from the proven reference `applications/zkloan/zkloan-credit-scorer.compact` (compiles + runs on Compact `0.31.0`):
+
+```compact
+export struct UserSecretKey { bytes: Bytes<32>; }
+export struct AdminPublicKey { bytes: Bytes<32>; }
+
+// One secret per browser/CLI instance, held in private state.
+witness getUserSecret(): UserSecretKey;
+
+// Domain-separated derivation. Deterministic => reproducible across transactions.
+export pure circuit deriveAdminPublicKey(sk: UserSecretKey): AdminPublicKey {
+  return AdminPublicKey {
+    bytes: persistentHash<Vector<2, Bytes<32>>>([
+      pad(32, "zkloan:admin:pk:v1"),
+      sk.bytes
+    ])
+  };
+}
+
+// Pin the deployer's derived admin identity at construction.
+constructor() {
+  contractAdmin = disclose(deriveAdminPublicKey(getUserSecret()));
+}
+export ledger contractAdmin: AdminPublicKey;
+
+// Authorization: re-derive from the caller's secret and compare to pinned state.
+export circuit registerProvider(providerId: Uint<16>, providerPk: JubjubPoint): [] {
+  assert(contractAdmin == deriveAdminPublicKey(getUserSecret()),
+         "Only admin can register providers");
+  providers.insert(disclose(providerId), disclose(providerPk));
+}
+```
+
+Why this is sound: only the holder of the secret whose `deriveAdminPublicKey(secret)` was pinned into `contractAdmin` can reproduce the equality inside the proof. A forged secret produces a different hash and fails the assertion. The secret never leaves the prover.
+
+The TypeScript witness simply returns the stored secret (from `applications/zkloan/witnesses.ts`):
+
+```typescript
+getUserSecret: ({ privateState }: WitnessContext<Ledger, ZKLoanCreditScorerPrivateState>):
+  [ZKLoanCreditScorerPrivateState, { bytes: Uint8Array }] => {
+    if (!privateState.userSecretKey || privateState.userSecretKey.length !== 32) {
+      throw new Error("getUserSecret: userSecretKey is missing or wrong length");
+    }
+    return [privateState, { bytes: privateState.userSecretKey }];
+  },
+```
+
+### Per-user vs admin identity
+
+Add a binding parameter (e.g. a PIN) for per-user identity so users get distinct, rotatable keys; keep admin un-PIN'd so the role is stable:
+
+```compact
+export pure circuit deriveUserPublicKey(sk: UserSecretKey, pin: Uint<16>): UserPublicKey {
+  const pinBytes = persistentHash<Uint<16>>(pin);
+  return UserPublicKey {
+    bytes: persistentHash<Vector<3, Bytes<32>>>([
+      pad(32, "zkloan:user:pk:v1"), pinBytes, sk.bytes
+    ])
+  };
+}
+```
+
+## The module pattern (witness lives in the top-level contract)
+
+Reusable modules must not embed the witness or export identity-parameterized circuits directly — otherwise a caller could pass a forged identity. Instead:
+
+- The `witness getUserSecret()` lives in the **top-level contract**.
+- **Module** circuits take the already-derived caller identity as a parameter (e.g. `circuit onlyAdmin(caller: AdminPublicKey)`), and never call the witness or `ownPublicKey()` themselves.
+- Only **top-level wrappers** that compute `deriveUserPublicKey(getUserSecret(), …)` / `deriveAdminPublicKey(getUserSecret())` are `export`ed. The identity-parameterized module circuits are **not** exported.
+
+This keeps the trust boundary (witness → derived identity) inside code the deployer controls.
+
+## Detection checklist (what a reviewer greps for)
+
+- `ownPublicKey()` appearing **anywhere other than** a `left<ZswapCoinPublicKey, ContractAddress>(...)` send/mint recipient → likely a Critical auth bypass. Confirm via a Verification Request.
+- A `witness` value flowing into an `assert(...)` (or a state-gating `if`) **without** first being hashed/compared against pinned ledger state.
+- An identity-parameterized module circuit (`caller: …PublicKey`) that is `export`ed (lets callers forge identity).
+- Authority stored from a caller-supplied value at runtime instead of pinned at `constructor`/initialize time.


### PR DESCRIPTION
## Summary

Adds a standalone, directly-invocable Compact **security-review specialist** to `compact-core`, complementing (not replacing) the broad 10-category `review-compact` pipeline.

- **New skill `compact-core:compact-security`** — threat model (three execution contexts, the witness trust boundary, the **`ownPublicKey()`-for-authorization** gap-fill + secure witness-secret pattern, the Verification Requests protocol). Thin index (`threat-catalog.md`) routes to the existing `compact-review` checklists rather than duplicating them.
- **New agent `security-reviewer`** (`model: opus`) — single deep adversarial pass. Tools are intentionally restricted (`Read, Grep, Glob, Bash, Skill, ToolSearch, WebFetch` — **no `Agent`/`SlashCommand`/`Write`/`Edit`**) so it structurally cannot self-dispatch. It emits a `## Verification Requests` block for Critical/High findings and hands confirmation back to the orchestrator.
- **New command `/compact-core:audit-compact`** — main-thread orchestrator: compile once → dispatch one `security-reviewer` → run `/midnight-verify:verify` on the agent's Verification Requests → annotate Confirmed/Refuted/Inconclusive → synthesize the report.
- **Patch** to `compact-review/references/security-review.md` — adds the `ownPublicKey()`-for-auth checklist item + anti-pattern row.
- **Version bumps** — `compact-core` `0.7.1 → 0.8.0`; marketplace `0.42.1 → 0.43.0`.

The `ownPublicKey()` gap-fill is anchored to proven in-repo code: secure = the zkloan template (`getUserSecret()` + `deriveAdminPublicKey` + pinned `contractAdmin`); insecure = `modules/access/ZOwnablePK.compact`'s `assertOnlyOwner()`.

## Test Plan

- [x] `plugin-validator` PASS on the new agent + skill (frontmatter, restricted `tools:`, referenced skills exist)
- [x] Both manifests valid JSON; secure-pattern PoC compiles on compiler `0.31.0`
- [x] Behavioral dry-runs (general-purpose agent primed with the new skill): banner-free insecure `ownPublicKey()`-auth contract → flagged **Critical** + Verification Requests; secure zkloan contract → **no** false-positive auth finding
- [x] Final holistic review APPROVED (0 Critical/Important)
- [ ] **Post-reload E2E smoke test:** in a fresh session (so the new agent/command register), run `/compact-core:audit-compact` on a real contract end-to-end and confirm a finding is marked **Confirmed**

## Notes

- ⚠️ **Marketplace version collision:** this bumps marketplace to `0.43.0`, which the open #189/#190 branches also take — reconcile at merge (pick the next free minor if those land first).

Generated with [Claude Code](https://claude.com/claude-code)