### PR TITLE
fix: document the error-117 additionalFeeOverhead fix; enrich status codes 117/138

### DIFF
--- a/plugins/midnight-status-codes/.claude-plugin/plugin.json
+++ b/plugins/midnight-status-codes/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-status-codes",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Catalog and lookup for all Midnight ecosystem error codes, status codes, and error types across the node, ledger, indexer, wallet, SDK, compiler, compact runtime, proof server, and DApp connector.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-status-codes/skills/status-codes-lookup/scripts/codes.json
+++ b/plugins/midnight-status-codes/skills/status-codes-lookup/scripts/codes.json
@@ -1420,22 +1420,29 @@
         "name": "Transaction Malformed Errors (110-139, 166-192)",
         "description": "Transactions that are structurally invalid or fail proof verification."
       },
-      "description": "The transaction is not in normalized form.",
+      "description": "The transaction is not in normal form. The most common cause on a local devnet is a zero fee: when feesWithMargin evaluates to 0 and no additionalFeeOverhead is set, the wallet builds an empty DustActions, which DustActions::well_formed rejects. A ContractDeploy is accepted but the first contract call fails; there is no special minimum-cost floor on ContractDeploy.",
       "fixes": [
-        "Use the SDK to build normalized transactions"
+        "Set a small positive additionalFeeOverhead (e.g. 1_000_000n) in the wallet's costParameters so a real DUST fee is spent",
+        "Any positive amount the wallet can cover in DUST works (the basic-start tutorial and compact-cli-dev template use 300_000_000_000_000n)",
+        "Build the transaction with the SDK so it is normalized"
       ],
       "aliases": [
         "TransactionMalformed(NotNormalized)",
         "InvalidTransaction::Custom(117)"
       ],
       "severity": "error",
-      "see_also": [],
+      "see_also": [
+        "138",
+        "173",
+        "1010"
+      ],
+      "reference_anchor": "skills/status-codes/references/node-errors.md#idle-devnet-dust-fee-pitfalls-117-notnormalized-and-138-balancecheckoverspend",
       "verified_against": {
         "source_repo": "midnightntwrk/midnight-node",
         "ref": "main",
-        "anchor": "ledger/src/versions/common/types.rs",
+        "anchor": "ledger/src/versions/common/types.rs:435",
         "anchor_modified": "2026-05-01",
-        "verified_at": "2026-05-04"
+        "verified_at": "2026-06-11"
       }
     },
     {
@@ -1994,22 +2001,29 @@
         "name": "Transaction Malformed Errors (110-139, 166-192)",
         "description": "Transactions that are structurally invalid or fail proof verification."
       },
-      "description": "The transaction overspends the available balance.",
+      "description": "A token balance went negative after fees were applied (balancing_check, midnight-ledger ledger/src/verify.rs). The transaction or one of its segments spends more of a token than it has once fees are applied. Because fees are paid in DUST, a DUST-side 138 means the DUST fee exceeded available DUST — not a NIGHT funding-level problem. DUST registration does NOT cause this: registration is self-funding (its fee is paid by the DUST the registered NIGHT UTXOs generate, not the wallet's existing DUST balance), so it succeeds even at a 0 DUST balance — verified on a local devnet, including with additionalFeeOverhead set.",
       "fixes": [
-        "Reduce the transaction outputs or add more inputs"
+        "Reduce the transaction outputs or add more inputs of the overspent token",
+        "For a DUST-side overspend, ensure the wallet holds enough DUST for the fee",
+        "Do not raise NIGHT funding to fix this — fees are denominated in DUST, not NIGHT"
       ],
       "aliases": [
         "TransactionMalformed(BalanceCheckOverspend)",
         "InvalidTransaction::Custom(138)"
       ],
       "severity": "error",
