### PR TITLE
fix: rebuild compact-cli-dev + midnight-dapp-dev templates for the 4.x SDK / npm

### DIFF
--- a/plugins/compact-cli-dev/.claude-plugin/plugin.json
+++ b/plugins/compact-cli-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compact-cli-dev",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Scaffold and develop Oclif CLIs for Midnight Compact smart contracts. Includes a complete CLI template with wallet management, contract deployment, devnet control, and an AI agent for ongoing development.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/compact-cli-dev/skills/core/templates/cli/package.json.tmpl
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/package.json.tmpl
@@ -40,6 +40,7 @@
 		"@midnight-ntwrk/midnight-js-node-zk-config-provider": "^4.0.0",
 		"@midnight-ntwrk/midnight-js-types": "^4.0.0",
 		"@midnight-ntwrk/midnight-js-utils": "^4.0.0",
+		"@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
 		"@midnight-ntwrk/wallet-sdk-address-format": "^3.1.2",
 		"@midnight-ntwrk/wallet-sdk-dust-wallet": "^4.1.0",
 		"@midnight-ntwrk/wallet-sdk-facade": "^4.0.1",

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/base-command.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/base-command.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
-import { Command, Flags } from "@oclif/core";
-import { classifyError, formatError } from "./lib/errors.js";
+import { Command } from "@oclif/core";
 import { initializeNetwork } from "./lib/config.js";
+import { INIT_MARKER, STATE_DIR } from "./lib/constants.js";
+import { classifyError, formatError } from "./lib/errors.js";
 import { setJsonMode } from "./lib/progress.js";
