### PR TITLE
docs(compact-core): rebuild basic-start on the current 4.x SDK line; drop unshipped MCP tools

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-expert",
   "metadata": {
-    "version": "0.46.0",
+    "version": "0.47.0",
     "description": "AI agent plugins for the Midnight data-protection blockchain. Covers Compact smart contract development, privacy-preserving patterns, DApp frontend design, and Midnight toolchain management."
   },
   "owner": {

--- a/plugins/compact-core/.claude-plugin/plugin.json
+++ b/plugins/compact-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compact-core",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Core knowledge for writing Midnight Compact smart contracts \u2014 contract structure, data types, ledger declarations, circuits, witnesses, and common patterns.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/compact-core/skills/basic-start/SKILL.md
+++ b/plugins/compact-core/skills/basic-start/SKILL.md
@@ -40,6 +40,23 @@ Work through each step in order. Each step's reference file contains the full pr
 | 5 | Token Transfer | Programmatic NIGHT transfer between wallets | `references/step-5-token-transfer.md` |
 | 6 | Ticket Contract | Privacy-preserving contract with commitments and nullifiers | `references/step-6-ticket-contract.md` |
 
+## When something errors
+
+**Your first stop for any error code or message is `/midnight-status-codes:lookup`.**
+It decodes node rejections (e.g. `1010: Custom error: 117`), SDK/Effect errors,
+Compact compiler diagnostics, proof-server and indexer errors, and more — telling
+you what produced the error and how to fix it.
+
+```
+/midnight-status-codes:lookup 117      # a numeric node/ledger code
+/midnight-status-codes:lookup NotNormalized   # an error name
+```
+
+Common early ones on a fresh devnet: **117** (NotNormalized — set a small
+`additionalFeeOverhead`, see step 4/5) and **1010** (the Substrate envelope that
+wraps the real `Custom(N)` cause). For environment problems, run
+`/midnight-tooling:doctor`.
+
 ## When You're Done
 
 Delete the temporary working directory:

--- a/plugins/compact-core/skills/basic-start/references/step-1-devnet-setup.md
+++ b/plugins/compact-core/skills/basic-start/references/step-1-devnet-setup.md
@@ -37,7 +37,7 @@ Docker is running and the three devnet services (node, indexer, proof server) st
 
 6. Health check — Indexer. This is a GraphQL endpoint (POST only), so use an introspection query:
    ```bash
-   curl -sf -X POST http://localhost:8088/api/v3/graphql \
+   curl -sf -X POST http://localhost:8088/api/v4/graphql \
      -H "Content-Type: application/json" \
      -d '{"query": "{ __typename }"}'
    ```
@@ -55,7 +55,7 @@ Docker is running and the three devnet services (node, indexer, proof server) st
 
    Indexer height:
    ```bash
-   curl -sf -X POST http://localhost:8088/api/v3/graphql \
+   curl -sf -X POST http://localhost:8088/api/v4/graphql \
      -H "Content-Type: application/json" \
      -d '{"query": "{ block { height } }"}' \
      | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['block']['height'])"

--- a/plugins/compact-core/skills/basic-start/references/step-3-wallet-setup.md
+++ b/plugins/compact-core/skills/basic-start/references/step-3-wallet-setup.md
@@ -4,11 +4,11 @@
 
 ### What this verifies
 
-Wallet creation, NIGHT token airdrop from the genesis wallet, and DUST registration all work on the local devnet.
+Wallet creation, NIGHT token funding from the genesis wallet, and DUST registration all work on the local devnet — driven entirely by the Midnight SDK (no extra tooling required).
 
 ### Procedure
 
-1. Verify the indexer is synced before proceeding. Use the block height comparison from Step 1:
+1. Verify the indexer is synced before proceeding. Use the block-height comparison from Step 1:
 
    Node height:
 
@@ -22,7 +22,7 @@ Wallet creation, NIGHT token airdrop from the genesis wallet, and DUST registrat
    Indexer height:
 
    ```bash
-   curl -sf -X POST http://localhost:8088/api/v3/graphql \
+   curl -sf -X POST http://localhost:8088/api/v4/graphql \
      -H "Content-Type: application/json" \
      -d '{"query": "{ block { height } }"}' \
      | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['block']['height'])"
@@ -30,36 +30,282 @@ Wallet creation, NIGHT token airdrop from the genesis wallet, and DUST registrat
 
    Heights should be within 1-2 blocks. If not, wait and re-check.
 
-2. Create a wallet using the `midnight_wallet_generate` MCP tool:
-   - `name`: `"deployer"`
-   - `network`: `"undeployed"`
+2. **Set up the Node.js project.** This project is shared by Steps 3-6, so install everything once now. From the working directory (`/tmp/midnight-basic-start`):
 
-   **Save the `seed` from the output** — you will need it for deployment scripts in later steps.
+   Create `package.json`:
 
-3. Airdrop NIGHT tokens using the `midnight_airdrop` MCP tool:
-   - `amount`: `"10000"`
-   - `wallet`: `"deployer"`
-   - `no-cache`: `"true"`
+   ```json
+   {
+     "name": "midnight-basic-start",
+     "version": "0.1.0",
+     "type": "module",
+     "scripts": {
+       "setup": "node --import tsx src/setup-deployer.ts"
+     },
+     "dependencies": {
+       "@midnight-ntwrk/compact-js": "2.5.1",
+       "@midnight-ntwrk/compact-runtime": "0.16.0",
+       "@midnight-ntwrk/ledger-v8": "8.1.0",
+       "@midnight-ntwrk/midnight-js-contracts": "4.1.1",
+       "@midnight-ntwrk/midnight-js-http-client-proof-provider": "4.1.1",
+       "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "4.1.1",
+       "@midnight-ntwrk/midnight-js-level-private-state-provider": "4.1.1",
+       "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+       "@midnight-ntwrk/midnight-js-node-zk-config-provider": "4.1.1",
+       "@midnight-ntwrk/midnight-js-types": "4.1.1",
+       "@midnight-ntwrk/wallet-sdk-abstractions": "2.1.0",
+       "@midnight-ntwrk/wallet-sdk-address-format": "3.1.2",
+       "@midnight-ntwrk/wallet-sdk-dust-wallet": "4.1.0",
+       "@midnight-ntwrk/wallet-sdk-facade": "4.0.1",
+       "@midnight-ntwrk/wallet-sdk-hd": "3.0.2",
+       "@midnight-ntwrk/wallet-sdk-shielded": "3.0.1",
+       "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "3.1.0",
+       "rxjs": "^7.8.0",
+       "ws": "^8.18.0"
+     },
+     "devDependencies": {
+       "@types/ws": "^8.5.0",
+       "tsx": "^4.0.0",
+       "typescript": "^5.5.0"
+     }
+   }
+   ```
 
