### PR TITLE
status-codes: expand error 170 (InvalidDustSpendProof) with verified remediation

### DIFF
--- a/plugins/midnight-status-codes/skills/status-codes-lookup/scripts/codes.json
+++ b/plugins/midnight-status-codes/skills/status-codes-lookup/scripts/codes.json
@@ -2175,9 +2175,11 @@
         "name": "Transaction Malformed Errors (110-139, 166-192)",
         "description": "Transactions that are structurally invalid or fail proof verification."
       },
-      "description": "The dust spend proof is invalid.",
+      "description": "The DUST fee spend proof failed node verification: it was proven against a DUST state the chain has already advanced past, so it no longer validates at the current tip. This is the fee leg, not a fault in the contract or its ZK proof.",
       "fixes": [
-        "Regenerate the dust spend proof using the proof server"
+        "Sync the wallet's DUST state to the current chain tip before submitting. A stale wallet checkpoint or a public indexer running behind the node yields a spend proof the node rejects.",
+        "On 170, rebuild and re-balance the transaction rather than resubmitting the same finalized tx: the stale dust proof is baked into that tx, so resubmitting or re-proving the identical transaction cannot clear it.",
+        "Diagnostic: an instant failure with \"could not balance dust\" (no proving delay) means the DUST state is too stale to balance at all - resync first; a failure after proving with 170 is the block-advance race, which rebuilding the tx on each retry rides through."
       ],
       "aliases": [
         "TransactionMalformed(InvalidDustSpendProof)",


### PR DESCRIPTION
## What

Expands the `description` and `fixes` for node error **170 — `InvalidDustSpendProof`** in `codes.json`.

The existing entry's only fix was *"Regenerate the dust spend proof using the proof server,"* which is incomplete — re-proving or resubmitting the **same** balanced transaction can't clear a 170, because the stale DUST spend proof is baked into that transaction. This adds the remediation that actually works.

## Why

I hit 170 repeatedly deploying a contract to Preprod, and then reproduced it on a **local devnet** where the indexer sits right at the node tip — which ruled out indexer lag and showed the cause was in how the fee transaction was built and retried. What actually landed it:

1. Sync the wallet's DUST state to the current chain tip before submitting (a stale checkpoint or a lagging indexer yields a spend proof the node rejects).
2. On 170, **rebuild and re-balance** the transaction instead of resubmitting the same finalized one.

I also added the practical tell for the two failure modes: an *instant* "could not balance dust" means the DUST is too stale to balance at all (resync first); a 170 *after* proving is the block-advance race (rebuilding on each retry rides through it).

All of this is execution-verified — reproduced, fixed, and deployed to Preprod.

## Checks

- `check-schema.sh` passes
- `tests/run.sh` passes (all)
- `lookup.sh --code 170` renders the updated entry

Only `codes.json` changed; `code` / `name` / `source` / `aliases` / `verified_against` are untouched.
