### PR TITLE
fix: move plugin artifacts out of users' working dirs (+ UTC compile-check fix)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-expert",
   "metadata": {
-    "version": "0.45.0",
+    "version": "0.46.0",
     "description": "AI agent plugins for the Midnight data-protection blockchain. Covers Compact smart contract development, privacy-preserving patterns, DApp frontend design, and Midnight toolchain management."
   },
   "owner": {

--- a/plugins/compact-cli-dev/.claude-plugin/plugin.json
+++ b/plugins/compact-cli-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compact-cli-dev",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Scaffold and develop Oclif CLIs for Midnight Compact smart contracts. Includes a complete CLI template with wallet management, contract deployment, devnet control, and an AI agent for ongoing development.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/compact-cli-dev/agents/dev.md
+++ b/plugins/compact-cli-dev/agents/dev.md
@@ -43,7 +43,7 @@ Do not proceed until both skills are loaded. The core skill's reference docs are
 Check whether a CLI package already exists in the project:
 
 1. Search for `oclif` config in any `package.json` within the project — check `./cli/package.json`, `./*/package.json`, and the root `package.json`.
-2. Look for a `.midnight-expert/` state directory (created by the CLI at runtime).
+2. Look for a `.dapp-state/` state directory (created by the CLI at runtime).
 3. Look for the `src/base-command.ts` file pattern that indicates the template was used.
 
 If **any** of these indicators are present, the CLI exists — go to Step 3.

--- a/plugins/compact-cli-dev/skills/core/SKILL.md
+++ b/plugins/compact-cli-dev/skills/core/SKILL.md
@@ -109,8 +109,8 @@ Place the file under `src/commands/` — the directory structure determines the 
 
 | File | Permissions | Contents |
 |------|------------|----------|
-| `.midnight-expert/wallets.json` | `0o600` | Wallet seeds, addresses, creation dates. Contains secrets — never commit. |
-| `.midnight-expert/deployed-contracts.json` | `0o644` | Contract addresses and deployment timestamps. Safe to share. |
+| `.dapp-state/wallets.json` | `0o600` | Wallet seeds, addresses, creation dates. Contains secrets — never commit. |
+| `.dapp-state/deployed-contracts.json` | `0o644` | Contract addresses and deployment timestamps. Safe to share. |
 
 Both files are stored relative to the project working directory.
 

--- a/plugins/compact-cli-dev/skills/core/references/contract-lifecycle.md
+++ b/plugins/compact-cli-dev/skills/core/references/contract-lifecycle.md
@@ -164,7 +164,7 @@ The `Contract.ledger(state.data)` call deserializes the raw on-chain data into t
 
 ## Address Persistence
 
-Deployed contract addresses are saved to `.midnight-expert/deployed-contracts.json`:
+Deployed contract addresses are saved to `.dapp-state/deployed-contracts.json`:
 
 ```json
 {

--- a/plugins/compact-cli-dev/skills/core/references/oclif-patterns.md
+++ b/plugins/compact-cli-dev/skills/core/references/oclif-patterns.md
@@ -48,7 +48,7 @@ All commands in this template extend `BaseCommand` instead of the raw Oclif `Com
 | `--json` flag | Automatically parsed; sets `this.jsonEnabled` |
 | JSON-mode spinners | Spinners are silenced when `--json` is active |
 | Network init | Calls `initializeNetwork()` to set the network ID at startup |
-| Welcome banner | Shown once per project (tracked via `.midnight-expert/.initialized`) |
+| Welcome banner | Shown once per project (tracked via `.dapp-state/.initialized`) |
 | Error classification | `catch()` is overridden to classify errors and format output |
 | `outputResult()` | Outputs structured JSON when `--json` is enabled |
 

--- a/plugins/compact-cli-dev/skills/core/references/wallet-management.md
+++ b/plugins/compact-cli-dev/skills/core/references/wallet-management.md
@@ -135,7 +135,7 @@ Always call `ctx.facade.stop()` in a `finally` block to clean up WebSocket conne
 
 ## Persistence
 
-Wallets are stored in `.midnight-expert/wallets.json` relative to the project working directory.
+Wallets are stored in `.dapp-state/wallets.json` relative to the project working directory.
 
 ```json
 {

--- a/plugins/compact-cli-dev/skills/core/templates/cli/.gitignore
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
 dist/
 coverage/
-.midnight-expert/
+.dapp-state/
 *.tsbuildinfo

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/constants.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/constants.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 
 // File system
-export const STATE_DIR = ".midnight-expert";
+export const STATE_DIR = ".dapp-state";
 export const WALLETS_FILE = "wallets.json";
 export const CONTRACTS_FILE = "deployed-contracts.json";
 export const INIT_MARKER = ".initialized";

--- a/plugins/compact-core/.claude-plugin/plugin.json
+++ b/plugins/compact-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compact-core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Core knowledge for writing Midnight Compact smart contracts \u2014 contract structure, data types, ledger declarations, circuits, witnesses, and common patterns.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/compact-core/README.md
+++ b/plugins/compact-core/README.md
@@ -266,7 +266,7 @@ Not intended for direct user invocation. Automatically dispatched by the review-
 Two scripts run at session start:
 
 - **CLI version check** (`scripts/SessionStart.sh`) -- checks Compact CLI availability, compiler version, and language version. Injects context about the current compiler state and reminds the agent about Midnight ecosystem practices (public npm packages, version checking commands). Falls back to static context if the compact CLI is not installed.
-- **`.compact` baseline snapshot** (`scripts/hooks/SessionStart-compact-check.sh`) -- snapshots SHA-256 hashes of every `*.compact` file under the project root into `.midnight-expert/settings.local.json` so the Stop hook can diff against them. If the previous SessionEnd persisted an unchecked-contracts list, prepends a warning naming those contracts to the additional context and clears the list in the same write.
+- **`.compact` baseline snapshot** (`scripts/hooks/SessionStart-compact-check.sh`) -- snapshots SHA-256 hashes of every `*.compact` file under the project root into `~/.midnight-expert/settings.local.json` so the Stop hook can diff against them. If the previous SessionEnd persisted an unchecked-contracts list, prepends a warning naming those contracts to the additional context and clears the list in the same write.
 
 ### SessionEnd
 
@@ -279,6 +279,6 @@ Diffs every `*.compact` file in the project against the SessionStart snapshot. F
 The check runs on **every** Stop event. Whether the agent is BLOCKED on the result is gated by a 5-trigger + 2-hour cooldown plus the `stop_hook_active` reattempt flag:
 
 - **Block path** (cooldown clear, not a reattempt): emits `{decision: "block", reason: ...}` on stderr and exits 2.
-- **Defer path** (cooldown active OR Stop reattempt): does not block, but writes the unchecked file list to `on_next_user_prompt[type == "compact-not-compiled"]` in `.midnight-expert/settings.local.json`. The `midnight-expert` plugin's `UserPromptSubmit` hook surfaces and drains that queue on the next user turn, so the warning still reaches the conversation without preventing the agent from stopping.
+- **Defer path** (cooldown active OR Stop reattempt): does not block, but writes the unchecked file list to `on_next_user_prompt[type == "compact-not-compiled"]` in `~/.midnight-expert/settings.local.json`. The `midnight-expert` plugin's `UserPromptSubmit` hook surfaces and drains that queue on the next user turn, so the warning still reaches the conversation without preventing the agent from stopping.
 
 When the check is clean, any stale `compact-not-compiled` queue entry left from a prior turn is removed.

--- a/plugins/compact-core/scripts/hooks/SessionEnd.sh
+++ b/plugins/compact-core/scripts/hooks/SessionEnd.sh
@@ -24,7 +24,7 @@ if [ -z "$PROJECT_ROOT" ]; then
   PROJECT_ROOT="$(pwd)"
 fi
 
-SETTINGS_DIR="$PROJECT_ROOT/.midnight-expert"
+SETTINGS_DIR="$HOME/.midnight-expert"
 SETTINGS_FILE="$SETTINGS_DIR/settings.local.json"
 
 if [ ! -f "$SETTINGS_FILE" ]; then

--- a/plugins/compact-core/scripts/hooks/SessionStart-compact-check.sh
+++ b/plugins/compact-core/scripts/hooks/SessionStart-compact-check.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # SessionStart hook: snapshot SHA-256 of every *.compact file under the
-# project root into .midnight-expert/settings.local.json so the Stop hook
+# project root into ~/.midnight-expert/settings.local.json so the Stop hook
 # can diff against it. Surface (and clear) any unchecked-contracts list
 # left by the previous SessionEnd as additionalContext.
 
@@ -20,7 +20,7 @@ if [ -z "$PROJECT_ROOT" ]; then
   PROJECT_ROOT="$(pwd)"
 fi
 
-SETTINGS_DIR="$PROJECT_ROOT/.midnight-expert"
+SETTINGS_DIR="$HOME/.midnight-expert"
 SETTINGS_FILE="$SETTINGS_DIR/settings.local.json"
 mkdir -p "$SETTINGS_DIR"
 

--- a/plugins/compact-core/scripts/hooks/Stop.sh
+++ b/plugins/compact-core/scripts/hooks/Stop.sh
@@ -90,8 +90,12 @@ if [ "$TRIGGERS" -lt 5 ]; then
   SHOULD_BLOCK=false
 fi
 if [ "$LAST_TIMESTAMP" != "null" ] && [ -n "$LAST_TIMESTAMP" ]; then
-  LAST_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${LAST_TIMESTAMP%%.*}" "+%s" 2>/dev/null \
-            || date -d "${LAST_TIMESTAMP}" "+%s" 2>/dev/null \
+  # last_block_timestamp is written as UTC (date -u ...Z, see below). Parse
+  # it back as UTC on both GNU (re-append Z) and BSD/macOS (-u forces UTC) so
+  # the cooldown DIFF is never skewed by the host's local timezone offset.
+  LAST_TS="${LAST_TIMESTAMP%Z}"; LAST_TS="${LAST_TS%%.*}"
+  LAST_EPOCH=$(date -u -d "${LAST_TS}Z" "+%s" 2>/dev/null \
+            || date -juf "%Y-%m-%dT%H:%M:%S" "$LAST_TS" "+%s" 2>/dev/null \
             || echo 0)
   NOW_EPOCH=$(date "+%s")
   DIFF=$(( NOW_EPOCH - LAST_EPOCH ))

--- a/plugins/compact-core/scripts/hooks/Stop.sh
+++ b/plugins/compact-core/scripts/hooks/Stop.sh
@@ -37,7 +37,7 @@ if [ -z "$PROJECT_ROOT" ]; then
 fi
 
 # --- Settings file ---
-SETTINGS_DIR="$PROJECT_ROOT/.midnight-expert"
+SETTINGS_DIR="$HOME/.midnight-expert"
 SETTINGS_FILE="$SETTINGS_DIR/settings.local.json"
 
 if [ ! -f "$SETTINGS_FILE" ]; then

--- a/plugins/compact-core/scripts/hooks/_compact-check.sh
+++ b/plugins/compact-core/scripts/hooks/_compact-check.sh
@@ -66,8 +66,12 @@ compact_unchecked_files() {
     if [ -n "$latest_compile_ts" ]; then
       ts="${latest_compile_ts%Z}"
       ts="${ts%%.*}"
-      compile_epoch=$(date -d "$ts" "+%s" 2>/dev/null \
-                   || date -j -f "%Y-%m-%dT%H:%M:%S" "$ts" "+%s" 2>/dev/null \
+      # $ts is a UTC wall-clock time with the trailing 'Z' and any
+      # fractional seconds stripped. Parse it back as UTC on both GNU
+      # (re-append Z) and BSD/macOS (-u forces UTC interpretation); never
+      # let the timestamp be reinterpreted in the host's local timezone.
+      compile_epoch=$(date -u -d "${ts}Z" "+%s" 2>/dev/null \
+                   || date -juf "%Y-%m-%dT%H:%M:%S" "$ts" "+%s" 2>/dev/null \
                    || echo 0)
       if [ "$compile_epoch" -ge "$file_mtime" ]; then
         continue

--- a/plugins/compact-core/scripts/hooks/tests/_lib.sh
+++ b/plugins/compact-core/scripts/hooks/tests/_lib.sh
@@ -123,9 +123,18 @@ run_hook_at() {
   local out_var="$3" err_var="$4" rc_var="$5"
   local out err rc=0
 
+  # The hooks now write their settings file to $HOME/.midnight-expert rather
+  # than $PROJECT_ROOT/.midnight-expert. To keep the tests hermetic (and the
+  # existing assertions, which look under the temp project root, valid), pin
+  # both HOME and CLAUDE_PROJECT_DIR to the payload's .cwd (the temp project
+  # root). The hook's `find "$PROJECT_ROOT"` then scans the temp root, and the
+  # settings file lands at $HOME/.midnight-expert == <temp root>/.midnight-expert.
+  local hook_root
+  hook_root=$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null || echo "")
+
   local tmp_err
   tmp_err=$(mktemp)
-  out=$(printf '%s' "$payload" | bash "$script_path" 2>"$tmp_err") || rc=$?
+  out=$(printf '%s' "$payload" | HOME="${hook_root:-$HOME}" CLAUDE_PROJECT_DIR="${hook_root:-${CLAUDE_PROJECT_DIR:-}}" bash "$script_path" 2>"$tmp_err") || rc=$?
   err=$(cat "$tmp_err")
   rm -f "$tmp_err"
 

--- a/plugins/midnight-expert/.claude-plugin/plugin.json
+++ b/plugins/midnight-expert/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-expert",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Meta-plugin for the midnight-expert marketplace. Provides comprehensive diagnostics and health reporting for the entire midnight-expert ecosystem — plugin installation, MCP server connectivity, external CLI tools, cross-plugin references, and NPM registry access.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-expert/README.md
+++ b/plugins/midnight-expert/README.md
@@ -22,7 +22,7 @@ Runs comprehensive diagnostics across the midnight-expert ecosystem. Launches fi
 
 ### UserPromptSubmit
 
-On every user prompt, drains the top-level `on_next_user_prompt` array in `.midnight-expert/settings.local.json` and surfaces its formatted contents as additional context for that turn. Each entry is an object with a `type` discriminator; the hook formats known types and silently skips unknown ones (forward-compat).
+On every user prompt, drains the top-level `on_next_user_prompt` array in `~/.midnight-expert/settings.local.json` and surfaces its formatted contents as additional context for that turn. Each entry is an object with a `type` discriminator; the hook formats known types and silently skips unknown ones (forward-compat).
 
 Currently consumed: `compact-not-compiled` entries written by the `compact-core` Stop hook when it detected unchecked Compact contracts but couldn't block (Stop reattempt, or cooldown still active). The format names the contract paths and asks the agent to compile / verify them before treating any related claim as confirmed.
 

--- a/plugins/midnight-expert/scripts/hooks/UserPromptSubmit.sh
+++ b/plugins/midnight-expert/scripts/hooks/UserPromptSubmit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# UserPromptSubmit hook: drain entries from .midnight-expert/settings.local.json's
+# UserPromptSubmit hook: drain entries from ~/.midnight-expert/settings.local.json's
 # top-level `on_next_user_prompt` array and surface them to Claude as
 # additional context for this turn. Each entry is an object with a `type`
 # discriminator; this hook formats known types and silently skips unknown
@@ -14,23 +14,13 @@
 
 set -uo pipefail
 
-# --- Read hook input ---
-INPUT=""
+# Drain hook input (if any) so producers piping JSON don't get SIGPIPE; we no
+# longer derive any paths from it — settings live in a shared home location.
 if [ ! -t 0 ]; then
-  INPUT=$(cat || true)
+  cat >/dev/null || true
 fi
 
-CWD=""
-if [ -n "$INPUT" ] && command -v jq >/dev/null 2>&1; then
-  CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || echo "")
-fi
-
-PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$CWD}"
-if [ -z "$PROJECT_ROOT" ]; then
-  PROJECT_ROOT="$(pwd)"
-fi
-
-SETTINGS_FILE="$PROJECT_ROOT/.midnight-expert/settings.local.json"
+SETTINGS_FILE="$HOME/.midnight-expert/settings.local.json"
 
 if [ ! -f "$SETTINGS_FILE" ] || ! command -v jq >/dev/null 2>&1; then
   exit 0

--- a/plugins/midnight-fact-check/.claude-plugin/plugin.json
+++ b/plugins/midnight-fact-check/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-fact-check",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Fact-checking pipeline for Midnight content \u2014 extracts testable claims from any source (markdown, code, PDFs, URLs, GitHub repos), classifies them by domain (Compact, SDK, ZKIR, Witness), and verifies each claim using the midnight-verify framework. Produces structured JSON artifacts and human-readable reports.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-fact-check/commands/check.md
+++ b/plugins/midnight-fact-check/commands/check.md
@@ -31,7 +31,7 @@ Generate a run directory:
 4. Create the run directory:
 
 ```bash
-RUN_DIR=".midnight-expert/fact-checker/MM-YY/run-short-name-XXXX"
+RUN_DIR="$HOME/.midnight-expert/fact-checker/MM-YY/run-short-name-XXXX"
 mkdir -p "$RUN_DIR"
 ```
 

--- a/plugins/midnight-fact-check/commands/fast-check.md
+++ b/plugins/midnight-fact-check/commands/fast-check.md
@@ -31,7 +31,7 @@ Generate a run directory:
 4. Create the run directory:
 
 ```bash
-RUN_DIR=".midnight-expert/fact-checker/MM-YY/fast-run-short-name-XXXX"
+RUN_DIR="$HOME/.midnight-expert/fact-checker/MM-YY/fast-run-short-name-XXXX"
 mkdir -p "$RUN_DIR"
 ```
 

--- a/plugins/midnight-fact-check/skills/fact-check-reporting/SKILL.md
+++ b/plugins/midnight-fact-check/skills/fact-check-reporting/SKILL.md
@@ -22,7 +22,7 @@ version: 0.1.0
 | `[run-short-name]` | Run directory basename | `fast-run-core-concepts-qoMk` |
 | `[timestamp]` | ISO 8601 timestamp from run metadata | `2026-04-02T12:00:00Z` |
 | `[target descriptions]` | Comma-separated list of input file paths or skill names | `compact-core/skills/compact-tokens/SKILL.md` |
-| `[full run directory path]` | Absolute path to run artifacts directory | `.midnight-expert/fact-checker/04-02/fast-run-...` |
+| `[full run directory path]` | Absolute path to run artifacts directory | `~/.midnight-expert/fact-checker/04-02/fast-run-...` |
 | `[claim text]` | The `claim` field from the extracted claim object | `persistentHash returns Bytes<32>` |
 | `[domain]` | The `primary_domain` from classification | `compact` |
 | `[evidence_summary]` | The evidence summary from the verification result | `Compiled and executed — hash length is 32 bytes` |

--- a/plugins/midnight-verify/.claude-plugin/plugin.json
+++ b/plugins/midnight-verify/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-verify",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Verification framework for Midnight claims \u2014 verifies Compact code by compiling and executing test contracts, SDK/TypeScript claims by type-checking and devnet E2E testing, ZKIR circuits by running through the WASM checker and inspecting compiled structure, witness implementations by cross-domain type-checking and execution against compiled contracts, or by inspecting source code. Multi-agent pipeline with explicit /verify command.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-verify/README.md
+++ b/plugins/midnight-verify/README.md
@@ -182,7 +182,7 @@ Dispatched by /verify when a claim is about opcode semantics, constraint behavio
 
 Injects a warning at session start reminding the model that its training data about Midnight, Compact, and the Midnight SDK is unreliable and should not be trusted without verification.
 
-The `.compact` hash-baseline snapshot used by the SubagentStop checks below is taken by the `compact-core` plugin's `SessionStart-compact-check.sh`. The two plugins share the file `.midnight-expert/settings.local.json` (key: `compact_compilation_check_hook`).
+The `.compact` hash-baseline snapshot used by the SubagentStop checks below is taken by the `compact-core` plugin's `SessionStart-compact-check.sh`. The two plugins share the file `~/.midnight-expert/settings.local.json` (key: `compact_compilation_check_hook`).
 
 ### SubagentStop
 

--- a/plugins/midnight-verify/scripts/hooks/_compact-check.sh
+++ b/plugins/midnight-verify/scripts/hooks/_compact-check.sh
@@ -66,8 +66,12 @@ compact_unchecked_files() {
     if [ -n "$latest_compile_ts" ]; then
       ts="${latest_compile_ts%Z}"
       ts="${ts%%.*}"
-      compile_epoch=$(date -d "$ts" "+%s" 2>/dev/null \
-                   || date -j -f "%Y-%m-%dT%H:%M:%S" "$ts" "+%s" 2>/dev/null \
+      # $ts is a UTC wall-clock time with the trailing 'Z' and any
+      # fractional seconds stripped. Parse it back as UTC on both GNU
+      # (re-append Z) and BSD/macOS (-u forces UTC interpretation); never
+      # let the timestamp be reinterpreted in the host's local timezone.
+      compile_epoch=$(date -u -d "${ts}Z" "+%s" 2>/dev/null \
+                   || date -juf "%Y-%m-%dT%H:%M:%S" "$ts" "+%s" 2>/dev/null \
                    || echo 0)
       if [ "$compile_epoch" -ge "$file_mtime" ]; then
         continue

--- a/plugins/midnight-verify/scripts/hooks/subagent-stop-cli-tester.sh
+++ b/plugins/midnight-verify/scripts/hooks/subagent-stop-cli-tester.sh
@@ -17,7 +17,7 @@ if [ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ]; then
 fi
 
 PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$CWD}"
-SETTINGS_FILE="$PROJECT_ROOT/.midnight-expert/settings.local.json"
+SETTINGS_FILE="$HOME/.midnight-expert/settings.local.json"
 
 # shellcheck source=_compact-check.sh
 source "$(dirname "$0")/_compact-check.sh"

--- a/plugins/midnight-verify/scripts/hooks/subagent-stop-contract-writer.sh
+++ b/plugins/midnight-verify/scripts/hooks/subagent-stop-contract-writer.sh
@@ -29,7 +29,7 @@ fi
 
 # Check 2: Any .compact file the agent touched must have been compiled
 PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$CWD}"
-SETTINGS_FILE="$PROJECT_ROOT/.midnight-expert/settings.local.json"
+SETTINGS_FILE="$HOME/.midnight-expert/settings.local.json"
 
 # shellcheck source=_compact-check.sh
 source "$(dirname "$0")/_compact-check.sh"

--- a/plugins/midnight-verify/scripts/hooks/subagent-stop-sdk-tester.sh
+++ b/plugins/midnight-verify/scripts/hooks/subagent-stop-sdk-tester.sh
@@ -18,7 +18,7 @@ fi
 CONTENT=$(cat "$TRANSCRIPT")
 
 # Check 1: Verify workspace was created
-if ! echo "$CONTENT" | grep -qE 'mkdir -p .midnight-expert/verify/sdk-workspace|mkdir -p .midnight-expert/verify/wallet-sdk-workspace'; then
+if ! echo "$CONTENT" | grep -qE '\.midnight-expert/verify/sdk-workspace|\.midnight-expert/verify/wallet-sdk-workspace'; then
   cat >&2 <<'EOF'
 {"decision":"block","reason":"You must follow the process as described in the `midnight-verify:verify-by-devnet` skill. Do not attempt to take shortcuts. Only verifications which have followed the process will be accepted and not blocked."}
 EOF

--- a/plugins/midnight-verify/scripts/hooks/subagent-stop-witness-verifier.sh
+++ b/plugins/midnight-verify/scripts/hooks/subagent-stop-witness-verifier.sh
@@ -29,7 +29,7 @@ fi
 
 # Check 2: Any .compact file the agent touched must have been compiled
 PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$CWD}"
-SETTINGS_FILE="$PROJECT_ROOT/.midnight-expert/settings.local.json"
+SETTINGS_FILE="$HOME/.midnight-expert/settings.local.json"
 
 # shellcheck source=_compact-check.sh
 source "$(dirname "$0")/_compact-check.sh"

--- a/plugins/midnight-verify/scripts/hooks/subagent-stop-zkir-checker.sh
+++ b/plugins/midnight-verify/scripts/hooks/subagent-stop-zkir-checker.sh
@@ -29,7 +29,7 @@ fi
 
 # Check 2: Any .compact file the agent touched must have been compiled
 PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$CWD}"
-SETTINGS_FILE="$PROJECT_ROOT/.midnight-expert/settings.local.json"
+SETTINGS_FILE="$HOME/.midnight-expert/settings.local.json"
 
 # shellcheck source=_compact-check.sh
 source "$(dirname "$0")/_compact-check.sh"

--- a/plugins/midnight-verify/skills/verify-by-cli-execution/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-by-cli-execution/SKILL.md
@@ -61,10 +61,10 @@ LANG_VER=$(compact compile --language-version 2>&1)
 
 # Create job directory
 JOB_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
-mkdir -p .midnight-expert/verify/compact-workspace/jobs/$JOB_ID
+mkdir -p "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID"
 
 # Write minimal contract
-cat > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test.compact << COMPACT_EOF
+cat > "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test.compact" << COMPACT_EOF
 pragma language_version $LANG_VER;
 import CompactStandardLibrary;
 
@@ -74,19 +74,19 @@ export circuit test(): Field {
 COMPACT_EOF
 
 # Compile WITHOUT the flag
-compact compile .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test.compact \
-  > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/stdout-without.txt 2>&1
-ls -R .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test/build/ \
-  > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/listing-without.txt 2>&1
+compact compile "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test.compact" \
+  > "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID/stdout-without.txt" 2>&1
+ls -R "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test/build/" \
+  > "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID/listing-without.txt" 2>&1
 
 # Clean compiled output
-rm -rf .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test/
+rm -rf "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test/"
 
 # Compile WITH the flag
-compact compile --skip-zk .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test.compact \
-  > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/stdout-with.txt 2>&1
-ls -R .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test/build/ \
-  > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/listing-with.txt 2>&1
+compact compile --skip-zk "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test.compact" \
+  > "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID/stdout-with.txt" 2>&1
+ls -R "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test/build/" \
+  > "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID/listing-with.txt" 2>&1
 ```
 
 Compare the two directory listings to identify what the flag changed.
@@ -97,7 +97,7 @@ Compile a minimal contract and inspect the build directory:
 
 ```bash
 # After compilation
-find .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test/build/ -type f | sort
+find "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test/build/" -type f | sort
 ```
 
 Compare the actual file tree against the claimed structure.
@@ -108,11 +108,11 @@ Feed invalid input and capture stderr:
 
 ```bash
 # Write intentionally invalid contract
-cat > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/bad.compact << 'COMPACT_EOF'
+cat > "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID/bad.compact" << 'COMPACT_EOF'
 <intentionally invalid code targeting the claimed error>
 COMPACT_EOF
 
-compact compile .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/bad.compact 2>&1
+compact compile "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID/bad.compact" 2>&1
 echo "Exit code: $?"
 ```
 
@@ -192,7 +192,7 @@ Compare the actual output against the claim.
 Remove the job directory if one was created:
 
 ```bash
-rm -rf .midnight-expert/verify/compact-workspace/jobs/$JOB_ID
+rm -rf "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID"
 ```
 
 Do NOT remove the base compact-workspace — it is shared across jobs.

--- a/plugins/midnight-verify/skills/verify-by-devnet/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-by-devnet/SKILL.md
@@ -32,7 +32,7 @@ If ANY service is unreachable:
 
 ## Step 2: Set Up the Workspace
 
-Uses the same workspace as the type-checker: `.midnight-expert/verify/sdk-workspace/`.
+Uses the same workspace as the type-checker: `~/.midnight-expert/verify/sdk-workspace/`.
 
 If it doesn't exist, follow the same initialization as `verify-by-type-check` (create workspace, install packages, create tsconfig).
 
@@ -40,7 +40,7 @@ Create a job directory:
 
 ```bash
 JOB_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
-mkdir -p .midnight-expert/verify/sdk-workspace/jobs/$JOB_ID
+mkdir -p "$HOME/.midnight-expert/verify/sdk-workspace/jobs/$JOB_ID"
 ```
 
 ## Step 3: Choose Your Approach
@@ -149,7 +149,7 @@ Compile it and place the output in the job directory.
 Write the chosen script to the job directory:
 
 ```bash
-cat > .midnight-expert/verify/sdk-workspace/jobs/$JOB_ID/test-claim.mjs << 'SCRIPT_EOF'
+cat > "$HOME/.midnight-expert/verify/sdk-workspace/jobs/$JOB_ID/test-claim.mjs" << 'SCRIPT_EOF'
 <script content>
 SCRIPT_EOF
 ```
@@ -157,7 +157,7 @@ SCRIPT_EOF
 Run it:
 
 ```bash
-cd .midnight-expert/verify/sdk-workspace/jobs/$JOB_ID
+cd "$HOME/.midnight-expert/verify/sdk-workspace/jobs/$JOB_ID"
 node test-claim.mjs
 ```
 
@@ -192,7 +192,7 @@ node test-claim.mjs
 ## Step 7: Clean Up
 
 ```bash
-rm -rf .midnight-expert/verify/sdk-workspace/jobs/$JOB_ID
+rm -rf "$HOME/.midnight-expert/verify/sdk-workspace/jobs/$JOB_ID"
 ```
 
 ## Wallet SDK Devnet Mode
@@ -214,7 +214,7 @@ If ANY container is unreachable:
 
 ### Workspace
 
-Reuse the wallet-sdk-workspace at `.midnight-expert/verify/wallet-sdk-workspace/`. It already has all wallet SDK packages installed.
+Reuse the wallet-sdk-workspace at `~/.midnight-expert/verify/wallet-sdk-workspace/`. It already has all wallet SDK packages installed.
 
 ### Script Approach
 

--- a/plugins/midnight-verify/skills/verify-by-execution/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-by-execution/SKILL.md
@@ -34,16 +34,16 @@ Load any of these if they would help you write a better test. Do not load them a
 
 ## Step 1: Set Up the Workspace
 
-The workspace lives at `.midnight-expert/verify/compact-workspace/` relative to the project root (same level as `.claude/`). Determine the project root from your working directory or `$CLAUDE_PROJECT_DIR`.
+The workspace lives at `~/.midnight-expert/verify/compact-workspace/` in your home directory. It is home-based and independent of the project you are working in.
 
 **First time (workspace does not exist):**
 
 ```bash
 # Create the workspace
-mkdir -p .midnight-expert/verify/compact-workspace
+mkdir -p "$HOME/.midnight-expert/verify/compact-workspace"
 
 # Initialize and install runtime
-cd .midnight-expert/verify/compact-workspace
+cd "$HOME/.midnight-expert/verify/compact-workspace"
 npm init -y
 npm install @midnight-ntwrk/compact-runtime
 ```
@@ -53,7 +53,7 @@ npm install @midnight-ntwrk/compact-runtime
 Run a quick integrity check:
 
 ```bash
-cd .midnight-expert/verify/compact-workspace
+cd "$HOME/.midnight-expert/verify/compact-workspace"
 npm ls @midnight-ntwrk/compact-runtime
 ```
 
@@ -64,7 +64,7 @@ If `npm ls` reports errors (missing or corrupted packages), run `npm install` to
 ```bash
 # Generate a unique job ID
 JOB_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
-mkdir -p .midnight-expert/verify/compact-workspace/jobs/$JOB_ID
+mkdir -p "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID"
 ```
 
 All contract files, compilation output, and runner scripts go in this job directory.
@@ -112,7 +112,7 @@ export circuit testClaimName(<params>): <ReturnType> {
 **Write the file:**
 
 ```bash
-cat > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test-<claim>.compact << 'COMPACT_EOF'
+cat > "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test-<claim>.compact" << 'COMPACT_EOF'
 <contract content>
 COMPACT_EOF
 ```
@@ -122,7 +122,7 @@ COMPACT_EOF
 Load the `midnight-tooling:compact-cli` skill for compilation flags, version management, and troubleshooting.
 
 ```bash
-compact compile .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test-<claim>.compact --skip-zk
+compact compile "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID/test-<claim>.compact" --skip-zk
 ```
 
 **If compilation succeeds:** Proceed to Step 5. The compiled output will be in `test-<claim>/build/` relative to where you ran the command, or in the contract's output directory. Check for the `contract/index.js` file.
@@ -152,7 +152,7 @@ If no `.zkir` output is found (some compilation modes may not produce it), note 
 **Create the runner script in the job directory:**
 
 ```bash
-cat > .midnight-expert/verify/compact-workspace/jobs/$JOB_ID/run.mjs << 'RUNNER_EOF'
+cat > "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID/run.mjs" << 'RUNNER_EOF'
 import { pureCircuits } from './out/contract/index.js';
 
 // Call the test circuit
@@ -171,7 +171,7 @@ Adjust the import path based on where `compact compile` placed the output. The c
 **Run it:**
 
 ```bash
-cd .midnight-expert/verify/compact-workspace/jobs/$JOB_ID
+cd "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID"
 node run.mjs
 ```
 
@@ -219,7 +219,7 @@ Compare the actual output to what the claim predicts.
 Remove the job directory:
 
 ```bash
-rm -rf .midnight-expert/verify/compact-workspace/jobs/$JOB_ID
+rm -rf "$HOME/.midnight-expert/verify/compact-workspace/jobs/$JOB_ID"
 ```
 
 Do NOT remove the base workspace — it's shared across jobs.

--- a/plugins/midnight-verify/skills/verify-by-type-check/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-by-type-check/SKILL.md
@@ -20,13 +20,13 @@ You are verifying an SDK claim or user TypeScript file by running the TypeScript
 
 ## Step 1: Set Up the Workspace
 
-The workspace lives at `.midnight-expert/verify/sdk-workspace/` relative to the project root (same level as `.claude/`). Determine the project root from your working directory or `$CLAUDE_PROJECT_DIR`.
+The workspace lives at `~/.midnight-expert/verify/sdk-workspace/` in your home directory. It is home-based and independent of the project you are working in.
 
 **First time (workspace does not exist):**
 
 ```bash
-mkdir -p .midnight-expert/verify/sdk-workspace
-cd .midnight-expert/verify/sdk-workspace
+mkdir -p "$HOME/.midnight-expert/verify/sdk-workspace"
+cd "$HOME/.midnight-expert/verify/sdk-workspace"
 
 # Initialize Node project
 npm init -y
@@ -73,7 +73,7 @@ TSCONFIG_EOF
 Run a quick integrity check:
 
 ```bash
-cd .midnight-expert/verify/sdk-workspace
+cd "$HOME/.midnight-expert/verify/sdk-workspace"
 npm ls typescript
 ```
 
@@ -83,18 +83,18 @@ If `npm ls` reports errors, run `npm install` to repair.
 
 ```bash
 JOB_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
-mkdir -p .midnight-expert/verify/sdk-workspace/jobs/$JOB_ID
+mkdir -p "$HOME/.midnight-expert/verify/sdk-workspace/jobs/$JOB_ID"
 ```
 
 ## Wallet SDK Workspace Mode
 
-When the orchestrator passes `domain: 'wallet-sdk'` context, use a separate workspace at `.midnight-expert/verify/wallet-sdk-workspace/` instead of the SDK workspace. This workspace has different packages installed.
+When the orchestrator passes `domain: 'wallet-sdk'` context, use a separate workspace at `~/.midnight-expert/verify/wallet-sdk-workspace/` instead of the SDK workspace. This workspace has different packages installed.
 
 **First time (workspace does not exist):**
 
 ```bash
-mkdir -p .midnight-expert/verify/wallet-sdk-workspace
-cd .midnight-expert/verify/wallet-sdk-workspace
+mkdir -p "$HOME/.midnight-expert/verify/wallet-sdk-workspace"
+cd "$HOME/.midnight-expert/verify/wallet-sdk-workspace"
 
 # Initialize Node project
 npm init -y
@@ -138,7 +138,7 @@ TSCONFIG_EOF
 **Subsequent times (workspace exists):**
 
 ```bash
-cd .midnight-expert/verify/wallet-sdk-workspace
+cd "$HOME/.midnight-expert/verify/wallet-sdk-workspace"
 npm ls typescript
 ```
 
@@ -147,8 +147,8 @@ If `npm ls` reports errors, run `npm install` to repair.
 **Job directory, type assertion writing, tsc execution, interpretation, and cleanup follow the same steps as the standard SDK workspace.** The only difference is the workspace path and the installed packages.
 
 **Mode selection:** When you receive a claim from the orchestrator, check the domain context:
-- `domain: 'wallet-sdk'` → use `.midnight-expert/verify/wallet-sdk-workspace/`
-- Otherwise → use `.midnight-expert/verify/sdk-workspace/` (existing behavior)
+- `domain: 'wallet-sdk'` → use `~/.midnight-expert/verify/wallet-sdk-workspace/`
+- Otherwise → use `~/.midnight-expert/verify/sdk-workspace/` (existing behavior)
 
 ## Ledger API Execution Mode
 
@@ -163,7 +163,7 @@ When the orchestrator passes `domain: 'ledger'` context and the claim is about b
 **Script pattern:**
 
 ```bash
-cat > .midnight-expert/verify/sdk-workspace/jobs/$JOB_ID/ledger-exec.mjs << 'EXEC_EOF'
+cat > "$HOME/.midnight-expert/verify/sdk-workspace/jobs/$JOB_ID/ledger-exec.mjs" << 'EXEC_EOF'
 // Import the specific function being tested
 import { nativeToken, coinCommitment, CostModel } from '@midnight-ntwrk/ledger';
 
@@ -181,17 +181,17 @@ EXEC_EOF
 Run it:
 
 ```bash
-cd .midnight-expert/verify/sdk-workspace/jobs/$JOB_ID
+cd "$HOME/.midnight-expert/verify/sdk-workspace/jobs/$JOB_ID"
 node ledger-exec.mjs
 ```
 
 **Report this as "ledger-v8 execution" evidence**, not as type-checking evidence. Include the script source, output, and interpretation in your report.
 
 **Mode selection summary:**
-- `domain: 'wallet-sdk'` → use `.midnight-expert/verify/wallet-sdk-workspace/`
+- `domain: 'wallet-sdk'` → use `~/.midnight-expert/verify/wallet-sdk-workspace/`
 - `domain: 'ledger'` + behavioral claim → use sdk-workspace + ledger execution script
 - `domain: 'ledger'` + type claim → use sdk-workspace + normal tsc type assertions
-- Otherwise → use `.midnight-expert/verify/sdk-workspace/` (existing behavior)
+- Otherwise → use `~/.midnight-expert/verify/sdk-workspace/` (existing behavior)
 
 ## Step 2: Determine the Mode
 
@@ -239,7 +239,7 @@ import { setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
 Write the file to the job directory:
 
 ```bash
-cat > .midnight-expert/verify/sdk-workspace/jobs/$JOB_ID/test-claim.ts << 'TS_EOF'
+cat > "$HOME/.midnight-expert/verify/sdk-workspace/jobs/$JOB_ID/test-claim.ts" << 'TS_EOF'
 <type assertion code>
 TS_EOF
 ```
@@ -265,7 +265,7 @@ TS_EOF
 ## Step 4: Run tsc
 
 ```bash
-cd .midnight-expert/verify/sdk-workspace
+cd "$HOME/.midnight-expert/verify/sdk-workspace"
 npx tsc --noEmit --project tsconfig.json 2>&1
 ```
 
@@ -313,5 +313,5 @@ npx tsc --noEmit jobs/$JOB_ID/test-claim.ts 2>&1
 ## Step 6: Clean Up
 
 ```bash
-rm -rf .midnight-expert/verify/sdk-workspace/jobs/$JOB_ID
+rm -rf "$HOME/.midnight-expert/verify/sdk-workspace/jobs/$JOB_ID"
 ```

--- a/plugins/midnight-verify/skills/verify-by-witness/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-by-witness/SKILL.md
@@ -21,13 +21,13 @@ You are verifying that a TypeScript witness implementation correctly matches and
 
 ## Phase 1: Setup and Locate Files
 
-The workspace lives at `.midnight-expert/verify/witness-workspace/` relative to the project root.
+The workspace lives at `~/.midnight-expert/verify/witness-workspace/` in your home directory. It is home-based and independent of the project you are working in.
 
 **First time (workspace does not exist):**
 
 ```bash
-mkdir -p .midnight-expert/verify/witness-workspace
-cd .midnight-expert/verify/witness-workspace
+mkdir -p "$HOME/.midnight-expert/verify/witness-workspace"
+cd "$HOME/.midnight-expert/verify/witness-workspace"
 npm init -y
 npm install @midnight-ntwrk/compact-runtime typescript
 ```
@@ -35,7 +35,7 @@ npm install @midnight-ntwrk/compact-runtime typescript
 **Subsequent times:**
 
 ```bash
-cd .midnight-expert/verify/witness-workspace
+cd "$HOME/.midnight-expert/verify/witness-workspace"
 npm ls typescript
 ```
 
@@ -45,7 +45,7 @@ If errors, `npm install` to repair.
 
 ```bash
 JOB_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
-mkdir -p .midnight-expert/verify/witness-workspace/jobs/$JOB_ID
+mkdir -p "$HOME/.midnight-expert/verify/witness-workspace/jobs/$JOB_ID"
 ```
 
 **Locate the files:**
@@ -60,13 +60,13 @@ mkdir -p .midnight-expert/verify/witness-workspace/jobs/$JOB_ID
 Compile the contract where it lives, directing build output to the job directory:
 
 ```bash
-compact compile -- --skip-zk <source-path> .midnight-expert/verify/witness-workspace/jobs/$JOB_ID/build/
+compact compile -- --skip-zk <source-path> "$HOME/.midnight-expert/verify/witness-workspace/jobs/$JOB_ID/build/"
 ```
 
 If the orchestrator indicated this claim also needs PLONK verification (Witness + ZKIR), compile without `--skip-zk` instead:
 
 ```bash
-compact compile -- <source-path> .midnight-expert/verify/witness-workspace/jobs/$JOB_ID/build/
+compact compile -- <source-path> "$HOME/.midnight-expert/verify/witness-workspace/jobs/$JOB_ID/build/"
 ```
 
 This produces `build/contract/index.js` and `build/contract/index.d.ts` which export the generated `Witnesses` type.
@@ -104,7 +104,7 @@ Create a `tsconfig.json` for the job:
 Run the type check:
 
 ```bash
-cd .midnight-expert/verify/witness-workspace/jobs/$JOB_ID
+cd "$HOME/.midnight-expert/verify/witness-workspace/jobs/$JOB_ID"
 npx tsc --noEmit --project tsconfig.json 2>&1
 ```
 
@@ -240,13 +240,13 @@ The orchestrator will decide whether to dispatch @"midnight-verify:sdk-tester (a
 If the orchestrator indicated PLONK verification is needed, include the build output path in the report so the orchestrator can pass it to @"midnight-verify:zkir-checker (agent)":
 
 ```
-**Build output:** .midnight-expert/verify/witness-workspace/jobs/$JOB_ID/build/
+**Build output:** ~/.midnight-expert/verify/witness-workspace/jobs/$JOB_ID/build/
 ```
 
 ## Clean Up
 
 ```bash
-rm -rf .midnight-expert/verify/witness-workspace/jobs/$JOB_ID
+rm -rf "$HOME/.midnight-expert/verify/witness-workspace/jobs/$JOB_ID"
 ```
 
 Do NOT remove the base workspace — it's shared across jobs. If the orchestrator needs the build output for @"midnight-verify:zkir-checker (agent)", do NOT clean up until the orchestrator confirms the zkir-checker is done.

--- a/plugins/midnight-verify/skills/verify-by-zkir-checker/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-by-zkir-checker/SKILL.md
@@ -22,13 +22,13 @@ You are verifying a Compact contract or ZKIR claim by running the full zero-know
 
 ## Step 1: Set Up the Workspace
 
-The workspace lives at `.midnight-expert/verify/zkir-workspace/` relative to the project root.
+The workspace lives at `~/.midnight-expert/verify/zkir-workspace/` in your home directory. It is home-based and independent of the project you are working in.
 
 **First time (workspace does not exist):**
 
 ```bash
-mkdir -p .midnight-expert/verify/zkir-workspace
-cd .midnight-expert/verify/zkir-workspace
+mkdir -p "$HOME/.midnight-expert/verify/zkir-workspace"
+cd "$HOME/.midnight-expert/verify/zkir-workspace"
 npm init -y
 npm install @midnight-ntwrk/zkir-v2 @midnight-ntwrk/compact-runtime
 ```
@@ -36,7 +36,7 @@ npm install @midnight-ntwrk/zkir-v2 @midnight-ntwrk/compact-runtime
 **Subsequent times (workspace exists):**
 
 ```bash
-cd .midnight-expert/verify/zkir-workspace
+cd "$HOME/.midnight-expert/verify/zkir-workspace"
 npm ls @midnight-ntwrk/zkir-v2
 ```
 
@@ -46,7 +46,7 @@ If `npm ls` reports errors, run `npm install` to repair.
 
 ```bash
 JOB_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
-mkdir -p .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID
+mkdir -p "$HOME/.midnight-expert/verify/zkir-workspace/jobs/$JOB_ID"
 ```
 
 ## Step 2: Get the Contract
@@ -66,7 +66,7 @@ You may load compact-core skills as hints for writing correct Compact code. The 
 ## Step 3: Compile Without `--skip-zk`
 
 ```bash
-compact compile -- <source-path> .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID/build/
+compact compile -- <source-path> "$HOME/.midnight-expert/verify/zkir-workspace/jobs/$JOB_ID/build/"
 ```
 
 **The source path is the `.compact` file where it lives** (contract mode) or in the job directory (claim mode). The build output always goes to `jobs/$JOB_ID/build/`.
@@ -224,7 +224,7 @@ A rejection in a negative test **confirms** the claim (the constraint is enforce
 ## Step 9: Clean Up
 
 ```bash
-rm -rf .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID
+rm -rf "$HOME/.midnight-expert/verify/zkir-workspace/jobs/$JOB_ID"
 ```
 
 Do NOT remove the base workspace — it's shared across jobs.

--- a/plugins/midnight-verify/skills/verify-by-zkir-inspection/SKILL.md
+++ b/plugins/midnight-verify/skills/verify-by-zkir-inspection/SKILL.md
@@ -25,13 +25,13 @@ If the checker method has already compiled the contract, use its build output fo
 
 ## Step 1: Set Up and Compile
 
-Uses the same workspace as the checker method: `.midnight-expert/verify/zkir-workspace/`. Does not require the WASM checker — only the Compact CLI and JSON parsing.
+Uses the same workspace as the checker method: `~/.midnight-expert/verify/zkir-workspace/`. Does not require the WASM checker — only the Compact CLI and JSON parsing.
 
 Create a job directory:
 
 ```bash
 JOB_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
-mkdir -p .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID
+mkdir -p "$HOME/.midnight-expert/verify/zkir-workspace/jobs/$JOB_ID"
 ```
 
 Write a minimal `.compact` contract targeting the claim. Only include what's needed to test the specific structural property.
@@ -40,7 +40,7 @@ Get the current language version and compile:
 
 ```bash
 compact compile --language-version
-compact compile -- --skip-zk <source-path> .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID/build/
+compact compile -- --skip-zk <source-path> "$HOME/.midnight-expert/verify/zkir-workspace/jobs/$JOB_ID/build/"
 ```
 
 For user-provided contracts, compile the contract where it lives (it may have imports) and direct only the build output to the job directory.
@@ -48,7 +48,7 @@ For user-provided contracts, compile the contract where it lives (it may have im
 If this inspection will be followed by checker verification, omit `--skip-zk` to avoid recompiling:
 
 ```bash
-compact compile -- <source-path> .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID/build/
+compact compile -- <source-path> "$HOME/.midnight-expert/verify/zkir-workspace/jobs/$JOB_ID/build/"
 ```
 
 Capture the compiler output. Note the compiler version — ZKIR output may change between versions.
@@ -123,5 +123,5 @@ For complex structural claims, write a small Node.js script in the job directory
 ## Step 5: Clean Up
 
 ```bash
-rm -rf .midnight-expert/verify/zkir-workspace/jobs/$JOB_ID
+rm -rf "$HOME/.midnight-expert/verify/zkir-workspace/jobs/$JOB_ID"
 ```


### PR DESCRIPTION
## Why

Plugins were writing scratch/state artifacts into the **user's project working directory**, where they were being committed by accident (the reported complaint). This moves them to a shared home location and fixes a related timezone bug surfaced while verifying the change.

## What changed

### 1. Artifacts → `~/.midnight-expert/` (shared, out of every working dir)
`${CLAUDE_PLUGIN_DATA}` was rejected as the target: it's **per-plugin** (would break the `settings.local.json` shared across compact-core/midnight-expert/midnight-verify) and only set **inside hooks** (not in the subagent Bash that creates the verify/fact-check dirs). A shared `$HOME/.midnight-expert/` solves the problem and matches the existing `~/.midnight-expert/{statusLine,devnet}` convention.

| Class | Artifact | Action |
|---|---|---|
| settings | `settings.local.json` (compact-core hooks write; midnight-expert + midnight-verify hooks read) | → `$HOME/.midnight-expert/` |
| workspaces | `verify/*-workspace/` (7 midnight-verify `verify-by-*` skills) | → `$HOME/.midnight-expert/verify/` |
| runs | `fact-checker/` (midnight-fact-check check/fast-check) | → `$HOME/.midnight-expert/fact-checker/` |

- **compact-cli-dev:** its `.midnight-expert/` is the *generated DApp's own* per-project state (wallet seeds, deployed-contract registry), so it stays project-local but is **renamed `.midnight-expert` → `.dapp-state`** to avoid confusion; template `.gitignore` updated so seeds stay protected. The devnet `COMPOSE_FALLBACK` (`~/.midnight-expert/devnet`) is preserved.
- **Left unchanged:** midnight-tooling `~/.midnight-expert/{statusLine,devnet}` (already home-based), all `/tmp` + `~/.cache` usage, intentional scaffolding, `docs/superpowers/` archival plans.
- The `subagent-stop-sdk-tester` grep now matches the workspace path as a prefix-independent substring, and the compact-core hook test harness pins `HOME`+`CLAUDE_PROJECT_DIR` to the temp root so assertions still hold.

A full 16-plugin sweep confirmed nothing else writes scratch/state into the working directory.

### 2. UTC compile-check timestamp fix
While verifying, the compact-core hook suite surfaced a **pre-existing** bug (reproduced on pristine `main`): UTC timestamps had their trailing `Z` stripped before parsing, so **both** date backends read them as host-**local** time — GNU `date -d "...:34"` (no zone) assumes local, BSD `date -j -f` lacks `-u`. On any non-UTC host this misfired the "uncompiled contract" detection and the 2h Stop cooldown. Fixed by keeping timestamps UTC-explicit (`date -u -d "${ts}Z"` / `date -juf`) in `_compact-check.sh` and `Stop.sh` (both byte-identical `_compact-check.sh` copies updated together).

### 3. Version bumps (minor)
compact-cli-dev 0.3.0→0.4.0 · compact-core 0.9.0→0.10.0 · midnight-expert 0.5.0→0.6.0 · midnight-fact-check 0.3.2→0.4.0 · midnight-verify 0.12.0→0.13.0 · marketplace 0.45.0→0.46.0

## Verification
- compact-core hook test suite: **10/10 scripts, 52/52 assertions** pass on a UTC+1 host (previously 2 failed there due to the timezone bug).
- `bash -n` + `shellcheck -S error` clean on all edited shell scripts.
- Repo-wide grep audit: zero `$PROJECT_ROOT/.midnight-expert` and zero relative `.midnight-expert/{verify,fact-checker}` remain.

Generated with [Claude Code](https://claude.com/claude-code)