-   **Always use `no-cache: "true"` for airdrops.** Without it, the wallet CLI's client-side cache can cause sync timeouts, even when the indexer is healthy and fully synced.
+   Install:
 
-4. Register DUST using the `midnight_dust_register` MCP tool:
-   - `wallet`: `"deployer"`
+   ```bash
+   mkdir -p src
+   npm install
+   ```
 
-   If this times out, wait 30 seconds and retry with `no-cache: "true"`.
+3. **Write the setup script.** Create `src/setup-deployer.ts`. In one run it generates a fresh "deployer" wallet, funds it with 10,000 NIGHT from the local genesis wallet, registers its NIGHT for DUST generation, and prints the seed + address + balances:
 
-5. Verify the NIGHT balance using the `midnight_balance` MCP tool:
-   - `wallet`: `"deployer"`
+   ```typescript
+   import WebSocket from "ws";
+   (globalThis as any).WebSocket = WebSocket;
 
-   Should show `10000.000000` NIGHT.
+   import { Buffer } from "buffer";
+   import {
+     HDWallet,
+     Roles,
+     generateRandomSeed,
+   } from "@midnight-ntwrk/wallet-sdk-hd";
+   import {
+     WalletFacade,
+     WalletEntrySchema,
+     type DefaultConfiguration,
+     type CombinedTokenTransfer,
+     type UtxoWithMeta,
+   } from "@midnight-ntwrk/wallet-sdk-facade";
+   import { ShieldedWallet } from "@midnight-ntwrk/wallet-sdk-shielded";
+   import {
+     UnshieldedWallet,
+     createKeystore,
+     PublicKey,
+   } from "@midnight-ntwrk/wallet-sdk-unshielded-wallet";
+   import { DustWallet } from "@midnight-ntwrk/wallet-sdk-dust-wallet";
+   import { InMemoryTransactionHistoryStorage } from "@midnight-ntwrk/wallet-sdk-abstractions";
+   import * as ledger from "@midnight-ntwrk/ledger-v8";
+   import {
+     MidnightBech32m,
+     UnshieldedAddress,
+   } from "@midnight-ntwrk/wallet-sdk-address-format";
+   import { firstValueFrom } from "rxjs";
+   import { filter, timeout } from "rxjs/operators";
 
-6. Verify DUST status using the `midnight_dust_status` MCP tool:
-   - `wallet`: `"deployer"`
+   // The local-devnet genesis seed. The dev preset pre-mints NIGHT to the wallet
+   // derived from this seed.
+   const GENESIS_SEED_HEX =
+     "0000000000000000000000000000000000000000000000000000000000000001";
+   const FUND_AMOUNT = 10_000_000_000n; // 10,000 NIGHT in micro-NIGHT
+   const BALANCE_WAIT_MS = 120_000;
 
-   `dustAvailable` should be `true` with a positive `dustBalance`.
+   function buildKeysFromSeed(seed: Uint8Array) {
+     const hd = HDWallet.fromSeed(seed);
+     if (hd.type !== "seedOk") throw new Error(`HDWallet.fromSeed failed: ${hd.type}`);
+     const derived = hd.hdWallet
+       .selectAccount(0)
+       .selectRoles([Roles.Zswap, Roles.NightExternal, Roles.Dust] as const)
+       .deriveKeysAt(0);
+     if (derived.type !== "keysDerived") throw new Error(`deriveKeysAt failed: ${derived.type}`);
+     hd.hdWallet.clear();
+     const k = derived.keys as Record<number, Uint8Array>;
+     return {
+       shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(k[Roles.Zswap]),
+       dustSecretKey: ledger.DustSecretKey.fromSeed(k[Roles.Dust]),
+       unshieldedKeystore: createKeystore(k[Roles.NightExternal], "undeployed"),
+     };
+   }
+
+   // `additionalFeeOverhead` keeps the fee non-zero on the idle devnet so a spend
+   // is not rejected as NotNormalized (error 117). Pass it for a wallet that
+   // SPENDS (the genesis sender). The deployer only registers DUST, which is
+   // self-funding, so it needs no overhead.
+   function buildConfiguration(additionalFeeOverhead?: bigint): DefaultConfiguration {
+     const costParameters: DefaultConfiguration["costParameters"] = { feeBlocksMargin: 5 };
+     if (additionalFeeOverhead !== undefined) costParameters.additionalFeeOverhead = additionalFeeOverhead;
+     return {
+       networkId: "undeployed",
+       costParameters,
+       relayURL: new URL("ws://localhost:9944"),
+       provingServerUrl: new URL("http://localhost:6300"),
+       indexerClientConnection: {
+         indexerHttpUrl: "http://localhost:8088/api/v4/graphql",
+         indexerWsUrl: "ws://localhost:8088/api/v4/graphql/ws",
+       },
+       txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema),
+     };
+   }
+
+   async function initWallet(
+     configuration: DefaultConfiguration,
+     shieldedSecretKeys: ledger.ZswapSecretKeys,
+     dustSecretKey: ledger.DustSecretKey,
+     unshieldedKeystore: ReturnType<typeof createKeystore>,
+   ): Promise<WalletFacade> {
+     const wallet = await WalletFacade.init({
+       configuration,
+       shielded: (cfg) => ShieldedWallet(cfg).startWithSecretKeys(shieldedSecretKeys),
+       unshielded: (cfg) =>
+         UnshieldedWallet(cfg).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
+       dust: (cfg) =>
+         DustWallet(cfg).startWithSecretKey(
+           dustSecretKey,
+           ledger.LedgerParameters.initialParameters().dust,
+         ),
+     });
+     await wallet.start(shieldedSecretKeys, dustSecretKey);
+     return wallet;
+   }
+
+   async function main() {
+     const NIGHT_TOKEN_TYPE = ledger.nativeToken().raw;
+
+     // 1. Generate the deployer wallet seed
+     const deployerSeed = generateRandomSeed();
+     const deployerSeedHex = Buffer.from(deployerSeed).toString("hex");
+     console.log(`Deployer seed (save this): ${deployerSeedHex}`);
+
+     // 2. Build + sync the deployer wallet (no fee overhead — it only registers DUST)
+     const deployer = buildKeysFromSeed(deployerSeed);
+     console.log("Initializing deployer wallet...");
+     const deployerWallet = await initWallet(
+       buildConfiguration(),
+       deployer.shieldedSecretKeys,
+       deployer.dustSecretKey,
+       deployer.unshieldedKeystore,
+     );
+     console.log("Syncing deployer wallet...");
+     const deployerInit = await deployerWallet.waitForSyncedState();
+     const deployerAddress = MidnightBech32m.encode("undeployed", deployerInit.unshielded.address).asString();
+     console.log(`Deployer unshielded address: ${deployerAddress}`);
+
+     // 3. Build the genesis wallet (it SPENDS, so it needs a fee overhead) and
+     //    transfer 10,000 NIGHT to the deployer
+     console.log("Initializing genesis wallet...");
+     const genesis = buildKeysFromSeed(Buffer.from(GENESIS_SEED_HEX, "hex"));
+     const genesisWallet = await initWallet(
+       buildConfiguration(300_000_000_000_000n),
+       genesis.shieldedSecretKeys,
+       genesis.dustSecretKey,
+       genesis.unshieldedKeystore,
+     );
+     await genesisWallet.waitForSyncedState();
+
+     const recipient = MidnightBech32m.parse(deployerAddress).decode(UnshieldedAddress, "undeployed");
+     const outputs: CombinedTokenTransfer[] = [{
+       type: "unshielded",
+       outputs: [{ type: NIGHT_TOKEN_TYPE, receiverAddress: recipient, amount: FUND_AMOUNT }],
+     }];
+     console.log(`Transferring ${Number(FUND_AMOUNT) / 1_000_000} NIGHT to deployer...`);
+     const recipe = await genesisWallet.transferTransaction(
+       outputs,
+       { shieldedSecretKeys: genesis.shieldedSecretKeys, dustSecretKey: genesis.dustSecretKey },
+       { ttl: new Date(Date.now() + 60 * 60 * 1000), payFees: true },
+     );
+     const signed = await genesisWallet.signRecipe(recipe, (p) => genesis.unshieldedKeystore.signData(p));
+     const fundTxId = await genesisWallet.submitTransaction(await genesisWallet.finalizeRecipe(signed));
+     console.log(`Fund transaction ID: ${fundTxId}`);
+     await genesisWallet.stop();
+
+     // 4. Wait for the deployer to receive the NIGHT
+     console.log("Waiting for deployer to receive NIGHT...");
+     let nightBalance = 0n;
+     try {
+       const funded = await firstValueFrom(
+         deployerWallet.state().pipe(
+           filter((s) => (s.unshielded.balances[NIGHT_TOKEN_TYPE] ?? 0n) >= FUND_AMOUNT),
+           timeout(BALANCE_WAIT_MS),
+         ),
+       );
+       nightBalance = funded.unshielded.balances[NIGHT_TOKEN_TYPE] ?? 0n;
+     } catch {
+       nightBalance = (await deployerWallet.waitForSyncedState()).unshielded.balances[NIGHT_TOKEN_TYPE] ?? 0n;
+     }
+     console.log(`Deployer NIGHT balance: ${Number(nightBalance) / 1_000_000} NIGHT`);
+
+     // 5. Register the deployer's NIGHT UTXOs for DUST generation
+     const fresh = await deployerWallet.waitForSyncedState();
+     const nightUtxos: readonly UtxoWithMeta[] = fresh.unshielded.availableCoins.filter(
+       (coin) => coin.utxo.type === NIGHT_TOKEN_TYPE && coin.meta.registeredForDustGeneration === false,
+     );
+     console.log(`NIGHT UTXOs to register: ${nightUtxos.length}`);
+     if (nightUtxos.length === 0) {
+       console.error("No NIGHT UTXOs available for DUST registration.");
+       await deployerWallet.stop();
+       process.exit(1);
+     }
+     const regRecipe = await deployerWallet.registerNightUtxosForDustGeneration(
+       nightUtxos,
+       deployer.unshieldedKeystore.getPublicKey(),
+       (p) => deployer.unshieldedKeystore.signData(p),
+     );
+     const dustTxId = await deployerWallet.submitTransaction(await deployerWallet.finalizeRecipe(regRecipe));
+     console.log(`DUST registration TX: ${dustTxId}`);
+
+     // 6. Wait for DUST to accrue
+     console.log("Waiting for DUST balance > 0...");
+     let dustBalance = 0n;
+     try {
+       const dustState = await firstValueFrom(
+         deployerWallet.state().pipe(
+           filter((s) => s.dust.balance(new Date()) > 0n),
+           timeout(BALANCE_WAIT_MS),
+         ),
+       );
+       dustBalance = dustState.dust.balance(new Date());
+     } catch {
+       console.log("Note: DUST balance still 0 after timeout. It may accrue as more blocks are produced.");
+     }
+
+     console.log("============================================================");
+     console.log(`Deployer seed hex:    ${deployerSeedHex}`);
+     console.log(`Deployer address:     ${deployerAddress}`);
+     console.log(`NIGHT balance:        ${Number(nightBalance) / 1_000_000} NIGHT`);
+     console.log(`DUST balance:         ${dustBalance}`);
+     console.log("============================================================");
+
+     await deployerWallet.stop();
+     process.exit(0);
+   }
+
+   main().catch((e) => { console.error("Fatal error:", e); process.exit(1); });
+   ```
+
+4. **Run the setup script:**
+
+   ```bash
+   node --import tsx src/setup-deployer.ts
+   ```
+
+   Use `node --import tsx` not `npx tsx` — some `@midnight-ntwrk/wallet-sdk-*` packages have ESM export issues with tsx's CJS loader.
+
+5. **Save the printed `Deployer seed hex`.** You will paste it into the deploy and transfer scripts in Steps 4 and 5. The wallet's funds live on-chain, so re-deriving from this seed reconnects to the same funded wallet.
 
 ### Expected output
 