-      "see_also": [],
+      "see_also": [
+        "117",
+        "173",
+        "1010"
+      ],
+      "reference_anchor": "skills/status-codes/references/node-errors.md#idle-devnet-dust-fee-pitfalls-117-notnormalized-and-138-balancecheckoverspend",
       "verified_against": {
         "source_repo": "midnightntwrk/midnight-node",
         "ref": "main",
-        "anchor": "ledger/src/versions/common/types.rs",
+        "anchor": "ledger/src/versions/common/types.rs:462",
         "anchor_modified": "2026-05-01",
-        "verified_at": "2026-05-04"
+        "verified_at": "2026-06-11"
       }
     },
     {

--- a/plugins/midnight-status-codes/skills/status-codes/references/node-errors.md
+++ b/plugins/midnight-status-codes/skills/status-codes/references/node-errors.md
@@ -68,6 +68,24 @@ Where `N` is the inner `LedgerApiError` u8 (0–255). To diagnose:
 
 > **Note on protocol versions.** The 1010 envelope is stable upstream substrate. The inner u8 mapping is Midnight-specific and **changes across ledger versions**: codes get added, retired, and (rarely) renumbered. Treat the tables below as the mapping for the current ledger only; archived chains/explorers may show u8 values from earlier mappings.
 
+### Idle-devnet DUST-fee pitfalls: 117 (NotNormalized) and 138 (BalanceCheckOverspend)
+
+These two are the most common early stumbling blocks on a freshly-started **local devnet**, where the per-block fee rate is effectively zero. Both come down to **how much DUST a transaction spends on fees** — all fees are denominated in **DUST**, never NIGHT.
+
+**117 — the fee computed to zero, so the DUST spend set was empty.** The wallet computes a transaction's fee as roughly `feesWithMargin(ledgerParams, feeBlocksMargin) + (additionalFeeOverhead ?? 0n)` (`calculateFee`, midnight-wallet `packages/dust-wallet/src/v1/Transacting.ts`). On an idle devnet `feesWithMargin` evaluates to `0`, so with no `additionalFeeOverhead` the fee is `0`. A zero fee gives the balancer no imbalance to cover, so it adds no DUST inputs and the transaction is built with an **empty `DustActions`**. `DustActions::well_formed` (midnight-ledger `ledger/src/dust.rs:773`) rejects empty dust actions, which the node maps to `NotNormalized` = **117** (midnight-node `ledger/src/versions/common/types.rs:435`). On submission it surfaces as `1010: Invalid Transaction: Custom error: 117`.
+
+In practice a `ContractDeploy` is accepted but the **first contract call fails** with 117. This deploy/call asymmetry is empirical — there is **no special minimum-cost floor on `ContractDeploy`** in the source, so don't assume one.
+
+**Fix:** give the wallet a small positive `additionalFeeOverhead` so a real DUST fee is spent:
+
+```ts
+costParameters: { feeBlocksMargin: 5, additionalFeeOverhead: 1_000_000n }
+```
+
+Any positive amount the wallet can cover in DUST works (the basic-start tutorial and the compact-cli-dev template use `300_000_000_000_000n`). The fix is verified end-to-end on a local devnet: with overhead `0n` the first contract call is rejected with 117; with `1_000_000n` both the deploy and the call succeed.
+
+**138 — a token balance went negative after fees.** `BalanceCheckOverspend` = **138** (midnight-node `ledger/src/versions/common/types.rs:462`) fires from `balancing_check` (midnight-ledger `ledger/src/verify.rs:1297`) when a transaction (or one of its segments) spends more of a token than it has available once fees are applied. Because fees are paid in **DUST**, a DUST-side 138 means the transaction's DUST fee exceeded the wallet's available DUST — raising NIGHT does **not** fix it. **DUST registration does not trigger this**, despite running at a `0` DUST balance: registration is self-funding — its fee is paid by the DUST the registered NIGHT UTXOs generate (`generatedNow`), not from the wallet's existing DUST balance. A wallet funded with as little as 5 NIGHT registers successfully (verified on a local devnet at 5, 100, and 10,000 NIGHT — all succeeded; setting `additionalFeeOverhead` during registration was also verified not to change this). See also 173 (`InsufficientDustForRegistrationFee`).
+
 ---
 
 ## Error Tables by Code Range
@@ -159,7 +177,7 @@ Group: "Structural validity errors caught before applying the transaction to led
 | 114 | ContractNotPresent | Transaction references a non-existent contract | Verify contract address; deploy the contract first |
 | 115 | InvalidProof | Zero-knowledge proof verification failed | Regenerate the proof; ensure proof server is compatible |
 | 116 | BindingCommitmentOpeningInvalid | Binding commitment was incorrectly opened | Internal Zswap error — rebuild the transaction |
-| 117 | NotNormalized | Transaction is not in normal form | Rebuild with the SDK; transactions must be normalized |
+| 117 | NotNormalized | Transaction is not in normal form — most often an idle-devnet zero fee that produced an empty DUST spend set | Set a small positive `additionalFeeOverhead` (e.g. `1_000_000n`) at wallet construction; see the idle-devnet DUST-fee deep dive above |
 | 118 | FallibleWithoutCheckpoint | Fallible transcript missing initial checkpoint | Add kernel.checkpoint() at the start of fallible sections |
 | 119 | ClaimReceiveFailed | Failed to claim a coin commitment receive | Coin commitment format error; rebuild the transaction |
 | 120 | ClaimSpendFailed | Failed to claim a coin commitment spend | Coin commitment format error; rebuild the transaction |
@@ -180,7 +198,7 @@ Group: "Structural validity errors caught before applying the transaction to led
 | 135 | InvalidCommitteeSignature | Committee signature verification failed | Verify the signing key and signature |
 | 136 | ThresholdMissed | Committee approval threshold not met | Gather more committee signatures |
 | 137 | TooManyZswapEntries | Too many Zswap entries (>=2^16) | Reduce the number of shielded operations |
-| 138 | BalanceCheckOverspend | Negative balance in a transaction segment | Segment spends more than available; check amounts |
+| 138 | BalanceCheckOverspend | A token balance went negative after fees — the tx (or a segment) spends more than it has once fees are applied; fees are paid in DUST, not NIGHT | Reduce outputs or add inputs; for a DUST-side 138 ensure enough DUST (raising NIGHT won't help). DUST registration is self-funding and does not cause this. See the idle-devnet DUST-fee deep dive above |
 | 139 | UnknownError | Unclassified malformed transaction error | Check node logs for details |
 | 166 | InvalidNetworkId | Transaction's network ID doesn't match the node's network | Verify networkId matches the target (e.g., 'undeployed' for devnet); check setNetworkId() |
 | 167 | IllegallyDeclaredGuaranteed | Guaranteed segment (0) used where forbidden | Don't use segment_id 0 for intents |

--- a/plugins/midnight-wallet/.claude-plugin/plugin.json
+++ b/plugins/midnight-wallet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-wallet",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Wallet SDK reference, test-wallet management patterns, and SDK regression checking for Midnight Network development.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-wallet/skills/managing-test-wallets/examples/full-test-wallet-setup.ts
+++ b/plugins/midnight-wallet/skills/managing-test-wallets/examples/full-test-wallet-setup.ts
@@ -130,11 +130,22 @@ function buildKeysFromSeed(seed: Uint8Array, networkId: Network) {
 
 // ─── Helper: build configuration ─────────────────────────────────────────────
 
-function buildConfiguration(network: Network): DefaultConfiguration {
+// `feeOverhead`, when provided, is added as additionalFeeOverhead so the fee is
+// non-zero on an idle local devnet (a zero fee is rejected as NotNormalized, 117).
+// Pass it for a wallet that SPENDS (e.g. the genesis sender below). The wallet that
+// only registers DUST does not need it: DUST registration is self-funding (the fee
+// is paid by the DUST the registered NIGHT UTXOs generate), so it succeeds at a 0
+// DUST balance with or without the overhead.
+function buildConfiguration(network: Network, feeOverhead?: bigint): DefaultConfiguration {
+  const costParameters =
+    feeOverhead === undefined
+      ? { feeBlocksMargin: 5 }
+      : { feeBlocksMargin: 5, additionalFeeOverhead: feeOverhead };
+
   if (network === "undeployed") {
     return {
       networkId: "undeployed",
-      costParameters: { feeBlocksMargin: 5 },
+      costParameters,
       relayURL: new URL("ws://localhost:9944"),
       provingServerUrl: new URL("http://localhost:6300"),
       indexerClientConnection: {
@@ -148,7 +159,7 @@ function buildConfiguration(network: Network): DefaultConfiguration {
   const netCfg = NETWORK_CONFIG[network];
   return {
     networkId: network,
-    costParameters: { feeBlocksMargin: 5 },
+    costParameters,
     relayURL: netCfg.relayURL,
     // Proof server runs locally even for public testnets.
     provingServerUrl: new URL("http://localhost:6300"),
@@ -244,6 +255,9 @@ async function main() {
     unshieldedKeystore,
   } = buildKeysFromSeed(seed, network);
 
+  // No fee overhead: this wallet only registers DUST below (Step 7), which is
+  // self-funding (paid by the DUST the registered NIGHT UTXOs generate), so it
+  // needs no overhead even at a 0 DUST balance.
   const configuration = buildConfiguration(network);
 
   const wallet = await initWallet(
@@ -284,7 +298,9 @@ async function main() {
       unshieldedKeystore: genKeystore,
     } = buildKeysFromSeed(genesisSeed, "undeployed");
 
-    const senderConfiguration = buildConfiguration("undeployed");
+    // The genesis sender spends (transfers NIGHT) and already holds DUST, so it
+    // gets a fee overhead to keep the fee non-zero on the idle devnet (error 117).
+    const senderConfiguration = buildConfiguration("undeployed", 1_000_000n);
     const sender = await initWallet(
       senderConfiguration,
       genShielded,

--- a/plugins/midnight-wallet/skills/managing-test-wallets/examples/fund-wallet-undeployed.ts
+++ b/plugins/midnight-wallet/skills/managing-test-wallets/examples/fund-wallet-undeployed.ts
@@ -117,7 +117,11 @@ async function main() {
 
   const configuration: DefaultConfiguration = {
     networkId: "undeployed",
-    costParameters: { feeBlocksMargin: 5 },
+    // This wallet is the genesis sender that transfers NIGHT to the new wallet.
+    // additionalFeeOverhead makes its fee non-zero on an idle local devnet, where
+    // feesWithMargin is 0 and a zero-fee transaction is rejected as NotNormalized
+    // (error 117). The genesis wallet already holds DUST, so it can cover the fee.
+    costParameters: { feeBlocksMargin: 5, additionalFeeOverhead: 1_000_000n },
     relayURL: new URL("ws://localhost:9944"),
     provingServerUrl: new URL("http://localhost:6300"),
     indexerClientConnection: {

--- a/plugins/midnight-wallet/skills/managing-test-wallets/examples/register-dust.ts
+++ b/plugins/midnight-wallet/skills/managing-test-wallets/examples/register-dust.ts
@@ -87,6 +87,11 @@ async function main() {
 
   const configuration: DefaultConfiguration = {
     networkId: "undeployed",
+    // No additionalFeeOverhead needed: DUST registration is self-funding — the fee
+    // is paid by the DUST the registered NIGHT UTXOs generate, not from the wallet's
+    // existing DUST balance, so it succeeds even at a 0 DUST balance. (Verified on
+    // a local devnet.) Add additionalFeeOverhead on wallets that submit transfers
+    // or contract calls — see examples/transfer-night.ts.
     costParameters: { feeBlocksMargin: 5 },
     relayURL: new URL("ws://localhost:9944"),
     provingServerUrl: new URL("http://localhost:6300"),

--- a/plugins/midnight-wallet/skills/managing-test-wallets/examples/transfer-night.ts
+++ b/plugins/midnight-wallet/skills/managing-test-wallets/examples/transfer-night.ts
@@ -117,7 +117,10 @@ async function main() {
 
   const configuration: DefaultConfiguration = {
     networkId: "undeployed",
-    costParameters: { feeBlocksMargin: 5 },
+    // additionalFeeOverhead makes the fee non-zero on an idle local devnet, where
+    // feesWithMargin is 0 and a zero-fee transaction is rejected as NotNormalized
+    // (error 117). Any positive amount the wallet can cover in DUST works.
+    costParameters: { feeBlocksMargin: 5, additionalFeeOverhead: 1_000_000n },
     relayURL: new URL("ws://localhost:9944"),
     provingServerUrl: new URL("http://localhost:6300"),
     indexerClientConnection: {

--- a/plugins/midnight-wallet/skills/managing-test-wallets/examples/transfer-shielded.ts
+++ b/plugins/midnight-wallet/skills/managing-test-wallets/examples/transfer-shielded.ts
@@ -105,7 +105,10 @@ async function main() {
 
   const configuration: DefaultConfiguration = {
     networkId: "undeployed",
-    costParameters: { feeBlocksMargin: 5 },
+    // additionalFeeOverhead makes the fee non-zero on an idle local devnet, where
+    // feesWithMargin is 0 and a zero-fee transaction is rejected as NotNormalized
+    // (error 117). Any positive amount the wallet can cover in DUST works.
+    costParameters: { feeBlocksMargin: 5, additionalFeeOverhead: 1_000_000n },
     relayURL: new URL("ws://localhost:9944"),
     provingServerUrl: new URL("http://localhost:6300"),
     indexerClientConnection: {

--- a/plugins/midnight-wallet/skills/managing-test-wallets/references/dust-registration.md
+++ b/plugins/midnight-wallet/skills/managing-test-wallets/references/dust-registration.md
@@ -45,6 +45,28 @@ For the exact `registerNightUtxosForDustGeneration` signature, see
 `/tmp/midnight-wallet/packages/facade/src/index.ts` (during plugin
 maintenance).
 
+## Registration is self-funding — it works at a 0 DUST balance
+
+Registration is the step that *starts* DUST generation, so when it runs the
+wallet's DUST balance is still `0`. That is fine: **registration pays its own
+fee from the DUST the registered NIGHT UTXOs generate** (the SDK builds the
+`DustRegistration` with a `feePayment` equal to the coins' `generatedNow` DUST),
+not from the wallet's existing DUST balance. So a freshly-funded wallet registers
+successfully even with `0` accrued DUST — verified on a local devnet at 5, 100,
+and 10,000 NIGHT, all succeeding.
+
+Two consequences:
+
+- A 138 (`BalanceCheckOverspend`) during registration is **not** a NIGHT
+  funding-level problem — do **not** raise the NIGHT amount to fix one. Fees are
+  denominated in DUST, not NIGHT.
+- You do **not** need to set `additionalFeeOverhead` for registration. Setting it
+  is also harmless (registration still self-funds), but `examples/register-dust.ts`
+  leaves it off to keep the point clear. Add `additionalFeeOverhead` on wallets
+  that submit **transfers or contract calls**, which on an idle devnet otherwise
+  compute a zero fee and are rejected as NotNormalized (error **117** — see
+  `/midnight-status-codes:lookup 117`).
+
 ## DUST has expiry
 
 DUST tokens expire. `state.dust.balance(time)` requires a `Date`

--- a/plugins/midnight-wallet/skills/managing-test-wallets/references/network-config.md
+++ b/plugins/midnight-wallet/skills/managing-test-wallets/references/network-config.md
@@ -14,7 +14,10 @@ import { WalletEntrySchema, type DefaultConfiguration } from '@midnight-ntwrk/wa
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
-  costParameters: { feeBlocksMargin: 5 },
+  // additionalFeeOverhead keeps the fee non-zero on an idle devnet for transfers
+  // and contract calls (else error 117). DUST registration is self-funding and
+  // doesn't need it. Full explanation in wallet-sdk/references/wallet-construction.md.
+  costParameters: { feeBlocksMargin: 5, additionalFeeOverhead: 1_000_000n },
   relayURL: new URL('ws://localhost:9944'),
   provingServerUrl: new URL('http://localhost:6300'),
   indexerClientConnection: {
@@ -56,6 +59,18 @@ const configuration: DefaultConfiguration = {
   txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema),
 };
 ```
+
+## `costParameters.additionalFeeOverhead`
+
+The `preprod`/`preview` examples above omit `additionalFeeOverhead` because public
+networks have a real, non-zero fee rate. It is the **local devnet** that needs it:
+there the per-block fee rate is ~0, so without an overhead a transfer's or contract
+call's fee is 0 and the node rejects it as `NotNormalized` (error 117). DUST
+registration is the one operation that does not need it on any network — it is
+self-funding (paid by the DUST the registered NIGHT UTXOs generate), so it works
+even at a 0 DUST balance. See
+[wallet-sdk/references/wallet-construction.md](../../wallet-sdk/references/wallet-construction.md)
+for the full mechanism.
 
 ## Node WebSocket polyfill
 

--- a/plugins/midnight-wallet/skills/wallet-sdk/examples/basic-wallet-setup.ts
+++ b/plugins/midnight-wallet/skills/wallet-sdk/examples/basic-wallet-setup.ts
@@ -65,6 +65,10 @@ const configuration: DefaultConfiguration = {
   networkId: "undeployed",
   costParameters: {
     feeBlocksMargin: 5,
+    // Forces a non-zero DUST fee so transactions normalize on an idle local
+    // devnet (a zero fee is rejected as NotNormalized, error 117). Any positive
+    // amount the wallet can cover in DUST works.
+    additionalFeeOverhead: 1_000_000n,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
   provingServerUrl: new URL(`http://localhost:${PROOF_SERVER_PORT}`),

--- a/plugins/midnight-wallet/skills/wallet-sdk/examples/dust-registration.ts
+++ b/plugins/midnight-wallet/skills/wallet-sdk/examples/dust-registration.ts
@@ -32,6 +32,11 @@ const PROOF_SERVER_PORT = Number.parseInt(process.env["PROOF_SERVER_PORT"] ?? "6
 
 const configuration: DefaultConfiguration = {
   networkId: "undeployed",
+  // No additionalFeeOverhead needed: DUST registration is self-funding — the fee
+  // is paid by the DUST the registered NIGHT UTXOs generate, not from the wallet's
+  // existing DUST balance, so it succeeds even at a 0 DUST balance. (Verified on a
+  // local devnet.) Add additionalFeeOverhead on wallets that submit transfers or
+  // contract calls — see examples/transfer-flow.ts.
   costParameters: { feeBlocksMargin: 5 },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
   provingServerUrl: new URL(`http://localhost:${PROOF_SERVER_PORT}`),

--- a/plugins/midnight-wallet/skills/wallet-sdk/examples/transfer-flow.ts
+++ b/plugins/midnight-wallet/skills/wallet-sdk/examples/transfer-flow.ts
@@ -32,7 +32,10 @@ const PROOF_SERVER_PORT = Number.parseInt(process.env["PROOF_SERVER_PORT"] ?? "6
 
 const configuration: DefaultConfiguration = {
   networkId: "undeployed",
-  costParameters: { feeBlocksMargin: 5 },
+  // additionalFeeOverhead makes the fee non-zero on an idle local devnet, where
+  // feesWithMargin is 0 and a zero-fee transaction is rejected as NotNormalized
+  // (error 117). Any positive amount the wallet can cover in DUST works.
+  costParameters: { feeBlocksMargin: 5, additionalFeeOverhead: 1_000_000n },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
   provingServerUrl: new URL(`http://localhost:${PROOF_SERVER_PORT}`),
   indexerClientConnection: {

--- a/plugins/midnight-wallet/skills/wallet-sdk/references/wallet-construction.md
+++ b/plugins/midnight-wallet/skills/wallet-sdk/references/wallet-construction.md
@@ -56,6 +56,9 @@ const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   costParameters: {
     feeBlocksMargin: 5,
+    // Forces a non-zero DUST fee. See "costParameters and additionalFeeOverhead"
+    // below — needed for transfers/contract calls on an idle devnet (error 117).
+    additionalFeeOverhead: 1_000_000n,
   },
   relayURL: new URL('ws://localhost:9944'),
   provingServerUrl: new URL('http://localhost:6300'),
@@ -68,6 +71,32 @@ const configuration: DefaultConfiguration = {
 ```
 
 See [infrastructure-clients.md](infrastructure-clients.md) for details on each URL endpoint and how to configure them for testnet/mainnet.
+
+### `costParameters` and `additionalFeeOverhead`
+
+`costParameters` controls how the wallet computes transaction fees (paid in
+**DUST**, never NIGHT):
+
+- `feeBlocksMargin` — how many blocks of fee headroom to add (5 is a safe default).
+- `additionalFeeOverhead` — a flat DUST amount added on top of the computed fee.
+
+On a freshly-started **local devnet** the per-block fee rate is effectively zero,
+so `feesWithMargin` evaluates to `0`. With no `additionalFeeOverhead` the fee is
+`0`, which makes the wallet build an empty DUST spend set — and the node rejects
+that as **NotNormalized (error 117)**. This bites the **first contract call** in
+particular (a `ContractDeploy` is accepted, the next call fails). Setting a small
+positive `additionalFeeOverhead` forces a real DUST fee so the transaction
+normalizes. Any positive amount the wallet can cover in DUST works; the
+basic-start tutorial and the compact-cli-dev template use `300_000_000_000_000n`.
+
+> **DUST registration does not need `additionalFeeOverhead`.** Registration is
+> self-funding — its fee is paid by the DUST the registered NIGHT UTXOs generate,
+> not from the wallet's existing DUST balance — so it succeeds even at a `0` DUST
+> balance (verified on a local devnet). `examples/register-dust.ts` leaves the
+> overhead off for that reason. Set `additionalFeeOverhead` on the wallets that
+> submit **transfers or contract calls**. See
+> [managing-test-wallets references/dust-registration.md](../../managing-test-wallets/references/dust-registration.md)
+> and `/midnight-status-codes:lookup 117` / `138`.
 
 ## WalletFacade Initialization
 


### PR DESCRIPTION
## Problem

On an idle local devnet the per-block fee rate is ~0, so a wallet built with only `costParameters: { feeBlocksMargin: 5 }` computes a zero fee, builds an empty `DustActions`, and the node rejects the transaction as **NotNormalized (error 117)**. The midnight-wallet examples didn't set `additionalFeeOverhead`, and the status-codes entries for 117/138 were terse. (Korean-developer walkthrough feedback.)

## Changes

**midnight-wallet examples + references**
- Add `additionalFeeOverhead: 1_000_000n` to the wallets that **submit transfers** (transfer-flow, transfer-night, transfer-shielded, fund-wallet-undeployed, the genesis sender in full-test-wallet-setup) and the canonical basic-wallet-setup, each with a comment explaining the 117 mechanism.
- Leave it **off** the DUST-registration wallets — not because of a trap, but because **registration is self-funding**; the comments explain that.
- Document `costParameters`/`additionalFeeOverhead` in wallet-construction.md and network-config.md; explain self-funding registration in dust-registration.md.

**midnight-status-codes**
- Enrich 117 and 138 (codes.json description/fixes/see_also + reference_anchor; node-errors.md rows) and add a shared "Idle-devnet DUST-fee pitfalls" deep dive with verified source locations. 138 is documented as a generic overspend; registration is explicitly noted as *not* a cause. Schema check passes; lookup renders both.

## Verification (devnet, midnight-verify pipeline)

- **117 confirmed**: overhead `0n` → first contract call rejected with 117; `1_000_000n` → deploy + call both succeed.
- **138 hypothesis REFUTED**: a 0-DUST wallet registers DUST successfully **with** `additionalFeeOverhead` set. DUST registration is self-funding (fee paid by `coin.dust.generatedNow`), so overhead during registration does **not** cause 138. The docs reflect this corrected understanding.

Plugins bumped: midnight-wallet 0.6.0, midnight-status-codes 0.10.0.

Generated with [Claude Code](https://claude.com/claude-code)