### PR TITLE
chore(ci): pin npm to 12.0.2 and add supply-chain cooldown

### DIFF
--- a/.github/workflows/ci-fact-checker-utils.yml
+++ b/.github/workflows/ci-fact-checker-utils.yml
@@ -26,9 +26,12 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: packages/midnight-fact-checker-utils/package-lock.json
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - run: npm ci
       - name: Biome check
         run: npx biome check .
@@ -41,9 +44,12 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: packages/midnight-fact-checker-utils/package-lock.json
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - run: npm ci
       - name: Biome format check
         run: npx biome format .
@@ -56,9 +62,12 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: packages/midnight-fact-checker-utils/package-lock.json
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - run: npm ci
       - run: npx tsc --noEmit
 
@@ -69,9 +78,12 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: packages/midnight-fact-checker-utils/package-lock.json
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - run: npm ci
       - run: npx tsc
 
@@ -82,9 +94,12 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: packages/midnight-fact-checker-utils/package-lock.json
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - run: npm ci
       - run: npx vitest run
 
@@ -95,9 +110,12 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: packages/midnight-fact-checker-utils/package-lock.json
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - run: npm ci
       - name: npm audit (high+)
         run: npm audit --audit-level=high

--- a/.github/workflows/ci-template-engine.yml
+++ b/.github/workflows/ci-template-engine.yml
@@ -26,9 +26,12 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: packages/template-engine/package-lock.json
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - run: npm ci
       - name: Biome check
         run: npx biome check .
@@ -41,9 +44,12 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: packages/template-engine/package-lock.json
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - run: npm ci
       - name: Biome format check
         run: npx biome format .
@@ -56,9 +62,12 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: packages/template-engine/package-lock.json
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - run: npm ci
       - run: npx tsc --noEmit
 
@@ -69,9 +78,12 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: packages/template-engine/package-lock.json
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - run: npm ci
       - run: npx tsc
 
@@ -82,9 +94,12 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: packages/template-engine/package-lock.json
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - run: npm ci
       - run: npx vitest run
 
@@ -95,9 +110,12 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: packages/template-engine/package-lock.json
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - run: npm ci
       - name: npm audit (high+)
         run: npm audit --audit-level=high

--- a/.github/workflows/publish-fact-checker-utils.yml
+++ b/.github/workflows/publish-fact-checker-utils.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: packages/midnight-fact-checker-utils/package-lock.json
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upgrade npm for trusted publishing (OIDC needs npm >= 11.5.1)
         if: steps.version-check.outputs.changed == 'true'
-        run: npm install -g npm@latest
+        run: npm install -g npm@12.0.2
 
       - name: Publish to npm with provenance
         if: steps.version-check.outputs.changed == 'true'

--- a/.github/workflows/publish-template-engine.yml
+++ b/.github/workflows/publish-template-engine.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: packages/template-engine/package-lock.json
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upgrade npm for trusted publishing (OIDC needs npm >= 11.5.1)
         if: steps.version-check.outputs.changed == 'true'
-        run: npm install -g npm@latest
+        run: npm install -g npm@12.0.2
 
       - name: Publish to npm with provenance
         if: steps.version-check.outputs.changed == 'true'

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Supply-chain cooldown: refuse dependency versions published <7 days ago (npm 12+).
+# Own packages are exempt so same-day @midnight-ntwrk releases stay installable.
+min-release-age=7
+min-release-age-exclude[]=@midnight-ntwrk/*
+min-release-age-exclude[]=@midnightntwrk/*

--- a/plugins/compact-cli-dev/skills/core/templates/cli/.github/workflows/ci.yml
+++ b/plugins/compact-cli-dev/skills/core/templates/cli/.github/workflows/ci.yml
@@ -14,8 +14,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
+
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
 
       - run: npm ci
 


### PR DESCRIPTION
Supply-chain hardening following the 2026-08-04 keyv/cacheable npm worm (868+ packages compromised via `preinstall` payloads published through legitimate maintainer accounts).

- Pin the npm CLI to 12.0.2 in CI (npm 12 blocks dependency lifecycle scripts by default behind `allowScripts`) instead of floating `npm@latest`/setup-node default
- Bump `node-version` where npm 12 requires it (engines: `^22.22.2 || ^24.15.0 || >=26`)
- Add `.npmrc` cooldown: `min-release-age=7` so freshly-published (potentially wormed) versions can't resolve for 7 days; `@midnight-ntwrk/*` and `@midnightntwrk/*` exempt so same-day internal releases still install
- Renovate: npm CLI pins in workflows/Earthfiles are matched by new custom managers in `midnightntwrk/renovate-config`, so this pin stays bumpable automatically
