### PR TITLE
Fix hardcoded localhost in compact-cli-dev template (wallet.ts, devnet:status)

### DIFF
--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/devnet/status.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/commands/devnet/status.ts
@@ -1,4 +1,5 @@
 import { BaseCommand } from "../../base-command.js";
+import { DEVNET_CONFIG } from "../../lib/config.js";
 
 interface ServiceStatus {
 	name: string;
@@ -26,9 +27,9 @@ export default class DevnetStatus extends BaseCommand {
 
 	async run(): Promise<void> {
 		const services = await Promise.all([
-			checkService("node", "http://127.0.0.1:9944"),
-			checkService("indexer", "http://127.0.0.1:8088/api/v4/graphql"),
-			checkService("proof-server", "http://127.0.0.1:6300"),
+			checkService("node", DEVNET_CONFIG.node),
+			checkService("indexer", DEVNET_CONFIG.indexer),
+			checkService("proof-server", DEVNET_CONFIG.proofServer),
 		]);
 
 		const result = {

--- a/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/wallet.ts
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/src/lib/wallet.ts
@@ -14,6 +14,7 @@ import {
 	createKeystore,
 } from "@midnight-ntwrk/wallet-sdk-unshielded-wallet";
 import { WebSocket } from "ws";
+import { DEVNET_CONFIG } from "./config.js";
 import {
 	ADDITIONAL_FEE_OVERHEAD,
 	DIR_MODE,
@@ -95,11 +96,11 @@ export async function buildFacade(seed: string): Promise<WalletContext> {
 	const walletConfig = {
 		networkId,
 		indexerClientConnection: {
-			indexerHttpUrl: "http://127.0.0.1:8088/api/v4/graphql",
-			indexerWsUrl: "ws://127.0.0.1:8088/api/v4/graphql/ws",
+			indexerHttpUrl: DEVNET_CONFIG.indexer,
+			indexerWsUrl: DEVNET_CONFIG.indexerWS,
 		},
 		// The default submission service submits via the node's RPC relay.
-		relayURL: new URL("http://127.0.0.1:9944"),
+		relayURL: new URL(DEVNET_CONFIG.node),
 		costParameters: {
 			additionalFeeOverhead: ADDITIONAL_FEE_OVERHEAD,
 			feeBlocksMargin: FEE_BLOCKS_MARGIN,


### PR DESCRIPTION
preprod-remote 설정으로 스캐폴딩했는데도 wallet.ts와 devnet:status 커맨드가 localhost 엔드포인트를 하드코딩하고 있어서, 원격 네트워크 배포 시 연결이 안 되는 문제를 발견하고 고쳤습니다. shieldedtab-contract 프로젝트 실제 사용 중 확인한 버그입니다.