-Wallet created with an `undeployed` address and seed. Airdrop returns a transaction hash. DUST registration succeeds with a positive balance. Balance check confirms 10000 NIGHT. Dust status shows `dustAvailable: true`.
+The script prints a deployer seed and address, a fund transaction ID, a DUST registration transaction ID, and a summary showing `NIGHT balance: 10000` with a positive `DUST balance`.
+
+> **If anything errors,** your first stop is `/midnight-status-codes:lookup <code>`. A node rejection like `1010: Custom error: 117` means the fee computed to zero — confirm `additionalFeeOverhead` is set on the spending (genesis) wallet. DUST registration is self-funding and needs no overhead.
 
 > **EPHEMERAL** — All code and files produced by this walkthrough are disposable. Do not commit, push, or retain any of it. Delete everything when done.

--- a/plugins/compact-core/skills/basic-start/references/step-4-counter-contract.md
+++ b/plugins/compact-core/skills/basic-start/references/step-4-counter-contract.md
@@ -71,7 +71,9 @@ This generates ZK proving/verifying keys in `keys/`. Required for deployment.
 
 **4.5. Set up the Node.js project**
 
-Create `package.json`:
+> If you completed Step 3, this project and all of its dependencies already exist in the working directory — you can **skip `npm install`** below. Just add the `compile` / `compile:full` / `deploy` scripts (shown in the `package.json` here) to your existing `package.json`, and create the `tsconfig.json`.
+
+Create `package.json` (this is the full manifest, identical to the one from Step 3 plus the contract scripts):
 
 ```json
 {
@@ -84,21 +86,23 @@ Create `package.json`:
     "deploy": "node --import tsx src/deploy.ts"
   },
   "dependencies": {
-    "@midnight-ntwrk/compact-js": "2.5.0",
+    "@midnight-ntwrk/compact-js": "2.5.1",
     "@midnight-ntwrk/compact-runtime": "0.16.0",
-    "@midnight-ntwrk/ledger-v8": "8.0.3",
-    "@midnight-ntwrk/midnight-js-contracts": "4.0.4",
-    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "4.0.4",
-    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "4.0.4",
-    "@midnight-ntwrk/midnight-js-level-private-state-provider": "4.0.4",
-    "@midnight-ntwrk/midnight-js-network-id": "4.0.4",
-    "@midnight-ntwrk/midnight-js-node-zk-config-provider": "4.0.4",
-    "@midnight-ntwrk/midnight-js-types": "4.0.4",
-    "@midnight-ntwrk/wallet-sdk-dust-wallet": "3.0.0",
-    "@midnight-ntwrk/wallet-sdk-facade": "3.0.0",
-    "@midnight-ntwrk/wallet-sdk-hd": "3.0.1",
-    "@midnight-ntwrk/wallet-sdk-shielded": "2.1.0",
-    "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "2.1.0",
+    "@midnight-ntwrk/ledger-v8": "8.1.0",
+    "@midnight-ntwrk/midnight-js-contracts": "4.1.1",
+    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "4.1.1",
+    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "4.1.1",
+    "@midnight-ntwrk/midnight-js-level-private-state-provider": "4.1.1",
+    "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+    "@midnight-ntwrk/midnight-js-node-zk-config-provider": "4.1.1",
+    "@midnight-ntwrk/midnight-js-types": "4.1.1",
+    "@midnight-ntwrk/wallet-sdk-abstractions": "2.1.0",
+    "@midnight-ntwrk/wallet-sdk-address-format": "3.1.2",
+    "@midnight-ntwrk/wallet-sdk-dust-wallet": "4.1.0",
+    "@midnight-ntwrk/wallet-sdk-facade": "4.0.1",
+    "@midnight-ntwrk/wallet-sdk-hd": "3.0.2",
+    "@midnight-ntwrk/wallet-sdk-shielded": "3.0.1",
+    "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "3.1.0",
     "rxjs": "^7.8.0",
     "ws": "^8.18.0"
   },
@@ -152,12 +156,12 @@ import { levelPrivateStateProvider } from "@midnight-ntwrk/midnight-js-level-pri
 import { NodeZkConfigProvider } from "@midnight-ntwrk/midnight-js-node-zk-config-provider";
 import { CompiledContract } from "@midnight-ntwrk/compact-js";
 import { HDWallet, Roles } from "@midnight-ntwrk/wallet-sdk-hd";
-import { WalletFacade } from "@midnight-ntwrk/wallet-sdk-facade";
+import { WalletFacade, WalletEntrySchema } from "@midnight-ntwrk/wallet-sdk-facade";
 import { DustWallet } from "@midnight-ntwrk/wallet-sdk-dust-wallet";
 import { ShieldedWallet } from "@midnight-ntwrk/wallet-sdk-shielded";
+import { InMemoryTransactionHistoryStorage } from "@midnight-ntwrk/wallet-sdk-abstractions";
 import {
   createKeystore,
-  InMemoryTransactionHistoryStorage,
   PublicKey,
   UnshieldedWallet,
 } from "@midnight-ntwrk/wallet-sdk-unshielded-wallet";
@@ -171,8 +175,8 @@ import { witnesses } from "./witnesses.js";
 
 // --- Config ---
 const NETWORK_ID = "undeployed"; // MUST be lowercase — "Undeployed" causes error 166 (InvalidNetworkId)
-const INDEXER_HTTP = "http://127.0.0.1:8088/api/v3/graphql";
-const INDEXER_WS = "ws://127.0.0.1:8088/api/v3/graphql/ws";
+const INDEXER_HTTP = "http://127.0.0.1:8088/api/v4/graphql";
+const INDEXER_WS = "ws://127.0.0.1:8088/api/v4/graphql/ws";
 const NODE_URL = "ws://127.0.0.1:9944"; // MUST be ws://, not http://
 const PROOF_SERVER = "http://127.0.0.1:6300";
 
@@ -220,13 +224,13 @@ async function main() {
         additionalFeeOverhead: 300_000_000_000_000n,
         feeBlocksMargin: 5,
       },
-      txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+      txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema),
     },
     shielded: (cfg) => ShieldedWallet(cfg).startWithSecretKeys(shieldedSecretKeys),
     unshielded: (cfg) =>
       UnshieldedWallet({
         ...cfg,
-        txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+        txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema),
       }).startWithPublicKey(PublicKey.fromKeyStore(keystore)),
     dust: (cfg) =>
       DustWallet(cfg).startWithSecretKey(
@@ -338,12 +342,12 @@ import { levelPrivateStateProvider } from "@midnight-ntwrk/midnight-js-level-pri
 import { NodeZkConfigProvider } from "@midnight-ntwrk/midnight-js-node-zk-config-provider";
 import { CompiledContract } from "@midnight-ntwrk/compact-js";
 import { HDWallet, Roles } from "@midnight-ntwrk/wallet-sdk-hd";
-import { WalletFacade } from "@midnight-ntwrk/wallet-sdk-facade";
+import { WalletFacade, WalletEntrySchema } from "@midnight-ntwrk/wallet-sdk-facade";
 import { DustWallet } from "@midnight-ntwrk/wallet-sdk-dust-wallet";
 import { ShieldedWallet } from "@midnight-ntwrk/wallet-sdk-shielded";
+import { InMemoryTransactionHistoryStorage } from "@midnight-ntwrk/wallet-sdk-abstractions";
 import {
   createKeystore,
-  InMemoryTransactionHistoryStorage,
   PublicKey,
   UnshieldedWallet,
 } from "@midnight-ntwrk/wallet-sdk-unshielded-wallet";
@@ -356,8 +360,8 @@ import { Contract, ledger as counterLedger } from "./managed/counter/contract/in
 import { witnesses } from "./witnesses.js";
 
 const NETWORK_ID = "undeployed";
-const INDEXER_HTTP = "http://127.0.0.1:8088/api/v3/graphql";
-const INDEXER_WS = "ws://127.0.0.1:8088/api/v3/graphql/ws";
+const INDEXER_HTTP = "http://127.0.0.1:8088/api/v4/graphql";
+const INDEXER_WS = "ws://127.0.0.1:8088/api/v4/graphql/ws";
 const NODE_URL = "ws://127.0.0.1:9944";
 const PROOF_SERVER = "http://127.0.0.1:6300";
 
@@ -402,11 +406,11 @@ async function main() {
       provingServerUrl: new URL(PROOF_SERVER),
       relayURL: new URL(NODE_URL),
       costParameters: { additionalFeeOverhead: 300_000_000_000_000n, feeBlocksMargin: 5 },
-      txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+      txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema),
     },
     shielded: (cfg) => ShieldedWallet(cfg).startWithSecretKeys(shieldedSecretKeys),
     unshielded: (cfg) =>
-      UnshieldedWallet({ ...cfg, txHistoryStorage: new InMemoryTransactionHistoryStorage() })
+      UnshieldedWallet({ ...cfg, txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema) })
         .startWithPublicKey(PublicKey.fromKeyStore(keystore)),
     dust: (cfg) =>
       DustWallet(cfg).startWithSecretKey(dustSecretKey, ledger.LedgerParameters.initialParameters().dust),

--- a/plugins/compact-core/skills/basic-start/references/step-5-token-transfer.md
+++ b/plugins/compact-core/skills/basic-start/references/step-5-token-transfer.md
@@ -4,209 +4,239 @@
 
 ### What this verifies
 
-Programmatic NIGHT token transfers between wallets using the WalletFacade SDK.
+Programmatic NIGHT token transfers between wallets using the `WalletFacade` SDK.
+
+This step reuses the project and dependencies from Steps 3-4 (`@midnight-ntwrk/wallet-sdk-*` and `@midnight-ntwrk/wallet-sdk-address-format` are already installed) and the deployer seed saved in Step 3.
 
 ### Procedure
 
-1. Create a second wallet using the `midnight_wallet_generate` MCP tool:
-   - `name`: `"alice"`
-   - `network`: `"undeployed"`
+1. **Write a small wallet-info script** you can reuse to create a wallet and to read balances. Create `src/wallet-info.ts`:
 
-2. Check deployer balance using the `midnight_balance` MCP tool with `wallet: "deployer"`.
+   ```typescript
+   import WebSocket from "ws";
+   (globalThis as any).WebSocket = WebSocket;
 
