### PR TITLE
Bind the Merkle path's leaf to the caller's commitment in two examples

### DIFF
--- a/plugins/compact-core/skills/basic-start/examples/ticket.compact
+++ b/plugins/compact-core/skills/basic-start/examples/ticket.compact
@@ -71,6 +71,14 @@ export circuit use_ticket(): [] {
 
   // Prove the commitment exists in the tree (without revealing which leaf)
   const path = get_ticket_path(commitment);
+
+  // Bind the path to THIS holder's commitment. MerkleTreePath carries its own
+  // `leaf` field, which is what merkleTreePathRoot hashes -- and the path
+  // comes from a witness running on the prover's machine. Without this check
+  // someone can supply another holder's path and be admitted with a ticket
+  // they never held. Soundness, not privacy.
+  assert(path.leaf == commitment, "Merkle path is not for this ticket");
+
   assert(
     tickets.checkRoot(disclose(merkleTreePathRoot<10, Bytes<32>>(path))),
     "Invalid ticket"

--- a/plugins/compact-core/skills/compact-privacy-disclosure/examples/NullifierDoubleSpend.compact
+++ b/plugins/compact-core/skills/compact-privacy-disclosure/examples/NullifierDoubleSpend.compact
@@ -181,10 +181,22 @@ export circuit spend(): [] {
   // remembers all past roots, so proofs remain valid even after new
   // tokens are issued).
   //
+  // Bind the path to THIS caller's commitment before checking the root.
+  //
+  // MerkleTreePath carries its own `leaf` field, and merkleTreePathRoot
+  // hashes that leaf -- not the commitment derived above. `path` comes from
+  // a witness, and witnesses run on the prover's own machine. Without this
+  // check a prover can return any genuinely-issued token's path and spend a
+  // token they never held.
+  //
+  // This is soundness, not privacy: the contract would admit people it
+  // should reject. The check costs 8 rows and does not change k.
+  assert(path.leaf == commitment, "Merkle path is not for this commitment");
+
   // disclose() is required on the merkleTreePathRoot result because
   // checkRoot is a ledger operation whose argument (the digest) becomes
-  // visible on-chain. However, the digest alone does not reveal which
-  // leaf was used -- it only proves that SOME valid leaf was verified.
+  // visible on-chain. The digest does not reveal which leaf was used, and
+  // the assert above is what ties it to the caller's own commitment.
   assert(
     commitments.checkRoot(disclose(merkleTreePathRoot<10, Bytes<32>>(path))),
     "Commitment not found in tree"


### PR DESCRIPTION
# Bind the Merkle path's leaf to the caller's commitment in two examples

Two teaching examples verify Merkle membership without binding the path to the
caller, which makes them unsound. Both are files developers copy.

- `plugins/compact-core/skills/compact-privacy-disclosure/examples/NullifierDoubleSpend.compact`
- `plugins/compact-core/skills/basic-start/examples/ticket.compact`

## The problem

`MerkleTreePath<A>` carries its own `leaf` field — confirmed in
`@midnight-ntwrk/compact-runtime/dist/compact-types.d.ts`:

```ts
export interface MerkleTreePath<A> {
    readonly leaf: A;
    readonly path: MerkleTreePathEntry[];
}
```

`merkleTreePathRoot` hashes **that** leaf, not anything the circuit computed.
And the path arrives from a witness, which runs on the prover's own machine.

So in `spend()`:

```compact
const commitment = derive_commitment(secret, randomness);
const path = get_commitment_path(commitment);
assert(
  commitments.checkRoot(disclose(merkleTreePathRoot<10, Bytes<32>>(path))),
  "Commitment not found in tree"
);
```

`commitment` is passed to the witness only as a **hint**. A prover who edits
their witness to return any genuinely-issued token's path is admitted, having
never held a token. `ticket.compact` has the identical shape in `use_ticket()`.

**This is soundness, not privacy** — the contract admits people it should
reject. The privacy analysis in both files remains accurate.

The comment in `NullifierDoubleSpend.compact` also states the bug as though it
were a safety property:

> the digest alone does not reveal which leaf was used -- it only proves that
> SOME valid leaf was verified.

"Only proves that SOME valid leaf was verified" is exactly the hole.

## The fix

One assert per circuit, before the root check:

```compact
assert(path.leaf == commitment, "Merkle path is not for this commitment");
```

This is the pattern already used correctly in `midnight-rwa.compact`, which as
far as I can tell is the only example in the repo that gets it right.

**Cost: 8 rows, `k` unchanged.** Measured on `NullifierDoubleSpend.compact`
itself, before and after the change:

| circuit | before | after |
| --- | --- | --- |
| `issue` | k=13, 6,455 rows | k=13, 6,455 rows |
| `spend` | k=14, **10,916** rows | k=14, **10,924** rows |

`ticket.compact` is structurally the same and compiles to the same post-change
figures (`issue_ticket` k=13/6,455, `use_ticket` k=14/10,924).

Since `k` only moves at powers of two, eight extra rows here cost nothing at
all — the proving parameters are identical either way.

I have also reworded the misleading comment and explained why the binding is
needed, since these files are read as teaching material.

## Verification

Both files compile clean with the change applied, at the repo's own
`pragma language_version >= 0.22`.

The underlying bug was verified by execution, not inspection —
[`tomiin/merkle-leaf-binding-probe`](https://github.com/tomiin/merkle-leaf-binding-probe)
(compactc 0.31.0, language 0.23.0, runtime 0.16.0). Test 3 demonstrates a
forged path being accepted by the unguarded circuit; test 4 shows the guarded
version rejecting the same forged path.

The same fix is applied in my own contracts, `midnight-rxlimit` (`f013ea7`) and
`threshold` (`bd050af`).

## The part worth flagging for the examples themselves

Both affected contracts already had passing tests whose names claimed to cover
this case — *"a prescription issued to someone else cannot be filled"*, *"fails
for someone never attested"*. They passed while the contracts were broken,
because every test used an **honest witness**.

A test suite that only exercises honest witnesses cannot detect a witness-trust
bug. You have to write the malicious witness yourself. The probe does it with a
`forgePathForLeaf` hook in private state, and that may be worth teaching
alongside the pattern — it generalises well beyond Merkle proofs.

Related: #224.
