### PR TITLE
fix: vendor unpublished npm deps so fact-check + compact-cli-dev work for everyone

### DIFF
--- a/plugins/compact-cli-dev/.claude-plugin/plugin.json
+++ b/plugins/compact-cli-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compact-cli-dev",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Scaffold and develop Oclif CLIs for Midnight Compact smart contracts. Includes a complete CLI template with wallet management, contract deployment, devnet control, and an AI agent for ongoing development.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/compact-cli-dev/commands/init.md
+++ b/plugins/compact-cli-dev/commands/init.md
@@ -61,33 +61,37 @@ Construct the template context from the resolved values:
 
 ## Step 4 -- Resolve Template Path
 
-The templates live inside this plugin's installation directory. Since `${CLAUDE_PLUGIN_ROOT}` does not expand in markdown files, resolve the path at runtime:
+The templates and the renderer both live inside this plugin's installation directory. Since `${CLAUDE_PLUGIN_ROOT}` does not expand in markdown files, resolve the path at runtime:
 
 ```bash
 PLUGIN_ROOT=$(find ~/.claude -path "*/compact-cli-dev/.claude-plugin/plugin.json" -exec dirname {} \; 2>/dev/null | head -1 | xargs dirname)
 TEMPLATE_DIR="${PLUGIN_ROOT}/skills/core/templates/cli"
+RENDER_SCRIPT="${PLUGIN_ROOT}/skills/core/scripts/render-template.mjs"
+echo "TEMPLATE_DIR=$TEMPLATE_DIR"
+echo "RENDER_SCRIPT=$RENDER_SCRIPT"
 ```
 
-Verify the template directory exists before proceeding:
+Note the printed `TEMPLATE_DIR` value — you will substitute it as a literal path in Step 5. Verify both the template directory and the renderer exist before proceeding:
 
 ```bash
-[ -d "$TEMPLATE_DIR" ] && echo "Template directory found: $TEMPLATE_DIR" || echo "ERROR: Template directory not found"
+[ -d "$TEMPLATE_DIR" ] && [ -f "$RENDER_SCRIPT" ] && echo "Template directory and renderer found" || echo "ERROR: template directory or renderer not found"
 ```
 
-If the template directory is not found, report the error and stop.
+If either is not found, report the error and stop.
 
-## Step 5 -- Run Template Engine
+## Step 5 -- Render the Template
 
-Invoke the template engine via stdin/stdout. Construct the JSON input with the template directory, output directory, and context object:
+Render the template via the vendored, dependency-free renderer (`skills/core/scripts/render-template.mjs`), which reads a JSON job from stdin. It needs only Node — there is nothing to install. Re-resolve `PLUGIN_ROOT` inside the same command so the path is correct even though shell variables do not persist between steps, then pipe the JSON job in. Substitute the literal `TEMPLATE_DIR` from Step 4, the resolved output `<directory>`, and the Step 3 context values:
 
 ```bash
-echo '{"template":"<TEMPLATE_DIR>","output":"<directory>","context":{"PROJECT_NAME":"...","CLI_PACKAGE_NAME":"...","CONTRACT_NAME":"...","CONTRACT_PACKAGE":"...","CONTRACT_ZK_CONFIG_PATH":"...","GENERATED_AT":"..."}}' | npx --ignore-scripts @aaronbassett/template-engine
+PLUGIN_ROOT=$(find ~/.claude -path "*/compact-cli-dev/.claude-plugin/plugin.json" -exec dirname {} \; 2>/dev/null | head -1 | xargs dirname)
+echo '{"template":"<TEMPLATE_DIR>","output":"<directory>","context":{"PROJECT_NAME":"...","CLI_PACKAGE_NAME":"...","CONTRACT_NAME":"...","CONTRACT_PACKAGE":"...","CONTRACT_ZK_CONFIG_PATH":"...","GENERATED_AT":"..."}}' | node "$PLUGIN_ROOT/skills/core/scripts/render-template.mjs"
 ```
 