-import { STATE_DIR, INIT_MARKER } from "./lib/constants.js";
 
 const WELCOME_BANNER = `
   ┌─────────────────────────────────────────────────────────────┐
@@ -15,26 +15,20 @@ const WELCOME_BANNER = `
 `;
 
 export abstract class BaseCommand extends Command {
-	static baseFlags = {
-		json: Flags.boolean({
-			description: "Output result as JSON",
-			default: false,
-		}),
-	};
+	// Opt in to oclif's built-in `--json` flag. When `--json` is passed,
+	// `this.jsonEnabled()` returns true. (In @oclif/core v4 `jsonEnabled` is a
+	// method on the base Command, so we must call it, not assign to it.)
+	static override enableJsonFlag = true;
 
-	protected jsonEnabled = false;
-
-	async init(): Promise<void> {
+	override async init(): Promise<void> {
 		await super.init();
-		const { flags } = await this.parse(this.constructor as typeof BaseCommand);
-		this.jsonEnabled = flags.json;
-		setJsonMode(this.jsonEnabled);
+		setJsonMode(this.jsonEnabled());
 		initializeNetwork();
 		this.showWelcomeBanner();
 	}
 
 	private showWelcomeBanner(): void {
-		if (this.jsonEnabled) return;
+		if (this.jsonEnabled()) return;
 
 		const markerPath = path.join(process.cwd(), STATE_DIR, INIT_MARKER);
 		if (fs.existsSync(markerPath)) return;
@@ -49,14 +43,14 @@ export abstract class BaseCommand extends Command {
 	}
 
 	protected outputResult(result: unknown): void {
-		if (this.jsonEnabled) {
+		if (this.jsonEnabled()) {
 			this.log(JSON.stringify(result, null, "\t"));
 		}
 	}
 
-	async catch(err: unknown): Promise<void> {
+	override async catch(err: unknown): Promise<void> {
 		const classified = classifyError(err);
-		if (this.jsonEnabled) {
+		if (this.jsonEnabled()) {
 			this.log(
 				JSON.stringify(
 					{ error: classified.code, message: classified.message, action: classified.action },

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/balance.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/balance.ts
@@ -1,10 +1,10 @@
-import { Args } from "@oclif/core";
 import { unshieldedToken } from "@midnight-ntwrk/ledger-v8";
+import { Args } from "@oclif/core";
 import * as Rx from "rxjs";
 import { BaseCommand } from "../base-command.js";
 import { DUST_POLL_INTERVAL } from "../lib/constants.js";
-import { buildFacade, getWallet } from "../lib/wallet.js";
 import { withSpinner } from "../lib/progress.js";
+import { buildFacade, getWallet } from "../lib/wallet.js";
 
 export default class Balance extends BaseCommand {
 	static override description = "Check NIGHT and DUST balances for a wallet";
@@ -27,14 +27,14 @@ export default class Balance extends BaseCommand {
 			);
 
 			const night = state.unshielded.balances[unshieldedToken().raw] ?? 0n;
-			const dust = state.dust.walletBalance(new Date());
+			const dust = state.dust.balance(new Date());
 
 			const result = {
 				night: night.toString(),
 				dust: dust.toString(),
 			};
 
-			if (!this.jsonEnabled) {
+			if (!this.jsonEnabled()) {
 				this.log(`  NIGHT: ${night.toString()}`);
 				this.log(`  DUST:  ${dust.toString()}`);
 			}

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/deploy.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/deploy.ts
@@ -1,11 +1,11 @@
 import { Flags } from "@oclif/core";
 import { BaseCommand } from "../base-command.js";
-import { buildFacade, getWallet } from "../lib/wallet.js";
-import { createProviders } from "../lib/providers.js";
-import { deploy } from "../lib/contract.js";
 import { CONTRACT_NAME } from "../lib/constants.js";
-import { withSpinner } from "../lib/progress.js";
+import { deploy } from "../lib/contract.js";
 import { waitForFunds } from "../lib/funding.js";
+import { withSpinner } from "../lib/progress.js";
+import { createProviders } from "../lib/providers.js";
+import { buildFacade, getWallet } from "../lib/wallet.js";
 
 export default class Deploy extends BaseCommand {
 	static override description = "Deploy the compiled contract to devnet";
@@ -38,8 +38,8 @@ export default class Deploy extends BaseCommand {
 
 			const result = await deploy(providers, {});
 
-			if (!this.jsonEnabled) {
-				this.log(`  Contract deployed!`);
+			if (!this.jsonEnabled()) {
+				this.log("  Contract deployed!");
 				this.log(`  Address:      ${result.contractAddress}`);
 				this.log(`  Transaction:  ${result.txId}`);
 				this.log(`  Block:        ${result.blockHeight.toString()}`);

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/devnet/start.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/devnet/start.ts
@@ -8,16 +8,16 @@ export default class DevnetStart extends BaseCommand {
 	async run(): Promise<void> {
 		const composeFile = findComposeFile();
 
-		if (!this.jsonEnabled) {
+		if (!this.jsonEnabled()) {
 			this.log(`  Using: ${composeFile}`);
 		}
 
 		execSync(`docker compose -f "${composeFile}" up -d`, {
-			stdio: this.jsonEnabled ? "pipe" : "inherit",
+			stdio: this.jsonEnabled() ? "pipe" : "inherit",
 		});
 
 		const result = { composePath: composeFile, started: true };
-		if (!this.jsonEnabled) {
+		if (!this.jsonEnabled()) {
 			this.log("  Devnet started.");
 		}
 		this.outputResult(result);

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/devnet/status.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/devnet/status.ts
@@ -37,7 +37,7 @@ export default class DevnetStatus extends BaseCommand {
 			proofServer: services[2],
 		};
 
-		if (!this.jsonEnabled) {
+		if (!this.jsonEnabled()) {
 			for (const svc of services) {
 				const icon = svc.healthy ? "+" : "x";
 				this.log(`  [${icon}] ${svc.name}: ${svc.url}`);

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/devnet/stop.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/devnet/stop.ts
@@ -9,10 +9,10 @@ export default class DevnetStop extends BaseCommand {
 		const composeFile = findComposeFile();
 
 		execSync(`docker compose -f "${composeFile}" down`, {
-			stdio: this.jsonEnabled ? "pipe" : "inherit",
+			stdio: this.jsonEnabled() ? "pipe" : "inherit",
 		});
 
-		if (!this.jsonEnabled) {
+		if (!this.jsonEnabled()) {
 			this.log("  Devnet stopped.");
 		}
 		this.outputResult({ stopped: true });

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/dust/register.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/dust/register.ts
@@ -1,8 +1,8 @@
 import { Args } from "@oclif/core";
 import { BaseCommand } from "../../base-command.js";
-import { buildFacade, getWallet } from "../../lib/wallet.js";
 import { registerDust, waitForDust, waitForFunds } from "../../lib/funding.js";
 import { withSpinner } from "../../lib/progress.js";
+import { buildFacade, getWallet } from "../../lib/wallet.js";
 
 export default class DustRegister extends BaseCommand {
 	static override description = "Register NIGHT UTXOs for DUST generation";
@@ -22,12 +22,12 @@ export default class DustRegister extends BaseCommand {
 
 			if (txId) {
 				await withSpinner("Waiting for DUST...", () => waitForDust(ctx.facade));
-				if (!this.jsonEnabled) {
+				if (!this.jsonEnabled()) {
 					this.log(`  DUST registered. tx: ${txId}`);
 				}
 				this.outputResult({ txId, registered: true });
 			} else {
-				if (!this.jsonEnabled) {
+				if (!this.jsonEnabled()) {
 					this.log("  DUST already available.");
 				}
 				this.outputResult({ txId: null, registered: false });

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/dust/status.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/dust/status.ts
@@ -2,8 +2,8 @@ import { Args } from "@oclif/core";
 import * as Rx from "rxjs";
 import { BaseCommand } from "../../base-command.js";
 import { DUST_POLL_INTERVAL } from "../../lib/constants.js";
-import { buildFacade, getWallet } from "../../lib/wallet.js";
 import { withSpinner } from "../../lib/progress.js";
+import { buildFacade, getWallet } from "../../lib/wallet.js";
 
 export default class DustStatus extends BaseCommand {
 	static override description = "Check DUST balance and registration status";
@@ -25,7 +25,7 @@ export default class DustStatus extends BaseCommand {
 				),
 			);
 
-			const balance = state.dust.walletBalance(new Date());
+			const balance = state.dust.balance(new Date());
 			const available = state.dust.availableCoins.length;
 			const registered = state.unshielded.availableCoins.filter(
 				(c: { meta?: { registeredForDustGeneration?: boolean } }) =>
@@ -38,7 +38,7 @@ export default class DustStatus extends BaseCommand {
 				registered,
 			};
 
-			if (!this.jsonEnabled) {
+			if (!this.jsonEnabled()) {
 				this.log(`  DUST balance:    ${balance.toString()}`);
 				this.log(`  Available coins: ${String(available)}`);
 				this.log(`  Registered:      ${String(registered)}`);

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/join.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/join.ts
@@ -1,11 +1,11 @@
 import { Args, Flags } from "@oclif/core";
 import { BaseCommand } from "../base-command.js";
-import { buildFacade, getWallet } from "../lib/wallet.js";
-import { createProviders } from "../lib/providers.js";
-import { join } from "../lib/contract.js";
 import { CONTRACT_NAME } from "../lib/constants.js";
-import { withSpinner } from "../lib/progress.js";
+import { join } from "../lib/contract.js";
 import { waitForFunds } from "../lib/funding.js";
+import { withSpinner } from "../lib/progress.js";
+import { createProviders } from "../lib/providers.js";
+import { buildFacade, getWallet } from "../lib/wallet.js";
 
 export default class Join extends BaseCommand {
 	static override description = "Join an existing deployed contract";
@@ -43,7 +43,7 @@ export default class Join extends BaseCommand {
 
 			await join(providers, args.address, {});
 
-			if (!this.jsonEnabled) {
+			if (!this.jsonEnabled()) {
 				this.log(`  Joined contract at: ${args.address}`);
 			}
 

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/wallet/create.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/wallet/create.ts
@@ -1,8 +1,8 @@
+import { getNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
+import { createKeystore } from "@midnight-ntwrk/wallet-sdk-unshielded-wallet";
 import { Args } from "@oclif/core";
 import { BaseCommand } from "../../base-command.js";
-import { newSeed, deriveKeys, saveWallet } from "../../lib/wallet.js";
-import { createKeystore } from "@midnight-ntwrk/wallet-sdk-unshielded-wallet";
-import { getNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
+import { deriveKeys, newSeed, saveWallet } from "../../lib/wallet.js";
 
 export default class WalletCreate extends BaseCommand {
 	static override description = "Generate a new wallet with a random seed";
@@ -21,7 +21,8 @@ export default class WalletCreate extends BaseCommand {
 		const seed = newSeed();
 		const keys = deriveKeys(seed);
 		const keystore = createKeystore(keys.nightExternal, getNetworkId());
-		const address = keystore.getBech32Address();
+		// getBech32Address() returns a branded MidnightBech32m; persist the string.
+		const address = keystore.getBech32Address().toString();
 
 		const wallet = {
 			seed,
@@ -31,7 +32,7 @@ export default class WalletCreate extends BaseCommand {
 
 		saveWallet(name, wallet);
 
-		if (!this.jsonEnabled) {
+		if (!this.jsonEnabled()) {
 			this.log(`Wallet "${name}" created.`);
 			this.log(`  Address: ${address}`);
 			this.log(`  Seed:    ${seed}`);

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/wallet/fund.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/wallet/fund.ts
@@ -1,8 +1,8 @@
 import { Args, Flags } from "@oclif/core";
 import { BaseCommand } from "../../base-command.js";
-import { buildFacade, getWallet } from "../../lib/wallet.js";
-import { airdropFromGenesis, registerDust, waitForFunds, waitForDust } from "../../lib/funding.js";
+import { airdropFromGenesis, registerDust, waitForDust, waitForFunds } from "../../lib/funding.js";
 import { withSpinner } from "../../lib/progress.js";
+import { buildFacade, getWallet } from "../../lib/wallet.js";
 
 export default class WalletFund extends BaseCommand {
 	static override description = "Fund a wallet from the genesis account and register for DUST";
@@ -29,7 +29,7 @@ export default class WalletFund extends BaseCommand {
 
 		// Step 1: Airdrop from genesis
 		const txId = await airdropFromGenesis(wallet.address, amount);
-		if (!this.jsonEnabled) {
+		if (!this.jsonEnabled()) {
 			this.log(`  Airdrop tx: ${txId}`);
 		}
 
@@ -41,13 +41,13 @@ export default class WalletFund extends BaseCommand {
 			// Step 3: Register for DUST
 			const dustTx = await registerDust(ctx.facade, ctx.keystore);
 			if (dustTx) {
-				if (!this.jsonEnabled) {
+				if (!this.jsonEnabled()) {
 					this.log(`  DUST registration tx: ${dustTx}`);
 				}
 				await withSpinner("Waiting for DUST generation...", () => waitForDust(ctx.facade));
 			}
 
-			if (!this.jsonEnabled) {
+			if (!this.jsonEnabled()) {
 				this.log(`  Wallet "${args.name}" funded and DUST registered.`);
 			}
 

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/wallet/info.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/wallet/info.ts
@@ -22,7 +22,7 @@ export default class WalletInfo extends BaseCommand {
 			createdAt: wallet.createdAt,
 		};
 
-		if (!this.jsonEnabled) {
+		if (!this.jsonEnabled()) {
 			this.log(`Wallet: ${args.name}`);
 			this.log(`  Address:    ${wallet.address}`);
 			this.log(`  Created:    ${wallet.createdAt}`);

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/wallet/list.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/wallet/list.ts
@@ -9,7 +9,7 @@ export default class WalletList extends BaseCommand {
 		const entries = Object.entries(store);
 
 		if (entries.length === 0) {
-			if (!this.jsonEnabled) {
+			if (!this.jsonEnabled()) {
 				this.log("No wallets found. Run `wallet:create` to create one.");
 			}
 			this.outputResult([]);
@@ -18,7 +18,7 @@ export default class WalletList extends BaseCommand {
 
 		const result = entries.map(([name, w]) => ({ name, address: w.address }));
 
-		if (!this.jsonEnabled) {
+		if (!this.jsonEnabled()) {
 			for (const { name, address } of result) {
 				this.log(`  ${name}: ${address}`);
 			}

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/constants.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/constants.ts
@@ -13,6 +13,11 @@ export const FILE_MODE_PUBLIC = 0o644;
 export const GENESIS_SEED = "0000000000000000000000000000000000000000000000000000000000000001";
 export const SEED_LENGTH = 64; // hex chars = 32 bytes
 
+// Local devnet private-state encryption. The level private-state provider
+// encrypts persisted private state at rest; on a throwaway local devnet a fixed
+// dev password is fine. Replace with a real secret for any non-local network.
+export const LOCAL_PRIVATE_STATE_PASSWORD = "midnight-local-devnet";
+
 // Network
 export const DEFAULT_TTL_MINUTES = 10;
 
@@ -36,12 +41,9 @@ export const NIGHT_DECIMALS = 6;
 export const DUST_DECIMALS = 15;
 
 // Devnet compose file search order
-export const COMPOSE_SEARCH_PATHS = [
-	"devnet.yml",
-	path.join(".midnight", "devnet.yml"),
-];
+export const COMPOSE_SEARCH_PATHS = ["devnet.yml", path.join(".midnight", "devnet.yml")];
 export const COMPOSE_FALLBACK = path.join(
-	process.env["HOME"] ?? "~",
+	process.env.HOME ?? "~",
 	".midnight-expert",
 	"devnet",
 	"devnet.yml",

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/contract.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/contract.ts
@@ -1,16 +1,16 @@
 import fs from "node:fs";
 import path from "node:path";
-import { deployContract, findDeployedContract } from "@midnight-ntwrk/midnight-js-contracts";
 import { CompiledContract } from "@midnight-ntwrk/compact-js";
-import type { Providers } from "./providers.js";
+import { deployContract, findDeployedContract } from "@midnight-ntwrk/midnight-js-contracts";
 import {
-	CONTRACT_NAME,
 	CONTRACTS_FILE,
+	CONTRACT_NAME,
 	FILE_MODE_PUBLIC,
 	STATE_DIR,
 	ZK_CONFIG_PATH,
 } from "./constants.js";
 import { withSpinner } from "./progress.js";
+import type { Providers } from "./providers.js";
 
 // NOTE: The contract module is imported dynamically at runtime because
 // the import path depends on the compiled contract output.
@@ -23,12 +23,21 @@ export async function loadCompiledContract() {
 	);
 }
 
+// The contract type, recovered from loadCompiledContract above. Providers are
+// typed against this (see ./providers.ts) so deployContract / findDeployedContract
+// accept them — they require providers whose circuit-id set matches the contract.
+export type AppContract = Awaited<
+	ReturnType<typeof loadCompiledContract>
+> extends CompiledContract.CompiledContract<infer C, infer _PS, infer _R>
+	? C
+	: never;
+
 // --- Deploy / Join ---
 
 export interface DeployResult {
 	contractAddress: string;
 	txId: string;
-	blockHeight: bigint;
+	blockHeight: number;
 }
 
 export async function deploy(
@@ -105,7 +114,7 @@ function saveDeployedContract(name: string, result: DeployResult): void {
 	if (!fs.existsSync(dir)) {
 		fs.mkdirSync(dir, { recursive: true });
 	}
-	fs.writeFileSync(contractsPath(), JSON.stringify(store, null, "\t") + "\n", {
+	fs.writeFileSync(contractsPath(), `${JSON.stringify(store, null, "\t")}\n`, {
 		mode: FILE_MODE_PUBLIC,
 	});
 }

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/devnet.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/devnet.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { COMPOSE_SEARCH_PATHS, COMPOSE_FALLBACK } from "./constants.js";
+import { COMPOSE_FALLBACK, COMPOSE_SEARCH_PATHS } from "./constants.js";
 
 export function findComposeFile(): string {
 	for (const relative of COMPOSE_SEARCH_PATHS) {
@@ -9,7 +9,6 @@ export function findComposeFile(): string {
 	}
 	if (fs.existsSync(COMPOSE_FALLBACK)) return COMPOSE_FALLBACK;
 	throw new Error(
-		"No devnet.yml found. Generate one with the midnight-tooling:devnet skill.\n" +
-			"Search paths: " + [...COMPOSE_SEARCH_PATHS, COMPOSE_FALLBACK].join(", "),
+		`No devnet.yml found. Generate one with the midnight-tooling:devnet skill.\nSearch paths: ${[...COMPOSE_SEARCH_PATHS, COMPOSE_FALLBACK].join(", ")}`,
 	);
 }

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/errors.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/errors.ts
@@ -61,7 +61,7 @@ export function classifyError(err: unknown): ClassifiedError {
 		};
 	}
 
-	if (lower.includes("stale") || lower.includes("utxo") && lower.includes("spent")) {
+	if (lower.includes("stale") || (lower.includes("utxo") && lower.includes("spent"))) {
 		return {
 			code: ErrorCode.STALE_UTXO,
 			message,

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/funding.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/funding.ts
@@ -1,5 +1,6 @@
-import * as ledger from "@midnight-ntwrk/ledger-v8";
 import { unshieldedToken } from "@midnight-ntwrk/ledger-v8";
+import { getNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
+import { MidnightBech32m, UnshieldedAddress } from "@midnight-ntwrk/wallet-sdk-address-format";
 import type { WalletFacade } from "@midnight-ntwrk/wallet-sdk-facade";
 import type { UnshieldedKeystore } from "@midnight-ntwrk/wallet-sdk-unshielded-wallet";
 import * as Rx from "rxjs";
@@ -9,8 +10,8 @@ import {
 	FUND_POLL_INTERVAL,
 	GENESIS_SEED,
 } from "./constants.js";
-import { buildFacade, type WalletContext } from "./wallet.js";
 import { withSpinner } from "./progress.js";
+import { buildFacade } from "./wallet.js";
 
 export async function waitForFunds(facade: WalletFacade): Promise<bigint> {
 	return Rx.firstValueFrom(
@@ -28,17 +29,14 @@ export async function waitForDust(facade: WalletFacade): Promise<bigint> {
 		facade.state().pipe(
 			Rx.throttleTime(DUST_POLL_INTERVAL),
 			Rx.filter((s) => s.isSynced),
-			Rx.map((s) => s.dust.walletBalance(new Date())),
+			Rx.map((s) => s.dust.balance(new Date())),
 			Rx.filter((balance) => balance > 0n),
 			Rx.timeout(DUST_GENERATION_TIMEOUT),
 		),
 	);
 }
 
-export async function airdropFromGenesis(
-	targetAddress: string,
-	amount: bigint,
-): Promise<string> {
+export async function airdropFromGenesis(targetAddress: string, amount: bigint): Promise<string> {
 	return withSpinner("Airdropping from genesis wallet...", async () => {
 		const genesis = await buildFacade(GENESIS_SEED);
 		try {
@@ -52,6 +50,12 @@ export async function airdropFromGenesis(
 			);
 
 			const ttl = new Date(Date.now() + 10 * 60 * 1000);
+			// Addresses are branded types in the 4.x SDK: decode the bech32m
+			// string into a typed UnshieldedAddress for the transfer output.
+			const receiverAddress = MidnightBech32m.parse(targetAddress).decode(
+				UnshieldedAddress,
+				getNetworkId(),
+			);
 			const recipe = await genesis.facade.transferTransaction(
 				[
 					{
@@ -59,7 +63,7 @@ export async function airdropFromGenesis(
 						outputs: [
 							{
 								amount,
-								receiverAddress: targetAddress,
+								receiverAddress,
 								type: unshieldedToken().raw,
 							},
 						],
@@ -89,17 +93,14 @@ export async function registerDust(
 	keystore: UnshieldedKeystore,
 ): Promise<string | null> {
 	return withSpinner("Registering for DUST generation...", async () => {
-		const state = await Rx.firstValueFrom(
-			facade.state().pipe(Rx.filter((s) => s.isSynced)),
-		);
+		const state = await Rx.firstValueFrom(facade.state().pipe(Rx.filter((s) => s.isSynced)));
 
 		if (state.dust.availableCoins.length > 0) {
 			return null; // Already has DUST
 		}
 
 		const nightUtxos = state.unshielded.availableCoins.filter(
-			(coin: { meta?: { registeredForDustGeneration?: boolean } }) =>
-				!coin.meta?.registeredForDustGeneration,
+			(coin) => !coin.meta.registeredForDustGeneration,
 		);
 
 		if (nightUtxos.length === 0) {
@@ -109,12 +110,16 @@ export async function registerDust(
 		const dustState = state.dust;
 		const ttl = new Date(Date.now() + 10 * 60 * 1000);
 
+		// createDustGenerationTransaction expects the Dust wallet's UtxoWithMeta
+		// shape (the ledger Utxo flattened with its `ctime`). `ctime` is already a
+		// Date on the unshielded wallet's UtxoWithMeta.
 		const recipe = await facade.dust.createDustGenerationTransaction(
 			new Date(),
 			ttl,
-			nightUtxos.map((u: { utxo: unknown; meta: { ctime: string } }) => ({
+			nightUtxos.map((u) => ({
 				...u.utxo,
-				ctime: new Date(u.meta.ctime),
+				ctime: u.meta.ctime,
+				registeredForDustGeneration: u.meta.registeredForDustGeneration,
 			})),
 			keystore.getPublicKey(),
 			dustState.address,

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/providers.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/providers.ts
@@ -1,29 +1,27 @@
+import type { ProvableCircuitId } from "@midnight-ntwrk/compact-js";
+import type * as ledger from "@midnight-ntwrk/ledger-v8";
+import type { ContractProviders } from "@midnight-ntwrk/midnight-js-contracts";
 import { httpClientProofProvider } from "@midnight-ntwrk/midnight-js-http-client-proof-provider";
 import { indexerPublicDataProvider } from "@midnight-ntwrk/midnight-js-indexer-public-data-provider";
 import { levelPrivateStateProvider } from "@midnight-ntwrk/midnight-js-level-private-state-provider";
 import { NodeZkConfigProvider } from "@midnight-ntwrk/midnight-js-node-zk-config-provider";
 import type { MidnightProvider, WalletProvider } from "@midnight-ntwrk/midnight-js-types";
 import type { WalletFacade } from "@midnight-ntwrk/wallet-sdk-facade";
-import type * as ledger from "@midnight-ntwrk/ledger-v8";
+import type { UnshieldedKeystore } from "@midnight-ntwrk/wallet-sdk-unshielded-wallet";
 import * as Rx from "rxjs";
 import { DEVNET_CONFIG } from "./config.js";
-import { ZK_CONFIG_PATH } from "./constants.js";
-import type { UnshieldedKeystore } from "@midnight-ntwrk/wallet-sdk-unshielded-wallet";
+import { LOCAL_PRIVATE_STATE_PASSWORD, ZK_CONFIG_PATH } from "./constants.js";
+import type { AppContract } from "./contract.js";
 
-export interface Providers {
-	privateStateProvider: ReturnType<typeof levelPrivateStateProvider>;
-	publicDataProvider: ReturnType<typeof indexerPublicDataProvider>;
-	zkConfigProvider: NodeZkConfigProvider<string>;
-	proofProvider: ReturnType<typeof httpClientProofProvider>;
-	walletProvider: WalletProvider & MidnightProvider;
-	midnightProvider: WalletProvider & MidnightProvider;
-}
+// The full provider set deployContract / findDeployedContract require for this
+// contract. ContractProviders ties the zkConfigProvider's circuit-id set to the
+// contract's circuits, so the providers are accepted without casting.
+export type Providers = ContractProviders<AppContract>;
 
 export async function createWalletProvider(
 	facade: WalletFacade,
 	shieldedSecretKeys: ledger.ZswapSecretKeys,
 	dustSecretKey: ledger.DustSecretKey,
-	keystore: UnshieldedKeystore,
 ): Promise<WalletProvider & MidnightProvider> {
 	const state = await Rx.firstValueFrom(facade.state().pipe(Rx.filter((s) => s.isSynced)));
 
@@ -50,23 +48,20 @@ export async function createProviders(
 	keystore: UnshieldedKeystore,
 	privateStateStoreName: string,
 ): Promise<Providers> {
-	const walletProvider = await createWalletProvider(
-		facade,
-		shieldedSecretKeys,
-		dustSecretKey,
-		keystore,
-	);
+	const walletProvider = await createWalletProvider(facade, shieldedSecretKeys, dustSecretKey);
 
-	const zkConfigProvider = new NodeZkConfigProvider(ZK_CONFIG_PATH);
+	const zkConfigProvider = new NodeZkConfigProvider<ProvableCircuitId<AppContract>>(ZK_CONFIG_PATH);
 
 	return {
 		privateStateProvider: levelPrivateStateProvider({
 			privateStateStoreName,
+			// Private state is encrypted at rest with this password and scoped to
+			// the wallet address. This is a LOCAL DEVNET CLI (plaintext seeds), so a
+			// fixed dev password is acceptable; use a real secret for any other network.
+			privateStoragePasswordProvider: () => LOCAL_PRIVATE_STATE_PASSWORD,
+			accountId: keystore.getBech32Address().toString(),
 		}),
-		publicDataProvider: indexerPublicDataProvider(
-			DEVNET_CONFIG.indexer,
-			DEVNET_CONFIG.indexerWS,
-		),
+		publicDataProvider: indexerPublicDataProvider(DEVNET_CONFIG.indexer, DEVNET_CONFIG.indexerWS),
 		zkConfigProvider,
 		proofProvider: httpClientProofProvider(DEVNET_CONFIG.proofServer, zkConfigProvider),
 		walletProvider,

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/wallet.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/wallet.ts
@@ -2,23 +2,23 @@ import fs from "node:fs";
 import path from "node:path";
 import * as ledger from "@midnight-ntwrk/ledger-v8";
 import { getNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
-import { WalletFacade } from "@midnight-ntwrk/wallet-sdk-facade";
+import { InMemoryTransactionHistoryStorage } from "@midnight-ntwrk/wallet-sdk-abstractions";
 import { DustWallet } from "@midnight-ntwrk/wallet-sdk-dust-wallet";
+import { WalletEntrySchema, WalletFacade } from "@midnight-ntwrk/wallet-sdk-facade";
 import { HDWallet, Roles, generateRandomSeed } from "@midnight-ntwrk/wallet-sdk-hd";
 import { ShieldedWallet } from "@midnight-ntwrk/wallet-sdk-shielded";
 import {
-	createKeystore,
-	InMemoryTransactionHistoryStorage,
 	PublicKey,
-	UnshieldedWallet,
 	type UnshieldedKeystore,
+	UnshieldedWallet,
+	createKeystore,
 } from "@midnight-ntwrk/wallet-sdk-unshielded-wallet";
 import { WebSocket } from "ws";
 import {
 	ADDITIONAL_FEE_OVERHEAD,
+	DIR_MODE,
 	FEE_BLOCKS_MARGIN,
 	FILE_MODE_PRIVATE,
-	DIR_MODE,
 	SEED_LENGTH,
 	STATE_DIR,
 	WALLETS_FILE,
@@ -59,7 +59,9 @@ export function deriveKeys(seed: string): {
 	dust: Uint8Array;
 } {
 	if (seed.length !== SEED_LENGTH) {
-		throw new Error(`Invalid seed length: expected ${String(SEED_LENGTH)} hex chars, got ${String(seed.length)}`);
+		throw new Error(
+			`Invalid seed length: expected ${String(SEED_LENGTH)} hex chars, got ${String(seed.length)}`,
+		);
 	}
 	const hdWallet = HDWallet.fromSeed(Buffer.from(seed, "hex"));
 	if (hdWallet.type !== "seedOk") {
@@ -96,11 +98,15 @@ export async function buildFacade(seed: string): Promise<WalletContext> {
 			indexerHttpUrl: "http://127.0.0.1:8088/api/v4/graphql",
 			indexerWsUrl: "ws://127.0.0.1:8088/api/v4/graphql/ws",
 		},
+		// The default submission service submits via the node's RPC relay.
+		relayURL: new URL("http://127.0.0.1:9944"),
 		costParameters: {
 			additionalFeeOverhead: ADDITIONAL_FEE_OVERHEAD,
 			feeBlocksMargin: FEE_BLOCKS_MARGIN,
 		},
-		txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+		// In the 4.x SDK the in-memory storage lives in wallet-sdk-abstractions
+		// and takes the entry schema (WalletEntrySchema) so it can serialize.
+		txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema),
 	};
 
 	const facade = await WalletFacade.init({
@@ -109,7 +115,7 @@ export async function buildFacade(seed: string): Promise<WalletContext> {
 		unshielded: (cfg) =>
 			UnshieldedWallet({
 				...cfg,
-				txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+				txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema),
 			}).startWithPublicKey(PublicKey.fromKeyStore(keystore)),
 		dust: (cfg) =>
 			DustWallet(cfg).startWithSecretKey(
@@ -146,7 +152,7 @@ export function loadWallets(): WalletStore {
 export function saveWallets(store: WalletStore): void {
 	ensureStateDir();
 	const filePath = walletsPath();
-	fs.writeFileSync(filePath, JSON.stringify(store, null, "\t") + "\n", {
+	fs.writeFileSync(filePath, `${JSON.stringify(store, null, "\t")}\n`, {
 		mode: FILE_MODE_PRIVATE,
 	});
 }
@@ -155,9 +161,7 @@ export function getWallet(name: string): StoredWallet {
 	const store = loadWallets();
 	const wallet = store[name];
 	if (!wallet) {
-		throw new Error(
-			`Wallet "${name}" not found. Run \`wallet:create ${name}\` to create it.`,
-		);
+		throw new Error(`Wallet "${name}" not found. Run \`wallet:create ${name}\` to create it.`);
 	}
 	return wallet;
 }

