### PR TITLE
docs: mark native Windows unsupported, recommend WSL

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "midnight-expert",
   "metadata": {
-    "version": "0.50.0",
+    "version": "0.50.1",
     "description": "AI agent plugins for the Midnight data-protection blockchain. Covers Compact smart contract development, privacy-preserving patterns, DApp frontend design, and Midnight toolchain management."
   },
   "owner": {

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ This project extends the Midnight Network with additional developer tooling.
 
 ## Install
 
+> [!IMPORTANT]
+> **Platform support: macOS and Linux.** Midnight Expert is developed and tested on macOS and Linux only. Native Windows (PowerShell, CMD, Git Bash/MSYS2, Cygwin) is **untested and unsupported** — the plugins' hooks and shell scripts assume a POSIX environment and are known to misbehave there (for example, a bare `compact` resolving to the unrelated Windows `compact.exe`, and path/encoding handling breaking under Git Bash).
+>
+> **Windows users should run everything inside [WSL](https://learn.microsoft.com/windows/wsl/) (WSL2 recommended).** Install a Linux distribution, then install Node.js, the Compact toolchain, Claude Code, and Midnight Expert *inside* the WSL environment — not on the Windows host. Under WSL the plugins behave exactly as they do on native Linux.
+
 ### Automatic install for Claude Code
 
 Run this in your terminal and follow the prompts:

--- a/plugins/midnight-expert/.claude-plugin/plugin.json
+++ b/plugins/midnight-expert/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "midnight-expert",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Meta-plugin for the midnight-expert marketplace. Provides comprehensive diagnostics and health reporting for the entire midnight-expert ecosystem — plugin installation, MCP server connectivity, external CLI tools, cross-plugin references, and NPM registry access.",
   "author": {
     "name": "Aaron Bassett",

--- a/plugins/midnight-expert/skills/doctor/SKILL.md
+++ b/plugins/midnight-expert/skills/doctor/SKILL.md
@@ -134,6 +134,8 @@ Read `references/fix-table.md` for the fix recipes.
 
 For each FAIL or WARN item in the report, determine the appropriate fix from the fix-table. Use the `platform` info line from check-ext-tools.sh to select macOS vs Linux commands.
 
+**Platform support:** Midnight Expert is developed and tested on macOS and Linux only. If the `platform` line reports `windows` (a `platform support` FAIL is also emitted), the user is on native Windows (Git Bash/MSYS2/Cygwin), which is untested and unsupported. Do not attempt tool-by-tool fixes — instead recommend they run everything inside WSL, per the **Platform Support** section of `references/fix-table.md`. WSL reports as `linux`, so this never fires for WSL users.
+
 **If `$ARGUMENTS` contains `--auto-fix`:**
 - Apply auto-fixable items silently (installs, enables, MCP adds via `claude mcp add`)
 - Always prompt before upgrading outdated tools — show current vs latest version

--- a/plugins/midnight-expert/skills/doctor/references/fix-table.md
+++ b/plugins/midnight-expert/skills/doctor/references/fix-table.md
@@ -17,6 +17,14 @@ Reference for resolving issues found by midnight-expert:doctor. Each section map
 - Docker daemon start on macOS
 - Network/proxy configuration
 
+## Platform Support
+
+Midnight Expert is developed and tested on **macOS and Linux only**. Native Windows (PowerShell, CMD, Git Bash/MSYS2, Cygwin) is untested and unsupported — the plugins' hooks and shell scripts assume a POSIX environment and misbehave on the Windows host.
+
+| Issue | Fix |
+|-------|-----|
+| platform support: native Windows (critical) | Not auto-fixable. Recommend the user run everything inside **WSL** (WSL2 recommended): install a Linux distribution (https://learn.microsoft.com/windows/wsl/install), then install Node.js, the Compact toolchain, Claude Code, and Midnight Expert *inside* the WSL environment — not on the Windows host. Under WSL, `doctor` reports the platform as `linux` and the plugins behave as on native Linux. |
+
 ## Plugin Issues
 
 Plugin not-installed and not-enabled rows are emitted as **info** — install only the plugins you actually need.

--- a/plugins/midnight-expert/skills/doctor/scripts/check-ext-tools.sh
+++ b/plugins/midnight-expert/skills/doctor/scripts/check-ext-tools.sh
@@ -9,11 +9,14 @@ emit() {
   printf '%s | %s | %s\n' "$name" "$status" "$detail"
 }
 
-# Detect OS for fix suggestions
+# Detect OS for fix suggestions.
+# WSL reports "Linux" from uname -s and is fully supported. Native Windows
+# shells (Git Bash/MSYS2, Cygwin) report MINGW*/MSYS*/CYGWIN* and are not.
 OS="unknown"
 case "$(uname -s)" in
-  Darwin*) OS="macos" ;;
-  Linux*)  OS="linux" ;;
+  Darwin*)               OS="macos" ;;
+  Linux*)                OS="linux" ;;
+  MINGW*|MSYS*|CYGWIN*)  OS="windows" ;;
 esac
 
 # Helper: fetch latest GitHub release tag
