### PR TITLE
compact-core: document that checkRoot publishes its result

### DIFF
--- a/plugins/compact-core/skills/compact-patterns/references/identity-membership-patterns.md
+++ b/plugins/compact-core/skills/compact-patterns/references/identity-membership-patterns.md
@@ -348,6 +348,29 @@ prior version of the tree, so a proof generated before new members were added
 remains valid. With plain `MerkleTree`, each insertion changes the root and
 invalidates all existing proofs.
 
+### Keep the checkRoot Result Constant
+
+Step 3 above asserts on `checkRoot` immediately rather than storing the result.
+That is load-bearing. `checkRoot` is a ledger operation and its Boolean result is
+written to the public transcript, tagged with the ledger field checked. Asserting
+immediately means every transaction that lands carries `true`, so the published
+bit is constant and reveals nothing.
+
+Do not capture the result and branch on it to build optional or threshold
+membership across several trees:
+
+```compact
+// Anti-pattern: leaks which trees the caller belongs to
+const inA = treeA.checkRoot(disclose(rootA));
+const inB = treeB.checkRoot(disclose(rootB));
+assert(inA || inB, "not a member of either");
+```
+
+Each result reaches the transcript separately, so the pattern is directly readable
+even though `inA || inB` is never disclosed. Use one shared tree with the category
+folded into the leaf instead, and assert inside the circuit that the categories
+differ. See "checkRoot Publishes Its Result" in `compact-privacy-disclosure`.
+
 ### Capacity Planning
 
 | Depth (N) | Max Members | Proof Size |

--- a/plugins/compact-core/skills/compact-privacy-disclosure/SKILL.md
+++ b/plugins/compact-core/skills/compact-privacy-disclosure/SKILL.md
@@ -30,7 +30,7 @@ The corollary: a value being "tagged with witness taint" does NOT mean it is pub
 | What to Protect | Approach | Key Primitives |
 |----------------|----------|----------------|
 | Hide a value on-chain | Commitment | `persistentCommit<T>` / `transientCommit<T>` |
-| Prove membership anonymously | MerkleTree + ZK path | `HistoricMerkleTree` + `merkleTreePathRoot<N, T>` |
+| Prove membership anonymously | MerkleTree + ZK path (assert on the result, see below) | `HistoricMerkleTree` + `merkleTreePathRoot<N, T>` |
 | Prevent double-actions | Nullifier | `persistentHash<T>([domain, secret])` + `Set<Bytes<32>>` |
 | Hide who is acting | Unlinkable auth | `Counter` + rotated `persistentHash` |
 | Multi-step hidden value | Commit-reveal | Commit phase + reveal phase |
