### PR TITLE
fix: point package repository.url at midnightntwrk/midnight-expert

### DIFF
--- a/packages/midnight-fact-checker-utils/package.json
+++ b/packages/midnight-fact-checker-utils/package.json
@@ -10,7 +10,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/devrelaicom/midnight-expert.git",
+		"url": "https://github.com/midnightntwrk/midnight-expert.git",
 		"directory": "packages/midnight-fact-checker-utils"
 	},
 	"publishConfig": {

--- a/packages/template-engine/package.json
+++ b/packages/template-engine/package.json
@@ -10,7 +10,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/devrelaicom/midnight-expert.git",
+		"url": "https://github.com/midnightntwrk/midnight-expert.git",
 		"directory": "packages/template-engine"
 	},
 	"publishConfig": {


### PR DESCRIPTION
The re-scope publish got all the way to the registry, then npm rejected it with **E422 provenance mismatch**:

> `repository.url` is `git+https://github.com/devrelaicom/midnight-expert.git`, expected to match `https://github.com/midnightntwrk/midnight-expert` from provenance

`npm publish --provenance` derives the repo from the GitHub Actions run and requires `package.json`'s `repository.url` to match. Both packages still pointed at the old **`devrelaicom`** org.

Fix: set `repository.url` → `github.com/midnightntwrk/midnight-expert` in both `package.json`s (`directory` unchanged). Biome green on both.

On merge, the Publish workflows should now authenticate (NPM_TOKEN) **and** pass provenance → both publish under `@midnightntwrk`.

Note: there's a broader `devrelaicom → midnightntwrk` cleanup elsewhere (plugin.json ×13, READMEs, `author` fields, one source file) — not required for publishing; happy to do that as a separate sweep.

_bot:ai-assisted — drafted with AI assistance. (`midnight-expert` doesn't carry the `bot:ai-assisted` label yet; added by midnight-iac PR #245.)_