@@ -165,6 +168,13 @@ fi
 
 # --- OS info ---
 emit "platform" "info" "$OS ($(uname -m))"
+
+# Native Windows is untested and unsupported — recommend WSL. WSL itself reports
+# "Linux" above, so this only fires on Git Bash/MSYS2/Cygwin on the Windows host.
+if [ "$OS" = "windows" ]; then
+  emit "platform support" "critical" "native Windows (Git Bash/MSYS2/Cygwin) is untested and unsupported — run Midnight Expert inside WSL instead; see the fix table"
+  fail=1
+fi
 
 if [ "$fail" -eq 0 ]; then
   emit "ALL_TOOLS_PASS" "pass" "all required tools installed"


### PR DESCRIPTION
## What

Documents that Midnight Expert is developed and tested on **macOS and Linux only**, that **native Windows is untested and unsupported**, and steers Windows users to **WSL** — where the plugins behave as on native Linux.

Motivated by [#204](https://github.com/devrelaicom/midnight-expert/issues/204), whose failures (bare `compact` resolving to the Windows `compact.exe`, Node ESM drive-letter crash, jq encoding fragility) are all artifacts of running the hooks under **native Windows Git Bash** rather than WSL. This PR does not attempt to *fix* Windows — it sets expectations and points users at the supported path.

## Changes

- **`README.md`** — `> [!IMPORTANT]` platform-support callout at the top of **Install**.
- **`doctor` skill** (`midnight-expert`):
  - `scripts/check-ext-tools.sh` — `uname -s` now maps `MINGW*`/`MSYS*`/`CYGWIN*` → a `windows` platform and emits a **`platform support` critical** check recommending WSL. WSL reports `Linux`, so it stays clean.
  - `references/fix-table.md` — new **Platform Support** remediation recipe (not auto-fixable; install a distro + toolchain inside WSL).
  - `SKILL.md` — Step 4 recommends WSL wholesale on native Windows instead of tool-by-tool fixes.
- Patch version bumps: `midnight-expert` `0.8.0 → 0.8.1`, marketplace `0.50.0 → 0.50.1` (separate commit).

## Verification

- `check-ext-tools.sh` runs clean on real Linux (`platform | info | linux`, no false Windows flag).
- A `uname` shim confirms `MINGW64_NT-*`, `MSYS_NT-*`, and `CYGWIN_NT-*` all trip the `platform support` critical check, while `Linux`/`Darwin` (and therefore WSL) do not.

## Notes

The detection is correct *because* it can't distinguish WSL from bare-metal Linux — WSL2 runs a real Linux kernel, so `uname -s` reports `Linux`. Only a shell bound to the Windows NT kernel (MSYS2/Cygwin) reports `*_NT-*` and trips the flag.

Generated with [Claude Code](https://claude.com/claude-code)