### PR TITLE
fix: make Publish prepublishOnly lint pass (template-engine + fact-checker-utils)

### DIFF
--- a/packages/midnight-fact-checker-utils/biome.json
+++ b/packages/midnight-fact-checker-utils/biome.json
@@ -1,0 +1,43 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"files": {
+		"include": ["src/**/*.ts", "*.json"],
+		"ignore": ["**/node_modules/**", "**/dist/**", "**/coverage/**"]
+	},
+	"organizeImports": {
+		"enabled": true
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"correctness": {
+				"noUnusedImports": "error",
+				"noUnusedVariables": "error"
+			},
+			"suspicious": {
+				"noExplicitAny": "error"
+			},
+			"style": {
+				"noNonNullAssertion": "warn",
+				"useConst": "error"
+			}
+		}
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab",
+		"lineWidth": 100
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double",
+			"semicolons": "always"
+		}
+	},
+	"json": {
+		"formatter": {
+			"indentStyle": "tab"
+		}
+	}
+}

--- a/packages/midnight-fact-checker-utils/package.json
+++ b/packages/midnight-fact-checker-utils/package.json
@@ -30,9 +30,7 @@
 			"import": "./dist/index.js"
 		}
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"scripts": {
 		"build": "tsc",
 		"check": "tsc --noEmit",

--- a/packages/template-engine/package.json
+++ b/packages/template-engine/package.json
@@ -34,9 +34,7 @@
 			"import": "./dist/engine.js"
 		}
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"scripts": {
 		"build": "tsc",
 		"check": "tsc --noEmit",


### PR DESCRIPTION
## Problem
`main` is red: **Publish - Template Engine** and **Publish - Fact Checker Utils** both fail at the `prepublishOnly` hook (`npm run lint` → `biome check .`, run inside each package dir). CI is green on the same commit because CI lints from the repo root; the per-package invocation is what breaks.

- **template-engine** — `package.json`'s `files` array wasn't Biome-formatted (multi-line vs collapsed).
- **midnight-fact-checker-utils** — it has **no local `biome.json`**, so `biome check .` from its own dir resolves the root config's `packages/**` globs against the wrong base and processes **0 files**, which Biome 1.9 treats as an error ("No files were processed").

## Fix
- Collapse the `files` arrays in both `package.json`s to Biome's format.
- Add a package-local `biome.json` to `midnight-fact-checker-utils`, mirroring the sibling `template-engine`, so it lints its own `src/` + `package.json`.
- **No source changes.** Verified locally with the pinned `@biomejs/biome@1.9.4`: `biome check .` now passes in both packages (9 and 15 files, no fixes). `check`/`test`/`build` are already green in CI.

_bot:ai-assisted — drafted with AI assistance. (`midnight-expert` doesn't carry the `bot:ai-assisted` label yet; it's added by midnight-iac PR #245.)_