### PR TITLE
fix: compact camelCase to snake_case

### DIFF
--- a/plugins/compact-core/skills/compact-standard-library/SKILL.md
+++ b/plugins/compact-core/skills/compact-standard-library/SKILL.md
@@ -154,7 +154,7 @@ Types provided by the standard library. All are available after `import CompactS
 | `Either<A, B>` | `A`, `B` -- any types | `is_left: Boolean`, `left: A`, `right: B` | `{ is_left: false, left: default<A>, right: default<B> }` (right variant, based on struct defaults) |
 | `JubjubPoint` | none | `x: Field`, `y: Field` | `{ x: 0, y: 0 }` |
 | `MerkleTreeDigest` | none | `field: Field` | `{ field: 0 }` |
-| `MerkleTreePathEntry` | none | `sibling: MerkleTreeDigest`, `goesLeft: Boolean` | `{ sibling: { field: 0 }, goesLeft: false }` |
+| `MerkleTreePathEntry` | none | `sibling: MerkleTreeDigest`, `goes_left: Boolean` (true when the current node is the left child) | `{ sibling: { field: 0 }, goes_left: false }` |
 | `MerkleTreePath<#N, T>` | `#N` -- depth, `T` -- leaf type | `leaf: T`, `path: Vector<#N, MerkleTreePathEntry>` | Default leaf + default path |
 | `ContractAddress` | none | `bytes: Bytes<32>` | `{ bytes: 0x00...00 }` |
 | `ZswapCoinPublicKey` | none | `bytes: Bytes<32>` | `{ bytes: 0x00...00 }` |

--- a/plugins/compact-core/skills/compact-standard-library/references/cryptographic-functions.md
+++ b/plugins/compact-core/skills/compact-standard-library/references/cryptographic-functions.md
@@ -131,7 +131,7 @@ struct MerkleTreePath<#n, T> {
 
 struct MerkleTreePathEntry {
   sibling: MerkleTreeDigest;
-  goesLeft: Boolean;
+  goes_left: Boolean; // true when the current node is the left child at this level
 }
 ```
 

--- a/plugins/compact-core/skills/compact-standard-library/references/types-and-constructors.md
+++ b/plugins/compact-core/skills/compact-standard-library/references/types-and-constructors.md
@@ -220,7 +220,7 @@ One step in a Merkle proof path: the sibling hash and a direction flag.
 ```compact
 struct MerkleTreePathEntry {
   sibling: MerkleTreeDigest;
-  goesLeft: Boolean;
+  goes_left: Boolean;
 }
 ```
 
@@ -229,7 +229,7 @@ struct MerkleTreePathEntry {
 | Field | Type | Meaning |
 |-------|------|---------|
 | `.sibling` | `MerkleTreeDigest` | Hash of the sibling node at this level |
-| `.goesLeft` | `Boolean` | Direction flag: `true` if the path goes left at this level |
+| `.goes_left` | `Boolean` | `true` when the current node is the left child at this level (the sibling occupies the right slot) |
 
 Primarily used as the element type inside `MerkleTreePath`.
 


### PR DESCRIPTION
Fixes #229.

## Problem

Three `compact-standard-library` skill locations documented `MerkleTreePathEntry`'s direction field as camelCase `goesLeft`. The compiler defines it as snake_case `goes_left`, so code written from the docs fails to compile:

```
Exception: structure MerkleTreePathEntry has no field named goesLeft
```

## Ground truth (verified from compiler source, not skill files)

`LFDT-Minokawa/compact:compiler/standard-library.compact` (`main`, last modified 2026-08-05):

```compact
export struct MerkleTreePathEntry {
  sibling: MerkleTreeDigest;
  goes_left: Boolean;
}
```

A `goes_left → goesLeft` alias **does** exist in `compiler/standard-library-aliases.ss`, but it is inside a commented-out block, explicitly deferred "until we can coordinate the changes with the onchain runtime" — alongside the sibling renames `is_some→isSome`, `is_left→isLeft`, `domain_sep→domainSep`, `mt_index→mtIndex`. So `goesLeft` is a *planned future* name that has not landed; the current field is `goes_left`. This matches the issue's generated-typings evidence (`goes_left: boolean`) and the reported compile error.

## Changes

Renamed `goesLeft` → `goes_left` in all three affected locations and added a one-line semantic note (the flag describes the **current node's** position, not the sibling's):

- `compact-standard-library/SKILL.md` — Types table
- `references/types-and-constructors.md` — struct definition + Fields table
- `references/cryptographic-functions.md` — struct snippet

`core-concepts/privacy-patterns` and `compact-core/basic-start` already used `goes_left` and were left untouched.

## Note for future maintenance

If/when the compiler's commented-out camelCase migration lands, this field (and the whole `is_some`/`is_left`/`domain_sep`/`mt_index` family) will need a coordinated flip. Flagging so this isn't prematurely "re-fixed" back to camelCase.