### PR TITLE
docs: document builtin protocol key gotcha with self-hosted httpClientProofProvider

### DIFF
--- a/plugins/midnight-dapp-dev/skills/core/references/provider-patterns.md
+++ b/plugins/midnight-dapp-dev/skills/core/references/provider-patterns.md
@@ -77,6 +77,44 @@ The proof server is a separate process that performs the computationally
 intensive ZK proof generation. In the browser, proof generation is delegated
 to this server via HTTP requests rather than running locally.
 
+#### Gotcha: builtin protocol keys with a self-hosted `httpClientProofProvider`
+
+A transaction that touches the shielded pool needs proofs not just for your
+contract's own circuits, but also for protocol-level builtin circuits —
+`midnight/zswap/spend`, `midnight/zswap/output`, `midnight/zswap/sign`,
+`midnight/dust/spend`. These are part of the ledger/kernel (see
+`proof-server:proof-server-architecture`'s `key-material.md` for the
+server-side prefetch/on-demand-fetch mechanics), not something any DApp
+compiles or serves itself.
+
+**Wallet-delegated proving** (`api.getProvingProvider(...)` from the DApp
+Connector, i.e. no `proofServerUri` configured) resolves these builtins
+*internally* inside the wallet — your `zkConfigProvider` is never asked for
+them. Your `zkConfigProvider`/`KeyMaterialProvider` is still consulted for
+your own contract's circuits, just not for the protocol builtins.
+
+**Self-hosted `httpClientProofProvider`** (the pattern shown above) has no
+such fallback. `@midnight-ntwrk/midnight-js-http-client-proof-provider`
+falls through to whatever `zkConfigProvider` you gave it for *any* circuit
+ID it doesn't recognize as a `contract:<address>/<circuitId>` location —
+including the protocol builtins. If your `zkConfigProvider` only serves
+your own contract's `.zkir`/prover/verifier files under
+`window.location.origin` (the common case shown above), fetching
+`midnight/zswap/output` (and friends) 404s, and proving fails with an
+opaque `'check' returned an error` or `key not found: <circuit>` message —
+easy to misdiagnose as a broken proof server or a missing key for your
+*own* circuit rather than a missing builtin.
+
+**Fix:** either don't configure `proofServerUri` at all and let wallet-delegated
+proving handle it (the simplest option — this is why apps that never set a
+proof server URI don't hit this), or, if a self-hosted proof server is a
+hard requirement, intercept builtin circuit IDs before they reach your
+contract's `zkConfigProvider` and resolve them separately (fetch from a
+known-good source, or delegate just those lookups to a wallet-provided
+resolver). `midnightntwrk/passport` (`demo/mn-passport-foundations/app/src/lib/wasmProver.ts`)
+does this with a hand-rolled `SYSTEM_KEYS` map and a `lookupSystemKey()`
+shim checked before falling through to the contract `zkConfigProvider`.
+
 ### 4. walletProvider
 
 **Purpose:** Provides cryptographic keys and transaction balancing. This is

--- a/plugins/proof-server/skills/proof-server-architecture/references/key-material.md
+++ b/plugins/proof-server/skills/proof-server-architecture/references/key-material.md
@@ -85,3 +85,4 @@ A circuit with `k` outside the prefetched range (`10..=15`) will trigger an on-d
 - `proof-server:proof-server-configuration` — `--no-fetch-params` flag details and startup time trade-offs
 - `proof-server:proof-server-architecture` — proving pipeline overview and worker pool
 - `compact-core:compact-circuit-costs` — how circuit structure determines `k` and proof cost
+- `midnight-dapp-dev:core` — client-side counterpart: how a DApp's own `zkConfigProvider` interacts with these same four builtin keys (`midnight/zswap/spend`, `midnight/zswap/output`, `midnight/zswap/sign`, `midnight/dust/spend`) when proving is self-hosted via `httpClientProofProvider` instead of wallet-delegated — see the "Gotcha" box in `references/provider-patterns.md`


### PR DESCRIPTION
## Summary

- Documents a non-obvious gotcha found while debugging a real DApp in production: a self-hosted `httpClientProofProvider` (proof server URI configured explicitly, instead of wallet-delegated proving) does **not** get the wallet's builtin fallback for protocol-level circuits (`midnight/zswap/spend`, `midnight/zswap/output`, `midnight/zswap/sign`, `midnight/dust/spend`). The DApp's own `zkConfigProvider` is asked for them instead, and if it only serves the app's own contract circuits (the common case), this 404s with a confusing `'check' returned an error` / `key not found: <circuit>` message that's easy to misattribute to a broken proof server or a missing key for the app's own circuit.
- Adds this as a "Gotcha" subsection to `midnight-dapp-dev:core`'s `provider-patterns.md`, right after the existing `proofProvider` explanation, with the underlying mechanism and a fix (avoid a configured proof server URI, or shim the builtin lookups like `midnightntwrk/passport` does).
- Cross-links it from the existing server-side `proof-server:proof-server-architecture`'s `key-material.md`, which already documents these same four builtin keys from the proof server's own prefetch/on-demand-fetch perspective, but had no pointer to the client-side interaction.

## Verification

Root-caused against real source (not memory) via `midnight-verify:source-investigator`:
- `midnight-ledger/zswap/src/construct.rs`, `ledger/src/prove.rs`, `ledger/src/test_utilities.rs` — confirm these four keys are protocol-level builtins.
- `midnight-wallet/packages/prover-client/src/effect/WasmProver.ts` — confirms wallet-delegated proving resolves them internally from a fixed source, without consulting the DApp's `ZKConfigProvider`.
- `midnight-js/packages/http-client-proof-provider/src/http-client-proving-provider.ts` — confirms the fallback-to-the-DApp's-flat-provider-for-any-unrecognized-circuit-ID behavior is by design.
- `midnightntwrk/passport`'s `wasmProver.ts` — the one official example found handling this correctly, via a hand-rolled `SYSTEM_KEYS` map/shim.

## Test plan

- [x] Read through both modified files for formatting/style consistency with surrounding content
- [x] Confirmed no references to internal/unrelated project details — content is generic and reusable
- This is a documentation-only change; no code/skill logic changes