### PR TITLE
fix: document devs plugin dependency and improve missing-devs diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ This project extends the Midnight Network with additional developer tooling.
 - **~37,700** Lines of reference documentation
 - **~21,800** Lines of example code
 
+## Prerequisites
+
+Some plugins in this marketplace (`compact-core`, `midnight-verify`) reference skills and agents from the **`devs`** plugin, which lives in a separate marketplace — [`aaronbassett/agent-foundry`](https://github.com/aaronbassett/agent-foundry). Install it before or alongside the midnight-expert plugins to avoid broken cross-references:
+
+```bash
+claude plugin marketplace add aaronbassett/agent-foundry
+claude plugin install devs@agent-foundry
+```
+
+> [!NOTE]
+> The Claude Code plugin schema does not currently have a `dependencies` field, so cross-marketplace dependencies cannot be declared in `plugin.json`. The `midnight-expert:doctor` command will flag missing `devs` references and show you the fix commands if this step is skipped.
+
 ## Install
 
 ### Automatic install for Claude Code

--- a/plugins/midnight-expert/skills/doctor/references/fix-table.md
+++ b/plugins/midnight-expert/skills/doctor/references/fix-table.md
@@ -76,6 +76,7 @@ The cross-refs check resolves three reference types: skills (`skills/<name>/SKIL
 |-------|-----|
 | Target marketplace not installed | Install the marketplace first (see Plugin Issues) |
 | Target plugin not installed | Install from the correct marketplace |
+| `devs` plugin not installed | `claude plugin marketplace add aaronbassett/agent-foundry` then `claude plugin install devs@agent-foundry` — `devs` lives outside this marketplace; see the Prerequisites section in the README |
 | Skill / agent / command not found in installed plugin | Plugin may be outdated — run `claude plugin update <name>` |
 | Reference points to renamed or removed item | Source plugin's prose is stale; report to the plugin maintainer or open an issue against this repo |
 

--- a/plugins/midnight-expert/skills/doctor/scripts/check-cross-refs.sh
+++ b/plugins/midnight-expert/skills/doctor/scripts/check-cross-refs.sh
@@ -156,7 +156,11 @@ for ref in "${REFS[@]}"; do
 
   # Check if target plugin is installed
   if [ -z "$target_path" ]; then
-    emit "$source → $target_name:$ref_name" "critical" "$target_name not installed"
+    if [ "$target_name" = "devs" ]; then
+      emit "$source → $target_name:$ref_name" "critical" "devs plugin not installed — fix: claude plugin marketplace add aaronbassett/agent-foundry && claude plugin install devs@agent-foundry"
+    else
+      emit "$source → $target_name:$ref_name" "critical" "$target_name not installed"
+    fi
     fail=1
     continue
   fi


### PR DESCRIPTION
## Problem

`compact-core` and `midnight-verify` reference skills and agents from the `devs` plugin (`devs:code-review`, `devs:typescript-core`, `devs:security-core`, `devs:deps-maintenance`), but the `devs` plugin lives in a separate marketplace — `aaronbassett/agent-foundry` — that is not mentioned anywhere in this repo. Fresh installs silently produce broken cross-references with no guidance on how to fix them.

### Why this can't be declared in `plugin.json`

The Claude Code plugin schema does not currently have a `dependencies` field, so cross-marketplace dependencies cannot be expressed declaratively. Until that capability exists, documentation and diagnostics are the only available mitigation.

### Graceful fallback status

`midnight-verify` already has a partial fallback for its `devs:deps-maintenance` reference — it falls back to `npm view` directly when the agent isn't available. `compact-core` agents (`devs:code-review`, `devs:typescript-core`, `devs:security-core`) do **not** have fallbacks and will silently fail without `devs` installed.

## Changes

### `README.md`
Added a **Prerequisites** section immediately before the Install section, with the two commands needed to add the `agent-foundry` marketplace and install `devs`. Also notes why the dependency isn't declared in `plugin.json`.

### `plugins/midnight-expert/skills/doctor/scripts/check-cross-refs.sh`
For the `devs not installed` FAIL case, the detail message now includes the actionable fix commands rather than the generic `"devs not installed"` string. Other missing-plugin messages are unchanged.

### `plugins/midnight-expert/skills/doctor/references/fix-table.md`
Added a dedicated row under **Cross-Plugin Reference Issues** for the `devs plugin not installed` case, with the two-command recipe and a pointer to the Prerequisites section in the README.

## Test plan

- [ ] Run `/midnight-expert:doctor` on a fresh install without `devs` — confirm the FAIL detail now includes the install commands
- [ ] Install `devs@agent-foundry` and re-run — confirm cross-ref checks pass for `compact-core → devs:*` and `midnight-verify → devs:deps-maintenance`
- [ ] Verify Prerequisites section renders correctly on GitHub and in the Claude Code plugin browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)