-The template engine will:
+The renderer will:
 - Copy all files from the template directory to the output directory
 - Substitute `{{VARIABLE}}` placeholders in `.tmpl` files and rename them (removing `.tmpl`)
-- Copy non-template files as-is
+- Copy non-template (and binary) files as-is
 
 Parse the stdout JSON result. On success it returns `{"output": "<absolute path>", "files": <number>}` where `output` is the resolved output directory and `files` is the count of files created. If it fails, the process exits with code 1 and stderr contains a JSON error like `{"error": "<message>"}` -- report the error message to the user.
 

--- a/plugins/compact-cli-dev/skills/core/scripts/render-template.mjs
+++ b/plugins/compact-cli-dev/skills/core/scripts/render-template.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+// Vendored template renderer for /compact-cli-dev:init.
+//
+// Self-contained, zero runtime dependencies (Node's stdlib only) so a fresh
+// user never has to install anything. Ported from the former
+// @aaronbassett/template-engine package (packages/template-engine).
+//
+// Reads a single JSON job from stdin:
+//   {"template": "<dir>", "output": "<dir>", "context": {"KEY": "value", ...}}
+//
+// Copies the template directory to the output directory, substituting
+// {{KEY}} placeholders in text files and stripping the .tmpl extension from
+// rendered filenames. Binary files are copied byte-for-byte.
+//
+// On success prints {"output": "<abs path>", "files": <count>} to stdout.
+// On failure prints {"error": "<message>"} to stderr and exits 1.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const BINARY_EXTENSIONS = new Set([
+	// Images
+	".png",
+	".jpg",
+	".jpeg",
+	".gif",
+	".bmp",
+	".webp",
+	".ico",
+	".tiff",
+	".tif",
+	// Fonts
+	".woff",
+	".woff2",
+	".ttf",
+	".eot",
+	".otf",
+	// Archives
+	".zip",
+	".tar",
+	".gz",
+	".bz2",
+	".7z",
+	".rar",
+	// Compiled / binary
+	".wasm",
+	".exe",
+	".dll",
+	".so",
+	".dylib",
+	".o",
+	".a",
+	// Media
+	".mp3",
+	".mp4",
+	".avi",
+	".mov",
+	".flv",
+	".ogg",
+	".wav",
+	// Documents
+	".pdf",
+	".doc",
+	".docx",
+	".xls",
+	".xlsx",
+	".ppt",
+	".pptx",
+	// Database
+	".sqlite",
+	".db",
+]);
+
+function isBinaryPath(filePath) {
+	return BINARY_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+function substitute(content, context) {
+	let result = content;
+	for (const [key, value] of Object.entries(context)) {
+		result = result.replaceAll(`{{${key}}}`, value);
+	}
+	return result;
+}
+
+function copyRecursive(src, dest, context) {
+	let fileCount = 0;
+	const entries = fs.readdirSync(src, { withFileTypes: true });
+
+	for (const entry of entries) {
+		const srcPath = path.join(src, entry.name);
+
+		// Determine output filename — strip .tmpl extension
+		const outputName = entry.name.endsWith(".tmpl") ? entry.name.slice(0, -5) : entry.name;
+		const destPath = path.join(dest, outputName);
+
+		if (entry.isDirectory()) {
+			fs.mkdirSync(destPath, { recursive: true });
+			fileCount += copyRecursive(srcPath, destPath, context);
+		} else {
+			if (isBinaryPath(srcPath)) {
+				fs.copyFileSync(srcPath, destPath);
+			} else {
+				const content = fs.readFileSync(srcPath, "utf-8");
+				fs.writeFileSync(destPath, substitute(content, context));
+			}
+			fileCount++;
+		}
+	}
+
+	return fileCount;
+}
+
+function processTemplate(input) {
+	const templateDir = path.resolve(input.template);
+	const outputDir = path.resolve(input.output);
+
+	if (!fs.existsSync(templateDir)) {
+		throw new Error(`Template directory does not exist: ${templateDir}`);
+	}
+
+	if (fs.existsSync(outputDir)) {
+		throw new Error(`Output directory already exists: ${outputDir}`);
+	}
+
+	fs.mkdirSync(outputDir, { recursive: true });
+	const fileCount = copyRecursive(templateDir, outputDir, input.context);
+
+	return { output: outputDir, files: fileCount };
+}
+
+function readStdin() {
+	return new Promise((resolve, reject) => {
+		const chunks = [];
+		process.stdin.setEncoding("utf-8");
+		process.stdin.on("data", (chunk) => chunks.push(chunk));
+		process.stdin.on("end", () => resolve(chunks.join("")));
+		process.stdin.on("error", reject);
+	});
+}
+
+function isValidInput(value) {
+	if (typeof value !== "object" || value === null) return false;
+	return (
+		typeof value.template === "string" &&
+		typeof value.output === "string" &&
+		typeof value.context === "object" &&
+		value.context !== null
+	);
+}
+
+async function main() {
+	let raw;
+	try {
+		raw = await readStdin();
+	} catch {
+		process.stderr.write(`${JSON.stringify({ error: "Failed to read stdin" })}\n`);
+		process.exit(1);
+	}
+
+	let input;
+	try {
+		const parsed = JSON.parse(raw);
+		if (!isValidInput(parsed)) {
+			throw new Error(
+				'Invalid input. Expected {"template": string, "output": string, "context": {...}}',
+			);
+		}
+		input = parsed;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : "Invalid JSON input";
+		process.stderr.write(`${JSON.stringify({ error: message })}\n`);
+		process.exit(1);
+	}
+
+	try {
+		const result = processTemplate(input);
+		process.stdout.write(`${JSON.stringify(result)}\n`);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : "Template processing failed";
+		process.stderr.write(`${JSON.stringify({ error: message })}\n`);
+		process.exit(1);
+	}
+}
+
+main();

--- a/plugins/midnight-expert/.claude-plugin/plugin.json
+++ b/plugins/midnight-expert/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-expert",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Meta-plugin for the midnight-expert marketplace. Provides comprehensive diagnostics and health reporting for the entire midnight-expert ecosystem — plugin installation, MCP server connectivity, external CLI tools, cross-plugin references, and NPM registry access.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-expert/skills/doctor/SKILL.md
+++ b/plugins/midnight-expert/skills/doctor/SKILL.md
@@ -169,7 +169,7 @@ Present a final summary:
 - `${CLAUDE_SKILL_DIR}/scripts/check-mcp-servers.sh` — MCP server configuration and connectivity
 - `${CLAUDE_SKILL_DIR}/scripts/check-ext-tools.sh` — External CLI tool availability and versions
 - `${CLAUDE_SKILL_DIR}/scripts/check-cross-refs.sh` — Cross-plugin skill / agent / command reference validation
-- `${CLAUDE_SKILL_DIR}/scripts/check-npm.sh` — NPM registry reachability, @midnight-ntwrk scope, and per-package availability for `@aaronbassett/midnight-fact-checker-utils` and `@aaronbassett/template-engine`
+- `${CLAUDE_SKILL_DIR}/scripts/check-npm.sh` — NPM registry reachability and @midnight-ntwrk scope accessibility
 
 ### References
 - `references/fix-table.md` — Fix recipes for all issue types with platform-specific commands

--- a/plugins/midnight-expert/skills/doctor/references/fix-table.md
+++ b/plugins/midnight-expert/skills/doctor/references/fix-table.md
@@ -85,5 +85,3 @@ The cross-refs check resolves three reference types: skills (`skills/<name>/SKIL
 |-------|-----|
 | Registry unreachable | Check network connection and proxy settings |
 | @midnight-ntwrk scope inaccessible | Check npm config — no custom registry configuration is needed for @midnight-ntwrk packages |
-| `@aaronbassett/midnight-fact-checker-utils` not published | Trigger the `Publish - Fact Checker Utils` workflow on GitHub (Actions tab → Run workflow). Until published, `/midnight-fact-check:check` and `/midnight-fact-check:fast-check` cannot run. |
-| `@aaronbassett/template-engine` not published | Trigger the `Publish - Template Engine` workflow on GitHub. Until published, `/compact-cli-dev:init` cannot run. |

--- a/plugins/midnight-expert/skills/doctor/scripts/check-npm.sh
+++ b/plugins/midnight-expert/skills/doctor/scripts/check-npm.sh
@@ -28,20 +28,6 @@ else
   exit 0
 fi
 
-# Helper: probe a package's published version, emit a row.
-# Args: <pkg> <reason-needed>
-check_package() {
-  local pkg="$1"
-  local needed_by="$2"
-  local ver
-  ver="$(npm view "$pkg" version 2>/dev/null)" || ver=""
-  if [ -n "$ver" ]; then
-    emit "$pkg" "pass" "v${ver} on npm"
-  else
-    emit "$pkg" "critical" "not published — $needed_by will fail"
-  fi
-}
-
 # Canary check on @midnight-ntwrk scope (no custom registry config required).
 canary_version="$(npm view @midnight-ntwrk/compact-runtime version 2>/dev/null)" || canary_version=""
 if [ -n "$canary_version" ]; then
@@ -50,6 +36,6 @@ else
   emit "@midnight-ntwrk scope" "warn" "could not resolve @midnight-ntwrk/compact-runtime — check npm config (no custom registry needed)"
 fi
 
-# Workflow-published utility packages used by plugin commands.
-check_package "@aaronbassett/midnight-fact-checker-utils" "midnight-fact-check commands (check, fast-check)"
-check_package "@aaronbassett/template-engine" "compact-cli-dev:init"
+# Note: /midnight-fact-check (check, fast-check) and /compact-cli-dev:init no
+# longer depend on any external npm package — their helpers are vendored into
+# the plugins (dependency-free Node scripts), so there is nothing to probe here.

--- a/plugins/midnight-fact-check/.claude-plugin/plugin.json
+++ b/plugins/midnight-fact-check/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-fact-check",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Fact-checking pipeline for Midnight content \u2014 extracts testable claims from any source (markdown, code, PDFs, URLs, GitHub repos), classifies them by domain (Compact, SDK, ZKIR, Witness), and verifies each claim using the midnight-verify framework. Produces structured JSON artifacts and human-readable reports.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-fact-check/commands/check.md
+++ b/plugins/midnight-fact-check/commands/check.md
@@ -1,7 +1,7 @@
 ---
 name: midnight-fact-check:check
 description: Fact-check content against the Midnight ecosystem. Extracts claims, classifies by domain, verifies each via midnight-verify, and produces a report.
-allowed-tools: Agent, AskUserQuestion, Read, Write, Glob, Grep, Bash, Skill
+allowed-tools: Agent, AskUserQuestion, Read, Write, Glob, Grep, Bash, Skill, WebFetch
 argument-hint: "<file, directory, URL, GitHub URL, or glob pattern>"
 ---
 
@@ -58,10 +58,7 @@ Parse `$ARGUMENTS` and resolve each target to readable content. Classify each ta
 
 ### Local directory (non-plugin)
 - Detected by: path exists, is a directory, does NOT contain `.claude-plugin/plugin.json`
-- Run file discovery:
-  ```bash
-  npx --ignore-scripts @aaronbassett/midnight-fact-checker-utils discover "**/*" --cwd "[directory path]"
-  ```
+- Discover files with the **Glob** tool: pattern `**/*` with `path` set to the directory. When presenting the list, ignore noise that is never source content: `node_modules`, `.git`, `dist`/build output, and lock files.
 - Show the matched file list to the user and ask for confirmation before proceeding.
 
 ### Plugin directory
@@ -71,10 +68,8 @@ Parse `$ARGUMENTS` and resolve each target to readable content. Classify each ta
 
 ### URL(s)
 - Detected by: starts with `http://` or `https://`, does NOT match `github.com`
-- For each URL, run:
-  ```bash
-  npx --ignore-scripts @aaronbassett/midnight-fact-checker-utils extract-url "[URL]" > "$RUN_DIR/url-content-N.md"
-  ```
+- For each URL, use the **WebFetch** tool with this prompt: "Return the full readable article/page content converted to clean Markdown. Preserve every technical detail verbatim — code blocks, command lines, version numbers, package names, API signatures, and error strings. Do not summarize, paraphrase, or omit anything."
+- Write the returned Markdown to `$RUN_DIR/url-content-N.md` (one file per URL, N starting at 1), with a leading `> Source: [URL]` line so provenance is preserved.
 - Add the saved markdown files to the content list.
 
 ### GitHub file URL
@@ -98,10 +93,7 @@ Parse `$ARGUMENTS` and resolve each target to readable content. Classify each ta
 
 ### Glob pattern
 - Detected by: contains `*`, `?`, `[`, or `{`
-- Run file discovery:
-  ```bash
-  npx --ignore-scripts @aaronbassett/midnight-fact-checker-utils discover "[pattern]"
-  ```
+- Discover files with the **Glob** tool using the pattern directly. Ignore `node_modules`, `.git`, `dist`/build output, and lock files when presenting the list.
 - Show matched file list to user and ask for confirmation.
 
 ### After all targets are resolved
@@ -143,9 +135,10 @@ Tell the user: `"Resolved N files from M targets"`
    - Instruction to read the files and extract claims
 4. Collect the JSON arrays returned by each extractor.
 5. Write each extractor's output to the run directory: `extracted-chunk-N.json`
-6. Merge all outputs using the merge script in concat mode:
+6. Merge all outputs using the vendored merge script in concat mode. The script (`skills/fact-check-extraction/scripts/merge.mjs`) is dependency-free and needs only Node — there is nothing to install. Re-resolve the plugin root in the same command, since shell variables do not persist between steps:
    ```bash
-   npx --ignore-scripts @aaronbassett/midnight-fact-checker-utils merge --mode concat -o "$RUN_DIR/extracted-claims.json" "$RUN_DIR/extracted-chunk-1.json" "$RUN_DIR/extracted-chunk-2.json" ...
+   PLUGIN_ROOT=$(find ~/.claude -path "*/midnight-fact-check/.claude-plugin/plugin.json" -exec dirname {} \; 2>/dev/null | head -1 | xargs dirname)
+   node "$PLUGIN_ROOT/skills/fact-check-extraction/scripts/merge.mjs" --mode concat -o "$RUN_DIR/extracted-claims.json" "$RUN_DIR/extracted-chunk-1.json" "$RUN_DIR/extracted-chunk-2.json" ...
    ```
 7. Read the merged file. Assign sequential IDs (`claim-001`, `claim-002`, ...) to each claim. Write back.
 8. Tell the user: `"Extracted N claims from M content chunks"`
@@ -168,9 +161,10 @@ If zero claims were extracted, tell the user and stop:
    - The path to its copy of the claims file
    - Instruction to tag claims belonging to its domain
 4. Wait for all classifiers to complete.
-5. Merge all copies:
+5. Merge all copies with the vendored merge script in update mode (re-resolve the plugin root in the same command, since shell variables do not persist between steps):
    ```bash
-   npx --ignore-scripts @aaronbassett/midnight-fact-checker-utils merge --mode update --original "$RUN_DIR/extracted-claims.json" -o "$RUN_DIR/classified-claims.json" "$RUN_DIR/extracted-claims.compact-classifier.json" "$RUN_DIR/extracted-claims.sdk-classifier.json" "$RUN_DIR/extracted-claims.zkir-classifier.json" "$RUN_DIR/extracted-claims.witness-classifier.json"
+   PLUGIN_ROOT=$(find ~/.claude -path "*/midnight-fact-check/.claude-plugin/plugin.json" -exec dirname {} \; 2>/dev/null | head -1 | xargs dirname)
+   node "$PLUGIN_ROOT/skills/fact-check-extraction/scripts/merge.mjs" --mode update --original "$RUN_DIR/extracted-claims.json" -o "$RUN_DIR/classified-claims.json" "$RUN_DIR/extracted-claims.compact-classifier.json" "$RUN_DIR/extracted-claims.sdk-classifier.json" "$RUN_DIR/extracted-claims.zkir-classifier.json" "$RUN_DIR/extracted-claims.witness-classifier.json"
    ```
 6. If the merge fails (validation error), tell the user:
    > "Merge validation failed. Agent copies preserved in [run directory] for debugging."

--- a/plugins/midnight-fact-check/commands/fast-check.md
+++ b/plugins/midnight-fact-check/commands/fast-check.md
@@ -1,7 +1,7 @@
 ---
 name: midnight-fact-check:fast-check
 description: Fast fact-check content against the Midnight ecosystem. Extracts claims, verifies each via source inspection (skipping classification and execution), and produces a report.
-allowed-tools: Agent, AskUserQuestion, Read, Write, Glob, Grep, Bash, Skill
+allowed-tools: Agent, AskUserQuestion, Read, Write, Glob, Grep, Bash, Skill, WebFetch
 argument-hint: "<file, directory, URL, GitHub URL, or glob pattern>"
 ---
 
@@ -59,10 +59,7 @@ Parse `$ARGUMENTS` and resolve each target to readable content. Classify each ta
 
 ### Local directory (non-plugin)
 - Detected by: path exists, is a directory, does NOT contain `.claude-plugin/plugin.json`
-- Run file discovery:
-  ```bash
-  npx --ignore-scripts @aaronbassett/midnight-fact-checker-utils discover "**/*" --cwd "[directory path]"
-  ```
+- Discover files with the **Glob** tool: pattern `**/*` with `path` set to the directory. When presenting the list, ignore noise that is never source content: `node_modules`, `.git`, `dist`/build output, and lock files.
 - Show the matched file list to the user and ask for confirmation before proceeding.
 
 ### Plugin directory
@@ -72,10 +69,8 @@ Parse `$ARGUMENTS` and resolve each target to readable content. Classify each ta
 
 ### URL(s)
 - Detected by: starts with `http://` or `https://`, does NOT match `github.com`
-- For each URL, run:
-  ```bash
-  npx --ignore-scripts @aaronbassett/midnight-fact-checker-utils extract-url "[URL]" > "$RUN_DIR/url-content-N.md"
-  ```
+- For each URL, use the **WebFetch** tool with this prompt: "Return the full readable article/page content converted to clean Markdown. Preserve every technical detail verbatim — code blocks, command lines, version numbers, package names, API signatures, and error strings. Do not summarize, paraphrase, or omit anything."
+- Write the returned Markdown to `$RUN_DIR/url-content-N.md` (one file per URL, N starting at 1), with a leading `> Source: [URL]` line so provenance is preserved.
 - Add the saved markdown files to the content list.
 
 ### GitHub file URL
@@ -99,10 +94,7 @@ Parse `$ARGUMENTS` and resolve each target to readable content. Classify each ta
 
 ### Glob pattern
 - Detected by: contains `*`, `?`, `[`, or `{`
-- Run file discovery:
-  ```bash
-  npx --ignore-scripts @aaronbassett/midnight-fact-checker-utils discover "[pattern]"
-  ```
+- Discover files with the **Glob** tool using the pattern directly. Ignore `node_modules`, `.git`, `dist`/build output, and lock files when presenting the list.
 - Show matched file list to user and ask for confirmation.
 
 ### After all targets are resolved
@@ -144,9 +136,10 @@ Tell the user: `"Resolved N files from M targets"`
    - Instruction to read the files and extract claims
 4. Collect the JSON arrays returned by each extractor.
 5. Write each extractor's output to the run directory: `extracted-chunk-N.json`
-6. Merge all outputs using the merge script in concat mode:
+6. Merge all outputs using the vendored merge script in concat mode. The script (`skills/fact-check-extraction/scripts/merge.mjs`) is dependency-free and needs only Node — there is nothing to install. Re-resolve the plugin root in the same command, since shell variables do not persist between steps:
    ```bash
-   npx --ignore-scripts @aaronbassett/midnight-fact-checker-utils merge --mode concat -o "$RUN_DIR/extracted-claims.json" "$RUN_DIR/extracted-chunk-1.json" "$RUN_DIR/extracted-chunk-2.json" ...
+   PLUGIN_ROOT=$(find ~/.claude -path "*/midnight-fact-check/.claude-plugin/plugin.json" -exec dirname {} \; 2>/dev/null | head -1 | xargs dirname)
+   node "$PLUGIN_ROOT/skills/fact-check-extraction/scripts/merge.mjs" --mode concat -o "$RUN_DIR/extracted-claims.json" "$RUN_DIR/extracted-chunk-1.json" "$RUN_DIR/extracted-chunk-2.json" ...
    ```
 7. Read the merged file. Assign sequential IDs (`claim-001`, `claim-002`, ...) to each claim. Write back.
 8. Tell the user: `"Extracted N claims from M content chunks"`

--- a/plugins/midnight-fact-check/skills/fact-check-extraction/scripts/merge.mjs
+++ b/plugins/midnight-fact-check/skills/fact-check-extraction/scripts/merge.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// Vendored JSON claim merger for /midnight-fact-check:check and :fast-check.
+//
+// Self-contained, zero runtime dependencies (Node's stdlib only) so a fresh
+// user never has to install anything. Ported from the `merge` command of the
+// former @aaronbassett/midnight-fact-checker-utils package
+// (packages/midnight-fact-checker-utils).
+//
+// Usage:
+//   node merge.mjs --mode concat -o <output> <file...>
+//   node merge.mjs --mode update --original <orig> -o <output> <file...>
+//
+//   concat: concatenate JSON arrays into a single array (Stage 1 extraction).
+//   update: deep-merge each update file's claims into the original by `id`,
+//           preserving original order and count (Stage 2 classification).
+//
+// On success prints "Merged N items to <path>" to stdout (exit 0).
+// On failure prints "Merge failed: <error>" to stderr and exits 1.
+
+import { readFile, writeFile } from "node:fs/promises";
+
+async function readJsonFile(filePath) {
+	const content = await readFile(filePath, "utf-8");
+	try {
+		return JSON.parse(content);
+	} catch {
+		throw new Error(`Invalid JSON in file: ${filePath}`);
+	}
+}
+
+function validateClaimArray(data, source) {
+	if (!Array.isArray(data)) {
+		throw new Error(`Expected JSON array in ${source}, got ${typeof data}`);
+	}
+	for (let i = 0; i < data.length; i++) {
+		const item = data[i];
+		if (typeof item !== "object" || item === null || !("id" in item)) {
+			throw new Error(`Item at index ${i} in ${source} is missing required "id" field`);
+		}
+		if (typeof item.id !== "string") {
+			throw new Error(`Item at index ${i} in ${source} has non-string "id" field`);
+		}
+	}
+	return data;
+}
+
+function validateJsonArray(data, source) {
+	if (!Array.isArray(data)) {
+		throw new Error(`Expected JSON array in ${source}, got ${typeof data}`);
+	}
+	return data;
+}
+
+// Deep merges two objects. Arrays are replaced, not concatenated.
+// Nested plain objects are recursively merged.
+function deepMerge(base, overlay) {
+	const result = { ...base };
+	for (const key of Object.keys(overlay)) {
+		const baseVal = base[key];
+		const overlayVal = overlay[key];
+		if (
+			typeof baseVal === "object" &&
+			baseVal !== null &&
+			!Array.isArray(baseVal) &&
+			typeof overlayVal === "object" &&
+			overlayVal !== null &&
+			!Array.isArray(overlayVal)
+		) {
+			result[key] = deepMerge(baseVal, overlayVal);
+		} else {
+			result[key] = overlayVal;
+		}
+	}
+	return result;
+}
+
+async function mergeConcat(inputPaths) {
+	const combined = [];
+	for (const p of inputPaths) {
+		const data = await readJsonFile(p);
+		const items = validateJsonArray(data, p);
+		combined.push(...items);
+	}
+	return combined;
+}
+
+async function mergeUpdate(originalPath, inputPaths) {
+	const originalData = await readJsonFile(originalPath);
+	const originalClaims = validateClaimArray(originalData, originalPath);
+
+	const claimMap = new Map();
+	for (const claim of originalClaims) {
+		claimMap.set(claim.id, { ...claim });
+	}
+
+	const originalCount = claimMap.size;
+
+	for (const p of inputPaths) {
+		const data = await readJsonFile(p);
+		const updates = validateClaimArray(data, p);
+		for (const update of updates) {
+			const existing = claimMap.get(update.id);
+			if (!existing) {
+				throw new Error(
+					`Update file "${p}" contains unknown claim id "${update.id}" not present in original`,
+				);
+			}
+			claimMap.set(update.id, deepMerge(existing, update));
+		}
+	}
+
+	if (claimMap.size !== originalCount) {
+		throw new Error(
+			`Claim count mismatch: original has ${originalCount} claims but result has ${claimMap.size}`,
+		);
+	}
+
+	return originalClaims.map((c) => c.id).map((id) => claimMap.get(id));
+}
+
+function parseArgs(argv) {
+	const opts = { mode: "update", original: undefined, output: undefined, inputs: [] };
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "--mode") {
+			opts.mode = argv[++i];
+		} else if (arg === "--original") {
+			opts.original = argv[++i];
+		} else if (arg === "-o" || arg === "--output") {
+			opts.output = argv[++i];
+		} else {
+			opts.inputs.push(arg);
+		}
+	}
+	return opts;
+}
+
+async function main() {
+	const opts = parseArgs(process.argv.slice(2));
+
+	if (!opts.output) {
+		process.stderr.write("Error: --output (-o) is required\n");
+		process.exit(1);
+	}
+
+	if (opts.mode !== "concat" && opts.mode !== "update") {
+		process.stderr.write(`Error: --mode must be "concat" or "update", got "${opts.mode}"\n`);
+		process.exit(1);
+	}
+
+	try {
+		let result;
+		if (opts.mode === "concat") {
+			result = await mergeConcat(opts.inputs);
+		} else {
+			if (!opts.original) {
+				throw new Error("Update mode requires an --original file path");
+			}
+			result = await mergeUpdate(opts.original, opts.inputs);
+		}
+
+		const json = JSON.stringify(result, null, 2);
+		await writeFile(opts.output, `${json}\n`, "utf-8");
+		process.stdout.write(`Merged ${result.length} items to ${opts.output}\n`);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : "Unknown error";
+		process.stderr.write(`Merge failed: ${message}\n`);
+		process.exit(1);
+	}
+}
+
+main();


### PR DESCRIPTION
## Problem

Both `/midnight-fact-check` (check, fast-check) and `/compact-cli-dev:init` depended on `@aaronbassett/*` packages that are **not published to public npm**, so the `npx` calls stalled for every external user. (From the Korean-developer walkthrough feedback.)

## Fix — vendor the logic, drop the external deps

- **compact-cli-dev**: faithful port of `@aaronbassett/template-engine` → `skills/core/scripts/render-template.mjs` (dependency-free Node). `init.md` runs it via `node`, re-resolving `PLUGIN_ROOT` in-command.
- **midnight-fact-check**: faithful port of the `merge` command → `skills/fact-check-extraction/scripts/merge.mjs` (concat + id-keyed deep-merge with count validation). The other two former subcommands map onto agent-native tools: `discover` → **Glob**, `extract-url` → **WebFetch** (added to allowed-tools). No external npm dep remains.
- **doctor**: drop the now-irrelevant "is it published" probes for the two packages from `check-npm.sh`, `fix-table.md`, `SKILL.md`.

## Verification

- `render-template.mjs` reproduces the real CLI template exactly (35 files, `.tmpl` stripped, all placeholders substituted, tree identical).
- `merge.mjs` passes concat, id-keyed update (order + count preserved), and error paths.

Plugins bumped: compact-cli-dev 0.5.0, midnight-fact-check 0.5.0, midnight-expert 0.7.0.

Generated with [Claude Code](https://claude.com/claude-code)