### PR TITLE
chore: re-scope packages to @midnightntwrk

### DIFF
--- a/packages/midnight-fact-checker-utils/package-lock.json
+++ b/packages/midnight-fact-checker-utils/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "@aaronbassett/midnight-fact-checker-utils",
+	"name": "@midnightntwrk/midnight-fact-checker-utils",
 	"version": "0.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@aaronbassett/midnight-fact-checker-utils",
+			"name": "@midnightntwrk/midnight-fact-checker-utils",
 			"version": "0.1.0",
 			"license": "MIT",
 			"dependencies": {

--- a/packages/midnight-fact-checker-utils/package.json
+++ b/packages/midnight-fact-checker-utils/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@aaronbassett/midnight-fact-checker-utils",
+	"name": "@midnightntwrk/midnight-fact-checker-utils",
 	"version": "0.1.0",
 	"description": "CLI utilities for midnight fact-checking workflows: file discovery, URL extraction, and JSON claim merging",
 	"type": "module",

--- a/packages/template-engine/package-lock.json
+++ b/packages/template-engine/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "@aaronbassett/template-engine",
+	"name": "@midnightntwrk/template-engine",
 	"version": "0.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@aaronbassett/template-engine",
+			"name": "@midnightntwrk/template-engine",
 			"version": "0.1.0",
 			"license": "MIT",
 			"bin": {

--- a/packages/template-engine/package.json
+++ b/packages/template-engine/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@aaronbassett/template-engine",
+	"name": "@midnightntwrk/template-engine",
 	"version": "0.1.0",
 	"description": "Generic template directory copier with placeholder substitution. Reads JSON from stdin, copies a template directory, replaces {{KEY}} placeholders, writes result to stdout.",
 	"type": "module",


### PR DESCRIPTION
Re-scopes both packages so they publish under the **`midnightntwrk`** npm org (the first packages in it):

- `@aaronbassett/template-engine` → **`@midnightntwrk/template-engine`**
- `@aaronbassett/midnight-fact-checker-utils` → **`@midnightntwrk/midnight-fact-checker-utils`**

Changes are limited to the two `package.json` `name` fields + their `package-lock.json`. No source or dependency changes; Biome stays green on both packages (9 / 15 files).

Left as-is: historical "ported from the former @aaronbassett/… package" comments in the vendored `render-template.mjs` / `merge.mjs` (accurate provenance), and unrelated `@aaronbassett-marketplace` example fixtures in the dependency-checker/scanner docs.

## Publishing
The `NPM_TOKEN` repo secret is set, and the Publish workflows already use `secrets.NPM_TOKEN` → `registry.npmjs.org` with `--access public`. On merge, the version-check sees these names as new under `@midnightntwrk` and publishes. (We'll switch to OIDC trusted publishing as a follow-up.)

_bot:ai-assisted — drafted with AI assistance. (`midnight-expert` doesn't carry the `bot:ai-assisted` label yet; it's added by midnight-iac PR #245.)_