### PR TITLE
fix(doctor): report optional cross-marketplace refs as info, not FAIL

### DIFF
--- a/plugins/midnight-expert/skills/doctor/references/fix-table.md
+++ b/plugins/midnight-expert/skills/doctor/references/fix-table.md
@@ -80,10 +80,13 @@ Always prompt the user before upgrading, even with --auto-fix.
 
 The cross-refs check resolves three reference types: skills (`skills/<name>/SKILL.md`), agents (`agents/<name>.md`), and slash commands (`commands/<name>.md`).
 
+References into a marketplace other than `midnight-expert` are optional integrations, and a missing one is reported as **info**, not a failure — the sources that reference them define their own fallbacks (`midnight-verify` falls back to `npm view` when `devs:deps-maintenance` is absent). Nothing needs fixing unless you want the extra capability.
+
 | Issue | Fix |
 |-------|-----|
 | Target marketplace not installed | Install the marketplace first (see Plugin Issues) |
-| Target plugin not installed | Install from the correct marketplace |
+| Target plugin not installed (info, external marketplace) | Optional — install it only if you want that integration (e.g. `devs` from `aaronbassett/agent-foundry`) |
+| Target plugin not installed (critical, midnight-expert) | Install from this marketplace (see Plugin Issues) |
 | Skill / agent / command not found in installed plugin | Plugin may be outdated — run `claude plugin update <name>` |
 | Reference points to renamed or removed item | Source plugin's prose is stale; report to the plugin maintainer or open an issue against this repo |
 

--- a/plugins/midnight-expert/skills/doctor/scripts/check-cross-refs.sh
+++ b/plugins/midnight-expert/skills/doctor/scripts/check-cross-refs.sh
@@ -98,6 +98,11 @@ get_cached_version() {
   grep "^$1|" "$CACHE_FILE" 2>/dev/null | head -1 | cut -d'|' -f3
 }
 
+# Marketplace whose plugins this repo ships. References into any other
+# marketplace are optional integrations, not requirements — see the
+# not-installed branch below.
+OWN_MARKETPLACE="midnight-expert"
+
 # Cross-plugin reference map
 # Format: source_plugin|target_plugin@marketplace|ref_type|ref_name
 # ref_type: skill | agent | command
@@ -156,7 +161,16 @@ for ref in "${REFS[@]}"; do
 
   # Check if target plugin is installed
   if [ -z "$target_path" ]; then
-    emit "$source → $target_name:$ref_name" "critical" "$target_name not installed"
+    # A missing plugin from another marketplace is a skipped optional
+    # integration, not a broken install: the sources that reference these
+    # define their own fallbacks (midnight-verify falls back to `npm view`
+    # when devs:deps-maintenance is absent). Report it as info, matching how
+    # check-plugins.sh reports a plugin the user chose not to install.
+    if [ "${target#*@}" != "$OWN_MARKETPLACE" ]; then
+      emit "$source → $target_name:$ref_name" "info" "$target_name not installed (optional, from ${target#*@})"
+    else
+      emit "$source → $target_name:$ref_name" "critical" "$target_name not installed"
+    fi
     fail=1
     continue
   fi


### PR DESCRIPTION
Running `/midnight-expert:doctor` on a healthy install reports four FAILs:

```
compact-core → devs:code-review | critical | devs not installed
compact-core → devs:typescript-core | critical | devs not installed
compact-core → devs:security-core | critical | devs not installed
midnight-verify → devs:deps-maintenance | critical | devs not installed
```

**These references are optional by design.** The `REFS` table already marks them `# (external)`, and the sources that use them define fallbacks — `verify-correctness/SKILL.md` says *"If deps-maintenance is not available (plugin not installed), run `npm view` directly as a fallback."* A dependency with a documented fallback is not a broken install, so it should not be badged FAIL.

`check-plugins.sh` already models the right behaviour: a plugin the user chose not to install is emitted as `info` ("install only what you need") while still setting `fail=1` so the section stays visible. This change mirrors that exactly — references into a marketplace other than `midnight-expert` become `info`; references into `midnight-expert` stay `critical`, since those really are missing dependencies.

| | critical | info | pass |
|---|---|---|---|
| Before | 4 | 0 | 24 |
| After | 0 | 4 | 24 |

`fix-table.md` is updated to match, so the fix guidance no longer tells you to install something you don't need.

### Verification

- Both branches exercised: injecting a reference to a non-existent `midnight-expert` plugin still reports `critical`, confirming genuine missing dependencies are unaffected.
- `bash -n` clean; `scripts/ci/validate.sh` passes (16/16 plugins).

### Notes

- The references are kept, not removed — they resolve correctly for anyone who does have `devs` from `agent-foundry`.
- `fail=1` is deliberately retained so the section still renders; dropping it would hide the rows entirely via the `ALL_REFS_PASS` path, and users would lose sight of the optional integrations.
- No test added: the doctor scripts have no existing tests (only `add-to-ecosystem` does) and CI doesn't run shell tests. Happy to add one in the established `test-*.sh` style if you'd like.

Found while running the doctor before starting a Compact project — the four FAILs sent me looking for a broken install that wasn't there.