-3. Add the address format package to dependencies:
+   import { Buffer } from "buffer";
+   import { HDWallet, Roles, generateRandomSeed } from "@midnight-ntwrk/wallet-sdk-hd";
+   import {
+     WalletFacade,
+     WalletEntrySchema,
+     type DefaultConfiguration,
+   } from "@midnight-ntwrk/wallet-sdk-facade";
+   import { ShieldedWallet } from "@midnight-ntwrk/wallet-sdk-shielded";
+   import {
+     UnshieldedWallet,
+     createKeystore,
+     PublicKey,
+   } from "@midnight-ntwrk/wallet-sdk-unshielded-wallet";
+   import { DustWallet } from "@midnight-ntwrk/wallet-sdk-dust-wallet";
+   import { InMemoryTransactionHistoryStorage } from "@midnight-ntwrk/wallet-sdk-abstractions";
+   import * as ledger from "@midnight-ntwrk/ledger-v8";
+   import { MidnightBech32m } from "@midnight-ntwrk/wallet-sdk-address-format";
 
-```bash
-npm install @midnight-ntwrk/wallet-sdk-address-format@3.1.0
-```
+   // Optional seed arg. With no arg, generates a fresh wallet and prints the seed.
+   let seedHex = process.argv[2];
+   if (!seedHex) {
+     seedHex = Buffer.from(generateRandomSeed()).toString("hex");
+     console.log(`New wallet seed (save this): ${seedHex}`);
+   }
 
