### PR TITLE
fix(ci): pin npm-installed CI tool versions

### DIFF
--- a/.github/workflows/publish-fact-checker-utils.yml
+++ b/.github/workflows/publish-fact-checker-utils.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upgrade npm for trusted publishing (OIDC needs npm >= 11.5.1)
         if: steps.version-check.outputs.changed == 'true'
-        run: npm install -g npm@latest
+        run: npm install -g npm@12.0.2
 
       - name: Publish to npm with provenance
         if: steps.version-check.outputs.changed == 'true'

--- a/.github/workflows/publish-template-engine.yml
+++ b/.github/workflows/publish-template-engine.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upgrade npm for trusted publishing (OIDC needs npm >= 11.5.1)
         if: steps.version-check.outputs.changed == 'true'
-        run: npm install -g npm@latest
+        run: npm install -g npm@12.0.2
 
       - name: Publish to npm with provenance
         if: steps.version-check.outputs.changed == 'true'


### PR DESCRIPTION
Closes #226

Pins floating-version npm tool installs in workflows to exact versions (vercel 58.7.1 / typedoc-plugin-markdown 4.12.0 / rimraf 6.1.3 / junit-report-merger 9.0.4 / npm 12.0.2 as applicable). Floating tags execute whatever the registry serves at run time; pinning closes that window.