### PR TITLE
docs: correct README inaccuracies across plugins + root marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This project extends the Midnight Network with additional developer tooling.
 ## At a glance
 
 - **13** Plugins
-- **82** Skills / Slash commands
-- **16** Agents
+- **87** Skills / Slash commands
+- **17** Agents
 - **~37,700** Lines of reference documentation
 - **~21,800** Lines of example code
 

--- a/plugins/compact-core/README.md
+++ b/plugins/compact-core/README.md
@@ -202,6 +202,17 @@ Review checklists for 10 categories of Compact smart contract review. Each refer
 | [testing-review](skills/compact-review/references/testing-review.md) | Edge cases, negative tests, private state testing, witness mocks | When reviewing testing adequacy |
 | [documentation-review](skills/compact-review/references/documentation-review.md) | Circuit docs, witness contracts, ledger semantics | When reviewing documentation completeness |
 
+### compact-core:compact-security
+
+Threat model and adversarial methodology for reviewing Compact contracts: the three execution contexts (public ledger, ZK circuit, local witness), the witness trust boundary and the ownPublicKey()-for-authorization anti-pattern, sealed-field misuse, disclosure placement, cryptographic-primitive selection, domain separation, and the Verification Requests protocol used by the security-reviewer agent. Routes to the compact-review checklists for granular line-items.
+
+#### References
+
+| Name | Description | When it is used |
+|------|-------------|-----------------|
+| [threat-catalog](skills/compact-security/references/threat-catalog.md) | Catalog of Compact threats with adversarial methodology and the Reuse Map to compact-review checklists | When reasoning about attacks and threat categories |
+| [witness-trust-boundary](skills/compact-security/references/witness-trust-boundary.md) | The witness trust boundary, ownPublicKey()-for-auth anti-pattern, and witness-derived identity | When reviewing authentication and witness-supplied data |
+
 ### compact-core:compact-debugging
 
 Process orchestration for debugging Compact smart contract errors. Routes to domain-specific compact-core skills based on symptom-driven triage, tracks fix attempts, and triggers escalation when consecutive fixes reveal deeper problems.
@@ -213,6 +224,20 @@ Process orchestration for debugging Compact smart contract errors. Routes to dom
 | [debugging-session.md](skills/compact-debugging/examples/debugging-session.md) | Walkthrough of a debugging session with triage and fix tracking | When learning the debugging methodology |
 
 ## Commands
+
+### compact-core:audit-compact
+
+Deep adversarial security audit of Compact smart contract code. Runs a single security-reviewer specialist over the threat model, then confirms Critical/High findings via midnight-verify and synthesizes a consolidated security report. Security-only; for a full 10-category review use /compact-core:review-compact.
+
+#### Output
+
+A consolidated security audit report with severity-sorted findings, each Critical/High finding marked Confirmed, Refuted, or Inconclusive based on mechanical verification.
+
+#### Invokes
+
+- `compact-core:security-reviewer` agent (one deep security pass)
+- `compact-core:compact-security` skill (loaded by the security-reviewer agent for the threat model)
+- `/midnight-verify:verify` (main-thread confirmation of Critical/High findings)
 
 ### compact-core:debug-contract
 
@@ -250,6 +275,14 @@ Compact smart contract developer agent that writes, generates, reviews, and fixe
 #### When to use
 
 When you need to create new contracts, modify existing ones, fix compilation errors, implement privacy patterns, work with shielded tokens, or answer questions about Compact syntax and semantics. Follows a mandatory workflow: gather syntax reference, load skills, research patterns, write code, pre-check, compile, verify, and review.
+
+### security-reviewer
+
+Focused, adversarial security review agent for Compact smart contract code. Performs a single coherent threat-model pass (witness trust boundary, access control, cryptography, tokens, privacy leakage) and reasons across dimensions so compounding issues are caught.
+
+#### When to use
+
+When you need a security-only review of Compact code. Unlike the command-only `reviewer` agent, this agent is directly invocable by users and other agents. It cannot spawn subagents: for Critical/High findings it emits a structured "Verification Requests" block and hands mechanical confirmation back to the caller (typically the /compact-core:audit-compact orchestrator). For a full multi-category review, use /compact-core:review-compact instead.
 
 ### reviewer
 

--- a/plugins/midnight-expert/README.md
+++ b/plugins/midnight-expert/README.md
@@ -18,6 +18,14 @@ Runs comprehensive diagnostics across the midnight-expert ecosystem. Launches fi
 |------|-------------|-----------------|
 | [fix-table.md](skills/doctor/references/fix-table.md) | Maps diagnostic output to actionable fixes, including auto-fix classification for silent vs prompted resolution | When interpreting doctor results and determining how to resolve detected issues |
 
+### midnight-expert:add-to-ecosystem
+
+Walks the user's current project through the four Electric Capital eligibility requirements (on GitHub, public, `midnightntwrk` topic, optional `compact` topic), inserts the canonical Midnight attribution sentence into `README.md`, commits, pushes, and opens a PR.
+
+### midnight-expert:feedback
+
+Routes a user's feedback to a GitHub issue or enhancement on `devrelaicom/midnight-expert`. The user types one paragraph; the skill silently scans the session transcript and environment, applies heavy redaction, and composes a maintainer-ready issue body.
+
 ## Hooks
 
 ### UserPromptSubmit

--- a/plugins/midnight-fact-check/README.md
+++ b/plugins/midnight-fact-check/README.md
@@ -35,7 +35,7 @@ A markdown report with an executive summary, results grouped by domain, and a de
 - midnight-fact-check:fact-check-extraction (skill, via claim-extractor agent)
 - midnight-fact-check:fact-check-classification (skill, via domain-classifier agent)
 - midnight-fact-check:fact-check-reporting (skill)