-4. Write `src/transfer.ts` with the following complete content:
+   function buildKeysFromSeed(hex: string) {
+     const hd = HDWallet.fromSeed(Buffer.from(hex, "hex"));
+     if (hd.type !== "seedOk") throw new Error(`HDWallet.fromSeed failed: ${hd.type}`);
+     const derived = hd.hdWallet
+       .selectAccount(0)
+       .selectRoles([Roles.Zswap, Roles.NightExternal, Roles.Dust] as const)
+       .deriveKeysAt(0);
+     if (derived.type !== "keysDerived") throw new Error(`deriveKeysAt failed: ${derived.type}`);
+     hd.hdWallet.clear();
+     const k = derived.keys as Record<number, Uint8Array>;
+     return {
+       shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(k[Roles.Zswap]),
+       dustSecretKey: ledger.DustSecretKey.fromSeed(k[Roles.Dust]),
+       unshieldedKeystore: createKeystore(k[Roles.NightExternal], "undeployed"),
+     };
+   }
 
-```typescript
-import { WebSocket } from "ws";
-// @ts-expect-error WebSocket polyfill for apollo client
-globalThis.WebSocket = WebSocket;
+   const configuration: DefaultConfiguration = {
+     networkId: "undeployed",
+     costParameters: { feeBlocksMargin: 5 },
+     relayURL: new URL("ws://localhost:9944"),
+     provingServerUrl: new URL("http://localhost:6300"),
+     indexerClientConnection: {
+       indexerHttpUrl: "http://localhost:8088/api/v4/graphql",
+       indexerWsUrl: "ws://localhost:8088/api/v4/graphql/ws",
+     },
+     txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema),
+   };
 
-import { setNetworkId, getNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
-import { HDWallet, Roles } from "@midnight-ntwrk/wallet-sdk-hd";
-import { WalletFacade } from "@midnight-ntwrk/wallet-sdk-facade";
-import { DustWallet } from "@midnight-ntwrk/wallet-sdk-dust-wallet";
-import { ShieldedWallet } from "@midnight-ntwrk/wallet-sdk-shielded";
-import {
-  createKeystore,
-  InMemoryTransactionHistoryStorage,
-  PublicKey,
-  UnshieldedWallet,
-} from "@midnight-ntwrk/wallet-sdk-unshielded-wallet";
-import * as ledger from "@midnight-ntwrk/ledger-v8";
-import { MidnightBech32m, UnshieldedAddress } from "@midnight-ntwrk/wallet-sdk-address-format";
-import * as Rx from "rxjs";
+   async function main() {
+     const NIGHT_TOKEN_TYPE = ledger.nativeToken().raw;
+     const keys = buildKeysFromSeed(seedHex);
+     const wallet = await WalletFacade.init({
+       configuration,
+       shielded: (cfg) => ShieldedWallet(cfg).startWithSecretKeys(keys.shieldedSecretKeys),
+       unshielded: (cfg) => UnshieldedWallet(cfg).startWithPublicKey(PublicKey.fromKeyStore(keys.unshieldedKeystore)),
+       dust: (cfg) => DustWallet(cfg).startWithSecretKey(keys.dustSecretKey, ledger.LedgerParameters.initialParameters().dust),
+     });
+     try {
+       await wallet.start(keys.shieldedSecretKeys, keys.dustSecretKey);
+       const state = await wallet.waitForSyncedState();
+       const address = MidnightBech32m.encode("undeployed", state.unshielded.address).asString();
+       const night = state.unshielded.balances[NIGHT_TOKEN_TYPE] ?? 0n;
+       const dust = state.dust.balance(new Date());
+       console.log(`Address:       ${address}`);
+       console.log(`NIGHT balance: ${Number(night) / 1_000_000}`);
+       console.log(`DUST balance:  ${dust}`);
+     } finally {
+       await wallet.stop();
+     }
+   }
+   main().catch((e) => { console.error("Failed:", e); process.exit(1); });
+   ```
 