--- a/plugins/midnight-dapp-dev/.claude-plugin/plugin.json
+++ b/plugins/midnight-dapp-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-dapp-dev",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Scaffold and build Midnight DApp frontends \u2014 Vite + React 19 + shadcn + Tailwind v4 templates, wallet integration, provider architecture, and a development agent for ongoing UI work.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-dapp-dev/skills/core/templates/ui/package.json
+++ b/plugins/midnight-dapp-dev/skills/core/templates/ui/package.json
@@ -12,7 +12,7 @@
     "copy-contract-keys": "echo 'TODO: Configure contract key paths. Example: cp -r ../contract/dist/managed/*/keys/* ./public/keys && cp -r ../contract/dist/managed/*/zkir/* ./public/zkir'"
   },
   "dependencies": {
-    "{{API_PACKAGE_NAME}}": "workspace:*",
+    "{{API_PACKAGE_NAME}}": "*",
     "@midnight-ntwrk/dapp-connector-api": "^4.0.1",
     "@midnight-ntwrk/midnight-js-types": "^4.1.1",
     "@radix-ui/react-slot": "^1.2.0",
@@ -39,7 +39,7 @@
     "tailwindcss": "^4.1.0",
     "typescript": "^5.8.0",
     "vite": "^7.0.0",
-    "vite-plugin-node-polyfills": "^0.23.0",
+    "vite-plugin-node-polyfills": "^0.28.0",
     "vite-plugin-top-level-await": "^1.5.0",
     "vite-plugin-wasm": "^3.4.1",
     "vitest": "^3.2.0"

--- a/plugins/midnight-dapp-dev/skills/init/scripts/init.sh
+++ b/plugins/midnight-dapp-dev/skills/init/scripts/init.sh
@@ -101,7 +101,11 @@ cp -r "$TEMPLATES_DIR/api" "$API_DIR"
 
 # Run substitution across all files
 find "$UI_DIR" "$API_DIR" -type f | while read -r file; do
-  if file "$file" | grep -q text; then
+  # Substitute placeholders in text files only. `grep -Iq .` is a portable text
+  # test (the -I flag treats binary files as non-matching); avoid `file | grep
+  # text`, which skips JSON on macOS (libmagic reports "JSON data", not "text"),
+  # leaving package.json placeholders like {{UI_PACKAGE_NAME}} unsubstituted.
+  if grep -Iq . "$file"; then
     sed -i'' -e "s|{{PROJECT_NAME}}|$PROJECT_NAME|g" "$file"
     sed -i'' -e "s|{{UI_PACKAGE_NAME}}|$UI_PACKAGE_NAME|g" "$file"
     sed -i'' -e "s|{{API_PACKAGE_NAME}}|$API_PACKAGE_NAME|g" "$file"


### PR DESCRIPTION
Fixes the two scaffold templates flagged in the new-developer walkthrough (WI#4: template drift). Both were reproduced and verified locally.

## compact-cli-dev CLI template (4.x SDK)
The generated CLI no longer type-checked against the current 4.x SDK (**18 `tsc` errors**). Every API usage was brought in line with the installed packages and **verified against a real compiled counter contract** (not a stub):

- **oclif v4** makes `jsonEnabled` a *method*, not a settable property → opt into native `--json` (`static enableJsonFlag = true`), call `this.jsonEnabled()`, add the `override` modifiers `noImplicitOverride` now requires.
- `InMemoryTransactionHistoryStorage` **moved** to `wallet-sdk-abstractions` and now takes `WalletEntrySchema`; the submission config now requires `relayURL: URL` (the devnet node RPC).
- `DustWalletState.walletBalance` → `balance`; corrected the unshielded `UtxoWithMeta` shape (`ctime` is a `Date`, plus `registeredForDustGeneration`); decode bech32m strings into a branded `UnshieldedAddress` for transfer outputs.
- `levelPrivateStateProvider` now requires `privateStoragePasswordProvider` + `accountId`; providers typed as `ContractProviders<AppContract>` with the zk-config provider carrying the contract's branded circuit id so `deployContract`/`findDeployedContract` accept them without casts.
- `getBech32Address()` returns a branded `MidnightBech32m` (persist the string); deploy `blockHeight` is a `number`, not `bigint`; declared the now-direct `wallet-sdk-abstractions` dependency.

Also brought the scaffold to **`biome check` clean** (it shipped with 27 pre-existing lint/format violations, so a fresh scaffold's own pre-push hook + CI failed out of the box).

**Verified:** render + `tsc --noEmit` (0 errors) and `biome check` (0 errors) against a real compiled counter contract.

## midnight-dapp-dev UI template (npm)
`npm install` failed two ways and the macOS scaffold shipped unsubstituted placeholders:

- API workspace dep used pnpm/yarn `workspace:*` (npm: `EUNSUPPORTEDPROTOCOL`) → `*`, matching the API template's convention.
- `vite-plugin-node-polyfills@^0.23.0` peers vite ≤ 6 but the template pins vite 7 (`ERESOLVE`) → bump to `^0.28.0` (lists vite 7/8 as peers).
- `init.sh`'s `file … | grep -q text` guard skips JSON on macOS (libmagic reports "JSON data"), so `package.json` shipped with literal `{{…}}` placeholders → use the portable `grep -Iq .` text test.

**Verified:** scaffold + `npm install` (exit 0) and UI `tsc --noEmit` (0 errors) on macOS with npm.

Bumps `compact-cli-dev` and `midnight-dapp-dev` to **0.6.0**. Does not touch `marketplace.json` (its bump rides with the case-sensitivity PR).

Generated with [Claude Code](https://claude.com/claude-code)