### PR TITLE
chore(ci): publish via npm trusted publishing (OIDC), drop NPM_TOKEN

### DIFF
--- a/.github/workflows/publish-fact-checker-utils.yml
+++ b/.github/workflows/publish-fact-checker-utils.yml
@@ -87,8 +87,10 @@ jobs:
         if: steps.version-check.outputs.changed == 'true'
         run: npm pack --dry-run
 
+      - name: Upgrade npm for trusted publishing (OIDC needs npm >= 11.5.1)
+        if: steps.version-check.outputs.changed == 'true'
+        run: npm install -g npm@latest
+
       - name: Publish to npm with provenance
         if: steps.version-check.outputs.changed == 'true'
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-template-engine.yml
+++ b/.github/workflows/publish-template-engine.yml
@@ -86,8 +86,10 @@ jobs:
         if: steps.version-check.outputs.changed == 'true'
         run: npm pack --dry-run
 
+      - name: Upgrade npm for trusted publishing (OIDC needs npm >= 11.5.1)
+        if: steps.version-check.outputs.changed == 'true'
+        run: npm install -g npm@latest
+
       - name: Publish to npm with provenance
         if: steps.version-check.outputs.changed == 'true'
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Switches both Publish workflows from a long-lived `NPM_TOKEN` to **npm trusted publishing (OIDC)**.

- Upgrade npm to `>= 11.5.1` (Node 20 ships npm 10.x, which predates OIDC publishing).
- Remove `NODE_AUTH_TOKEN` / `secrets.NPM_TOKEN`. `id-token: write` was already present, so npm mints a short-lived credential from the workflow's OIDC identity per run. Provenance stays automatic.

**⚠️ Do NOT merge until the trusted publishers are configured on npm** (see below) — otherwise the next version-bump publish has no credential. Merging this PR alone won't publish (it only touches `.github/`).

Once confirmed working over OIDC, the `NPM_TOKEN` repo secret can be deleted.

_bot:ai-assisted — drafted with AI assistance. (`midnight-expert` doesn't carry the `bot:ai-assisted` label yet; added by midnight-iac PR #245.)_