-// --- Config ---
-const NETWORK_ID = "undeployed";
-const INDEXER_HTTP = "http://127.0.0.1:8088/api/v3/graphql";
-const INDEXER_WS = "ws://127.0.0.1:8088/api/v3/graphql/ws";
-const NODE_URL = "ws://127.0.0.1:9944";
-const PROOF_SERVER = "http://127.0.0.1:6300";
+2. **Create a second wallet (`alice`)** by running the script with no seed argument. **Save the printed seed and address** — you need alice's address as the transfer recipient:
 
-// --- Parse args ---
-const SENDER_SEED = process.argv[2];
-const RECIPIENT_ADDRESS = process.argv[3];
-const AMOUNT = process.argv[4];
+   ```bash
+   node --import tsx src/wallet-info.ts
+   ```
 
-if (!SENDER_SEED || !RECIPIENT_ADDRESS || !AMOUNT) {
-  console.error("Usage: node --import tsx src/transfer.ts <sender-seed> <recipient-address> <amount-night>");
-  process.exit(1);
-}
+3. **Check the deployer's balance** by running the same script with the deployer seed from Step 3:
 
-const amountMicroNight = BigInt(Math.round(parseFloat(AMOUNT) * 1_000_000));
+   ```bash
+   node --import tsx src/wallet-info.ts <deployer-seed>
+   ```
 
-function deriveKeys(seed: string) {
-  const hdWallet = HDWallet.fromSeed(Buffer.from(seed, "hex"));
-  if (hdWallet.type !== "seedOk") throw new Error("Invalid seed");
-  const result = hdWallet.hdWallet
-    .selectAccount(0)
-    .selectRoles([Roles.Zswap, Roles.NightExternal, Roles.Dust])
-    .deriveKeysAt(0);
-  if (result.type !== "keysDerived") throw new Error("Key derivation failed");
-  hdWallet.hdWallet.clear();
-  return {
-    zswap: result.keys[Roles.Zswap],
-    nightExternal: result.keys[Roles.NightExternal],
-    dust: result.keys[Roles.Dust],
-  };
-}
+   It should show roughly 10000 NIGHT and a positive DUST balance.
 