-- midnight-verify:verify-correctness (skill, from midnight-verify plugin)
+- midnight-verify verification agents (dispatched directly, from midnight-verify plugin)
 
 ### midnight-fact-check:fast-check
 
@@ -49,7 +49,7 @@ A markdown report with verification results and a terminal summary. Faster and c
 
 - midnight-fact-check:fact-check-extraction (skill, via claim-extractor agent)
 - midnight-fact-check:fact-check-reporting (skill)
-- midnight-verify:verify-correctness (skill, from midnight-verify plugin)
+- midnight-verify:source-investigator (agent, dispatched directly, from midnight-verify plugin)
 
 ## Agents
 

--- a/plugins/midnight-status-codes/README.md
+++ b/plugins/midnight-status-codes/README.md
@@ -53,7 +53,7 @@ Each entry in `codes.json` has the following fields:
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `code` | string | yes | The code, name, or identifier the user pastes (e.g. `"166"`, `"400/JobNotPending"`, `"InvalidNetworkIdError"`). |
+| `code` | string | yes | The code, name, or identifier the user pastes (e.g. `"166"`, `"400/JobNotPending"`, `"ContractRuntimeError"`). |
 | `name` | string | yes | Canonical name. |
 | `source` | string | yes | One of `midnight-node`, `substrate`, `jsonrpc-2.0`, `partner-chains`, `compact-compiler`, `compact-runtime`, `compact-js-sdk`, `midnight-js`, `midnight-wallet`, `midnight-indexer`, `proof-server`, `dapp-connector`. |
 | `category` | string | yes | Used by `--category` filter. |

--- a/plugins/midnight-tooling/README.md
+++ b/plugins/midnight-tooling/README.md
@@ -35,6 +35,10 @@ Covers the local 3-service development network (node, indexer, proof server) lif
 | [network-lifecycle.md](skills/devnet/references/network-lifecycle.md) | Generating, starting, stopping, and monitoring the devnet via Docker Compose | Managing the devnet through its full lifecycle |
 | [version-resolution.md](skills/devnet/references/version-resolution.md) | How Docker image versions are resolved and checked for compatibility | Resolving version conflicts or selecting specific component versions |
 
+### midnight-tooling:devnet-health
+
+Status and health checks for the local 3-service devnet (node, indexer, proof server) -- distinguishing whether each container is running from whether each service is responding to its health endpoint. Used directly or by other agents (doctor, statusline) that need structured per-service status.
+
 ### midnight-tooling:proof-server
 
 Covers working with the Midnight proof server in any context -- local development via devnet, standalone Docker instances, and remote servers on testnet/mainnet. Includes API endpoints, version selection, and environment endpoint lookup.

--- a/plugins/midnight-verify/README.md
+++ b/plugins/midnight-verify/README.md
@@ -116,7 +116,10 @@ A verdict based on source inspection, with an optional background execution chec
 #### Invokes
 
 - `midnight-verify:verify-correctness` (hub skill for domain classification)
-- `midnight-verify:source-investigator` (agent, primary method)
+- `midnight-verify:source-investigator` (agent, primary foreground method for most domains)
+- `midnight-verify:cli-tester` (agent, foreground method for Tooling claims)
+- `midnight-verify:contract-writer` (agent, optional background execution check for Compact claims)
+- `midnight-verify:type-checker` (agent, optional background execution check for SDK claims)
 
 ## Agents
 


### PR DESCRIPTION
## Summary

Verified all **17 READMEs** (root + 16 plugins) against the actual repo contents using a two-phase audit → independent-verification pass, and corrected the drift between what each plugin ships and what its README documents. **7 READMEs changed; 10 were already accurate.**

The dominant theme: components added since the READMEs were last touched were never documented, and the root "at a glance" counts had drifted.

## Changes

| README | Fix |
|--------|-----|
| **root** | `82 → 87` Skills/Slash commands and `16 → 17` Agents — recomputed over the 13 published plugins (73 `SKILL.md` + 14 `commands/*.md` = 87; 17 `agents/*.md`) |
| **compact-core** | Documented 3 shipped-but-undocumented components: the `compact-security` skill (+ its 2 reference files), the `audit-compact` command, and the `security-reviewer` agent |
| **midnight-expert** | Documented the `add-to-ecosystem` and `feedback` skills |
| **midnight-tooling** | Documented the `devnet-health` skill (6 skills shipped, 5 listed) |
| **midnight-verify** | Completed `fast-verify`'s "Invokes" list — added `cli-tester`, `contract-writer`, `type-checker` (confirmed against the command's routing table) |
| **midnight-fact-check** | Corrected `check`/`fast-check` "Invokes": `verify-correctness` is only a preflight existence gate, not invoked — the commands dispatch midnight-verify **agents** directly |
| **midnight-status-codes** | Schema-table example `"InvalidNetworkIdError"` did not exist in `codes.json` (lookup returned no match) → replaced with the real, lookup-matchable `"ContractRuntimeError"` |

## Known follow-up (not in this PR)

- **midnight-node README** states the JSON-RPC API has "approximately ~68 methods," but the source `node-rpc-api/SKILL.md` enumerates ~55 rows. Left unchanged: the README faithfully mirrors its SKILL.md source, the figure is hedged, and the true count is an external claim about a live node that can't be confirmed from repo files. If precision is wanted, it should be checked against a running node (`rpc.discover`/OpenRPC) and reconciled in **both** the SKILL.md and README.

## Verification

All edits were re-checked by an independent verifier agent that re-derived ground truth from the actual files (component dirs, `plugin.json`, every relative link via `test -f`, recomputed counts). No regressions.

Generated with [Claude Code](https://claude.com/claude-code)