@@ -79,6 +79,79 @@ const hash = persistentHash<Field>(secretValue);
 storedHash = disclose(hash);  // disclose() required — persistentHash does NOT clear taint
 ```
 
+## checkRoot Publishes Its Result
+
+`checkRoot` is a ledger operation, so it has two disclosure surfaces, not one. The
+argument is the widely-known part. The **return value** is the part that is easy to
+miss: the call compiles to a `member` check against the tree's historic roots
+followed by `popeq`, and `popeq` writes the outcome into the public transcript,
+tagged with the index of the ledger field that was checked.
+
+Omitting `disclose()` makes the compiler name all three channels at once:
+
+```text
+nature of the disclosure:
+  ledger operation might disclose a hash of the witness value
+nature of the disclosure:
+  ledger operation might disclose a hash of the boolean value of the witness value
+nature of the disclosure:
+  ledger operation might disclose a hash of a modulus of a hash of the witness value
+```
+
+The middle channel is the result of the check. A single `disclose()` clears all
+three, and the message reads as though it concerns only the root, so the second
+line is easy to skip past.
+
+**This is why every membership example in this skill asserts immediately:**
+
+```compact
+assert(members.checkRoot(disclose(digest)), "Not a member");
+```
+
+Asserting makes the published bit *constant*. A caller whose check fails never
+lands a transaction, so every transcript on-chain carries the same value and it
+reveals nothing.
+
+Capturing the result and branching on it removes that property:
+
+```compact
+// Anti-pattern: leaks which trees the caller belongs to
+const inA = treeA.checkRoot(disclose(merkleTreePathRoot<10, Bytes<32>>(pathA(leaf))));
+const inB = treeB.checkRoot(disclose(merkleTreePathRoot<10, Bytes<32>>(pathB(leaf))));
+assert(inA || inB, "not a member of either");
+```
+
+`inA || inB` is never disclosed, but each result reached the transcript
+separately. Reading `proofData.publicTranscript` for two callers, one enrolled
+only in tree A and one only in tree B:
+
+| Caller | check vs `treeA` | check vs `treeB` |
+|--------|------------------|------------------|
+| A-only | `popeq -> [1]`   | `popeq -> []`    |
+| B-only | `popeq -> []`    | `popeq -> [1]`   |
+
+No inference is required; the answers are recorded in order.
+
+### The rule
+
+> Every `checkRoot` call in a circuit must return the same value for every honest
+> caller. If a call can legitimately return `false` for some callers, that `false`
+> is public.
+
+For "N of M" designs, use **one shared tree** with the category folded into the
+leaf, `hash(domain, identity, categoryTag)`, prove N memberships against that
+single tree, and assert inside the circuit that the tags differ. Every caller then
+publishes the same constant.
+
+The corollary is worth stating plainly: supplying a deliberately invalid path so a
+check can return `false` without failing the proof is the only way to express
+*optional* membership across several trees, and it is exactly what makes the
+published bit vary. Optional membership and unlinkability are not simultaneously
+achievable this way.
+
+Verified against Compact 0.31.1 and `@midnight-ntwrk/compact-runtime` 0.16.0.
+Reproduction: https://github.com/tomiin/checkroot-transcript-probe
+
 ## Common Disclosure Mistakes
 
 | Wrong | Correct | Why |
@@ -88,6 +161,7 @@ storedHash = disclose(hash);  // disclose() required — persistentHash does NOT
 | `return computeResult()` | `return disclose(computeResult())` | Exported circuit return requires disclosure |
 | `disclose(getBalance()); ...; balance = x` | `balance = disclose(x)` | Disclose at disclosure point, not at source |
 | `Set` for private membership | `MerkleTree` + ZK path proof | Set reveals which element is tested |
+| `const ok = tree.checkRoot(...)` then branch on `ok` | `assert(tree.checkRoot(...), "...")` | The result is written to the public transcript; asserting keeps it constant |
 | Same domain for commitment and nullifier | Different domains | Same domain enables linking attack |
 | `persistentHash(secret)` to "hide" witness | `persistentCommit(secret, rand)` | Hash doesn't clear witness taint; commit does |
 


### PR DESCRIPTION
## What this fixes

The membership guidance in `compact-core` documents that the **argument** to
`checkRoot` is visible on-chain. It does not mention that the **return value** is
also published, and that omission is the one that bites.

Every membership example in the plugin is written as:

```compact
assert(members.checkRoot(disclose(digest)), "Not a member");
```

That form is safe, but nothing explains *why*. It is safe because asserting
immediately makes the published Boolean constant: a caller whose check fails never
lands a transaction, so every on-chain transcript carries the same value.

Adapt that pattern to "2 of 3 issuers" and the safety disappears. Storing each
result and combining them means the individual answers vary per caller, and each
one is public.

## Evidence

Verified against Compact 0.31.1 and `@midnight-ntwrk/compact-runtime` 0.16.0.
Reproduction, four commands: https://github.com/tomiin/checkroot-transcript-probe

Removing `disclose()` from a `checkRoot` argument makes the compiler name three
disclosure channels, not one:

```text
ledger operation might disclose a hash of the witness value
ledger operation might disclose a hash of the boolean value of the witness value
ledger operation might disclose a hash of a modulus of a hash of the witness value
```

The middle channel is the result of the check. A single `disclose()` clears all
three, and the message reads as though it concerns only the root.

Reading `proofData.publicTranscript` for two callers of the same circuit, one
enrolled only in tree A and one only in tree B, neither disclosing the combined
result:

| Caller | check vs `treeA` | check vs `treeB` |
|--------|------------------|------------------|
| A-only | `popeq -> [1]`   | `popeq -> []`    |
| B-only | `popeq -> []`    | `popeq -> [1]`   |

Each `checkRoot` compiles to `member` followed by `popeq`, tagged with the ledger
field index, so the membership pattern is read directly rather than inferred.

## Changes

- `compact-privacy-disclosure/SKILL.md`: new section "checkRoot Publishes Its
  Result", one row added to the mistakes table, and a pointer on the decision-tree
  row.
- `compact-patterns/references/identity-membership-patterns.md`: new subsection
  explaining why Step 3 of Anonymous Membership asserts immediately, with the
  anti-pattern spelled out.

No existing guidance is contradicted. The examples were already correct; this
documents the property that makes them correct so it survives adaptation.

## Validation

```
$ bash scripts/validate-plugin.sh plugins/compact-core
✓ Plugin validated: plugins/compact-core
```

## Note for reviewers

One claim is worth challenging: the docs now state that optional or threshold
membership across several trees cannot be made unlinkable, because expressing it
requires a Boolean that varies between callers and that variation is the leak.
That rules out a pattern people reach for, so I would rather it be argued with now
than published unchallenged.

Same finding is in flight as midnightntwrk/midnight-docs#1170. I hit it in my own
contract, which had the flaw.