-async function main() {
-  console.log(`Transferring ${AMOUNT} NIGHT to ${RECIPIENT_ADDRESS.slice(0, 30)}...`);
+4. **Write the transfer script.** Create `src/transfer.ts`:
 
-  setNetworkId(NETWORK_ID);
-  const networkId = getNetworkId();
+   ```typescript
+   import WebSocket from "ws";
+   (globalThis as any).WebSocket = WebSocket;
 
-  const keys = deriveKeys(SENDER_SEED);
-  const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(keys.zswap);
-  const dustSecretKey = ledger.DustSecretKey.fromSeed(keys.dust);
-  const keystore = createKeystore(keys.nightExternal, networkId);
+   import { Buffer } from "buffer";
+   import { HDWallet, Roles } from "@midnight-ntwrk/wallet-sdk-hd";
+   import {
+     WalletFacade,
+     WalletEntrySchema,
+     type DefaultConfiguration,
+     type CombinedTokenTransfer,
+   } from "@midnight-ntwrk/wallet-sdk-facade";
+   import { ShieldedWallet } from "@midnight-ntwrk/wallet-sdk-shielded";
+   import {
+     UnshieldedWallet,
+     createKeystore,
+     PublicKey,
+   } from "@midnight-ntwrk/wallet-sdk-unshielded-wallet";
+   import { DustWallet } from "@midnight-ntwrk/wallet-sdk-dust-wallet";
+   import { InMemoryTransactionHistoryStorage } from "@midnight-ntwrk/wallet-sdk-abstractions";
+   import * as ledger from "@midnight-ntwrk/ledger-v8";
+   import { MidnightBech32m, UnshieldedAddress } from "@midnight-ntwrk/wallet-sdk-address-format";
 
-  console.log("Initializing wallet...");
-  const facade = await WalletFacade.init({
-    configuration: {
-      networkId,
-      indexerClientConnection: {
-        indexerHttpUrl: INDEXER_HTTP,
-        indexerWsUrl: INDEXER_WS,
-      },
-      provingServerUrl: new URL(PROOF_SERVER),
-      relayURL: new URL(NODE_URL),
-      costParameters: {
-        additionalFeeOverhead: 300_000_000_000_000n,
-        feeBlocksMargin: 5,
-      },
-      txHistoryStorage: new InMemoryTransactionHistoryStorage(),
-    },
-    shielded: (cfg) => ShieldedWallet(cfg).startWithSecretKeys(shieldedSecretKeys),
-    unshielded: (cfg) =>
-      UnshieldedWallet({
-        ...cfg,
-        txHistoryStorage: new InMemoryTransactionHistoryStorage(),
-      }).startWithPublicKey(PublicKey.fromKeyStore(keystore)),
-    dust: (cfg) =>
-      DustWallet(cfg).startWithSecretKey(
-        dustSecretKey,
-        ledger.LedgerParameters.initialParameters().dust,
-      ),
-  });
+   const SENDER_SEED = process.argv[2];
+   const RECIPIENT_ADDRESS = process.argv[3];
+   const AMOUNT = process.argv[4];
+   if (!SENDER_SEED || !RECIPIENT_ADDRESS || !AMOUNT) {
+     console.error("Usage: node --import tsx src/transfer.ts <sender-seed> <recipient-address> <amount-night>");
+     process.exit(1);
+   }
+   const amountMicroNight = BigInt(Math.round(parseFloat(AMOUNT) * 1_000_000));
 
-  try {
-    console.log("Starting and syncing wallet...");
-    await facade.start(shieldedSecretKeys, dustSecretKey);
-    const state = await Rx.firstValueFrom(
-      facade.state().pipe(
-        Rx.filter((s) => s.isSynced),
-        Rx.timeout(120_000),
-      ),
-    );
+   function buildKeysFromSeed(hex: string) {
+     const hd = HDWallet.fromSeed(Buffer.from(hex, "hex"));
+     if (hd.type !== "seedOk") throw new Error(`HDWallet.fromSeed failed: ${hd.type}`);
+     const derived = hd.hdWallet
+       .selectAccount(0)
+       .selectRoles([Roles.Zswap, Roles.NightExternal, Roles.Dust] as const)
+       .deriveKeysAt(0);
+     if (derived.type !== "keysDerived") throw new Error(`deriveKeysAt failed: ${derived.type}`);
+     hd.hdWallet.clear();
+     const k = derived.keys as Record<number, Uint8Array>;
+     return {
+       shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(k[Roles.Zswap]),
+       dustSecretKey: ledger.DustSecretKey.fromSeed(k[Roles.Dust]),
+       unshieldedKeystore: createKeystore(k[Roles.NightExternal], "undeployed"),
+     };
+   }
 
-    // Check balance
-    const token = ledger.unshieldedToken().raw;
-    const balance = state.unshielded?.balances?.[token] ?? 0n;
-    const balanceNight = Number(balance) / 1_000_000;
-    console.log(`  Sender balance: ${balanceNight} NIGHT`);
+   const configuration: DefaultConfiguration = {
+     networkId: "undeployed",
+     // The sender spends, so additionalFeeOverhead keeps the fee non-zero on the
+     // idle devnet (a zero fee is rejected as NotNormalized, error 117).
+     costParameters: { feeBlocksMargin: 5, additionalFeeOverhead: 300_000_000_000_000n },
+     relayURL: new URL("ws://localhost:9944"),
+     provingServerUrl: new URL("http://localhost:6300"),
+     indexerClientConnection: {
+       indexerHttpUrl: "http://localhost:8088/api/v4/graphql",
+       indexerWsUrl: "ws://localhost:8088/api/v4/graphql/ws",
+     },
+     txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema),
+   };
 
-    if (balance < amountMicroNight) {
-      throw new Error(`Insufficient balance: ${balanceNight} NIGHT, need ${AMOUNT} NIGHT`);
-    }
+   async function main() {
+     const NIGHT_TOKEN_TYPE = ledger.nativeToken().raw;
+     const keys = buildKeysFromSeed(SENDER_SEED);
+     const wallet = await WalletFacade.init({
+       configuration,
+       shielded: (cfg) => ShieldedWallet(cfg).startWithSecretKeys(keys.shieldedSecretKeys),
+       unshielded: (cfg) => UnshieldedWallet(cfg).startWithPublicKey(PublicKey.fromKeyStore(keys.unshieldedKeystore)),
+       dust: (cfg) => DustWallet(cfg).startWithSecretKey(keys.dustSecretKey, ledger.LedgerParameters.initialParameters().dust),
+     });
+     try {
+       await wallet.start(keys.shieldedSecretKeys, keys.dustSecretKey);
+       const state = await wallet.waitForSyncedState();
+       const balance = state.unshielded.balances[NIGHT_TOKEN_TYPE] ?? 0n;
+       console.log(`Sender NIGHT balance: ${Number(balance) / 1_000_000}`);
+       if (balance < amountMicroNight) throw new Error("Insufficient balance for transfer");
 
-    // Decode bech32m address to raw unshielded address
-    const decodedAddress = MidnightBech32m.parse(RECIPIENT_ADDRESS).decode(UnshieldedAddress, NETWORK_ID);
+       // Bech32m addresses must be decoded before passing to transferTransaction
+       const recipient = MidnightBech32m.parse(RECIPIENT_ADDRESS).decode(UnshieldedAddress, "undeployed");
+       const outputs: CombinedTokenTransfer[] = [{
+         type: "unshielded",
+         outputs: [{ type: NIGHT_TOKEN_TYPE, receiverAddress: recipient, amount: amountMicroNight }],
+       }];
 
-    // Build transfer transaction
-    console.log("Building transfer transaction...");
-    const ttl = new Date(Date.now() + 10 * 60 * 1000);
-    const recipe = await facade.transferTransaction(
-      [
-        {
-          type: "unshielded",
-          outputs: [
-            {
-              amount: amountMicroNight,
-              receiverAddress: decodedAddress,
-              type: token,
-            },
-          ],
-        },
-      ],
-      {
-        shieldedSecretKeys,
-        dustSecretKey,
-      },
-      { ttl, payFees: true },
-    );
+       // Flow: transferTransaction -> signRecipe -> finalizeRecipe -> submitTransaction
+       const recipe = await wallet.transferTransaction(
+         outputs,
+         { shieldedSecretKeys: keys.shieldedSecretKeys, dustSecretKey: keys.dustSecretKey },
+         { ttl: new Date(Date.now() + 60 * 60 * 1000), payFees: true },
+       );
+       const signed = await wallet.signRecipe(recipe, (p) => keys.unshieldedKeystore.signData(p));
+       const txId = await wallet.submitTransaction(await wallet.finalizeRecipe(signed));
+       console.log(`Transfer submitted: ${txId}`);
+     } finally {
+       await wallet.stop();
+     }
+   }
+   main().catch((e) => { console.error("Transfer failed:", e); process.exit(1); });
+   ```
 
-    // Sign the transaction
-    console.log("Signing transaction...");
-    const signed = await facade.signRecipe(recipe, (msg: Uint8Array) =>
-      keystore.signData(msg),
-    );
+   Key points:
+   - Bech32m addresses are decoded before use: `MidnightBech32m.parse(address).decode(UnshieldedAddress, "undeployed")`.
+   - Transfer amounts are micro-NIGHT (1 NIGHT = 1,000,000) as `bigint`.
+   - The sender needs `additionalFeeOverhead` set (the deployer registered DUST in Step 3, so it can pay the fee).
 
-    // Finalize and submit
-    console.log("Finalizing and submitting...");
-    const finalized = await facade.finalizeRecipe(signed);
-    const txHash = await facade.submitTransaction(finalized);
+5. **Run the transfer** (replace `<deployer-seed>` with the seed from Step 3, and `<alice-address>` with alice's address from sub-step 2):
 
-    console.log(`\nTransfer successful!`);
-    console.log(`  TX Hash: ${txHash}`);
-    console.log(`  Amount:  ${AMOUNT} NIGHT`);
-    console.log(`  To:      ${RECIPIENT_ADDRESS}`);
-  } finally {
-    await facade.stop();
-  }
-}
+   ```bash
+   node --import tsx src/transfer.ts <deployer-seed> <alice-address> 25
+   ```
 
-main().catch((err) => {
-  console.error("Transfer failed:", err);
-  process.exit(1);
-});
-```
+   Use `node --import tsx` not `npx tsx` — some `@midnight-ntwrk/wallet-sdk-*` packages have ESM export issues with tsx's CJS loader.
 
-Key points to note:
+6. **Verify both balances** with the wallet-info script — once with the deployer seed (down by ~25 plus fees) and once with alice's seed (now holds 25 NIGHT):
 
-- Bech32m addresses must be decoded before passing to `transferTransaction`: `MidnightBech32m.parse(address).decode(UnshieldedAddress, "undeployed")`
-- Transfer amounts are in micro-NIGHT (1 NIGHT = 1,000,000 micro-NIGHT) as bigint
-- The flow is: `transferTransaction` -> `signRecipe` -> `finalizeRecipe` -> `submitTransaction`
-
-5. Run the transfer (replace `<deployer-seed>` with the seed from step 3, and `<alice-address>` with alice's undeployed address):
-
-```bash
-node --import tsx src/transfer.ts <deployer-seed> <alice-address> 25
-```
-
-Use `node --import tsx` not `npx tsx` — some `@midnight-ntwrk/wallet-sdk-*` packages have ESM export issues with tsx's CJS loader.
-
-6. Verify both balances using `midnight_balance` MCP tool for both `deployer` and `alice`. Deployer should be down by 25, alice should have 25 NIGHT.
+   ```bash
+   node --import tsx src/wallet-info.ts <deployer-seed>
+   node --import tsx src/wallet-info.ts <alice-seed>
+   ```
 
 ### Expected output
 
-Transfer tx hash printed. Deployer balance decreased by 25 NIGHT. Alice balance is 25 NIGHT.
+A transfer tx id is printed. The deployer's NIGHT balance has decreased by 25 (plus fees), and alice's NIGHT balance is 25.
+
+> **If anything errors,** your first stop is `/midnight-status-codes:lookup <code>`. A `1010: Custom error: 117` on submission means the fee computed to zero — confirm the sender's `additionalFeeOverhead` is set and the sender has accrued DUST.
 
 > **EPHEMERAL** — All code and files produced by this walkthrough are disposable. Do not commit, push, or retain any of it. Delete everything when done.

--- a/plugins/compact-core/skills/basic-start/references/step-6-ticket-contract.md
+++ b/plugins/compact-core/skills/basic-start/references/step-6-ticket-contract.md
@@ -207,12 +207,12 @@ import { levelPrivateStateProvider } from "@midnight-ntwrk/midnight-js-level-pri
 import { NodeZkConfigProvider } from "@midnight-ntwrk/midnight-js-node-zk-config-provider";
 import { CompiledContract } from "@midnight-ntwrk/compact-js";
 import { HDWallet, Roles } from "@midnight-ntwrk/wallet-sdk-hd";
-import { WalletFacade } from "@midnight-ntwrk/wallet-sdk-facade";
+import { WalletFacade, WalletEntrySchema } from "@midnight-ntwrk/wallet-sdk-facade";
 import { DustWallet } from "@midnight-ntwrk/wallet-sdk-dust-wallet";
 import { ShieldedWallet } from "@midnight-ntwrk/wallet-sdk-shielded";
+import { InMemoryTransactionHistoryStorage } from "@midnight-ntwrk/wallet-sdk-abstractions";
 import {
   createKeystore,
-  InMemoryTransactionHistoryStorage,
   PublicKey,
   UnshieldedWallet,
 } from "@midnight-ntwrk/wallet-sdk-unshielded-wallet";
@@ -226,8 +226,8 @@ import { ticketWitnesses, createTicketState, type TicketPrivateState } from "./t
 
 // --- Config ---
 const NETWORK_ID = "undeployed";
-const INDEXER_HTTP = "http://127.0.0.1:8088/api/v3/graphql";
-const INDEXER_WS = "ws://127.0.0.1:8088/api/v3/graphql/ws";
+const INDEXER_HTTP = "http://127.0.0.1:8088/api/v4/graphql";
+const INDEXER_WS = "ws://127.0.0.1:8088/api/v4/graphql/ws";
 const NODE_URL = "ws://127.0.0.1:9944";
 const PROOF_SERVER = "http://127.0.0.1:6300";
 
@@ -274,13 +274,13 @@ async function main() {
         additionalFeeOverhead: 300_000_000_000_000n,
         feeBlocksMargin: 5,
       },
-      txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+      txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema),
     },
     shielded: (cfg) => ShieldedWallet(cfg).startWithSecretKeys(shieldedSecretKeys),
     unshielded: (cfg) =>
       UnshieldedWallet({
         ...cfg,
-        txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+        txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema),
       }).startWithPublicKey(PublicKey.fromKeyStore(keystore)),
     dust: (cfg) =>
       DustWallet(cfg).startWithSecretKey(


### PR DESCRIPTION
## Problem

basic-start steps 3 and 5 referenced MCP wallet tools (`midnight_wallet_generate`, `midnight_airdrop`, `midnight_dust_register`, `midnight_balance`, `midnight_dust_status`) that **no shipped plugin provides**, so the walkthrough stalled for fresh users. The rest of the tutorial pinned a **stale 3.x wallet-SDK / 4.0.4 midnight-js** line. (Korean-developer walkthrough feedback.)

## Changes (whole tutorial bumped to the current, verified 4.x line)

- **step-3**: rewritten around a self-contained `setup-deployer.ts` that creates a wallet, funds it with 10,000 NIGHT from genesis, and registers DUST in one run. Sets up the shared project steps 4-6 reuse.
- **step-4**: counter deploy + increment + read on 4.x. Two breaking changes applied: `InMemoryTransactionHistoryStorage` moved `wallet-sdk-unshielded-wallet` → `wallet-sdk-abstractions` and now takes `WalletEntrySchema`; indexer path `/api/v3` → `/api/v4`. Versions → midnight-js-* 4.1.1, wallet-sdk-facade 4.0.1, dust-wallet 4.1.0, ledger-v8 8.1.0, compact-js 2.5.1.
- **step-5**: MCP wallet-create + balance-checks replaced by a reusable `wallet-info.ts` and a 4.x `transfer.ts`.
- **step-6**: ticket test script updated with the same verified 4.x wallet-construction + `/api/v4` changes.
- **step-1**: indexer health-check curls → `/api/v4`.
- **SKILL.md**: a troubleshooting section making `/midnight-status-codes:lookup` the first stop on any error; per-step routing in steps 3 and 5.

## Verification (devnet, midnight-verify pipeline)

The full wallet setup (create + fund + register), the counter **deploy + increment + read** (0 → 1 on-chain), and the NIGHT transfer were all confirmed on the running devnet against the 4.x SDK. `additionalFeeOverhead` is set on spending wallets (error 117) and omitted from self-funding DUST registration.

Plugins bumped: compact-core 0.11.0. **Marketplace bumped to 0.47.0** (this PR carries the marketplace version — merge it last).

Generated with [Claude Code](https://claude.com/claude-code)